### PR TITLE
Added changelogs from commits between tags

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -17,9 +17,9 @@ default_platform(:android)
 platform :android do
   lane :set_build_code_internal do
     versions = google_play_track_version_codes(
-        track: "internal",
-        json_key: "./keys.json"
-      )
+      track: "internal",
+      json_key: "./keys.json"
+    )
     last_version = versions[0].to_i
     version_name = last_git_tag.gsub("v", "")
     Dir.chdir("../..") do
@@ -30,6 +30,10 @@ platform :android do
       result = config.gsub(re, subst)
 
       File.open("./pubspec.yaml", 'w') { |file| file.write(result) }
+    end
+
+    File.open("./metadata/android/en-US/changelogs/#{last_version+1}.txt", 'w') do |file|
+      file.write(changelog_from_git_commits(between: [sh("git tag | tail -2 | head -1").strip, last_git_tag]))
     end
   end
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -43,7 +43,7 @@ platform :ios do
       export_method: "app-store"
     )
     upload_to_testflight(
-      skip_waiting_for_build_processing: true,
+      changelog: changelog_from_git_commits(between: [sh("git tag | tail -2 | head -1").strip, last_git_tag]),
       ipa: "Runner.ipa"
     )
   end
@@ -70,4 +70,3 @@ platform :ios do
     # slack(message: "Successfully uploaded a new App Store build")
   end
 end
-


### PR DESCRIPTION
This should populate the `Release notes` section for Android:

![image](https://github.com/linagora/twake-on-matrix/assets/39090621/56add906-8d87-44fc-89a1-8a87c058b8f1)

and `Test details` section for iOS:

![image](https://github.com/linagora/twake-on-matrix/assets/39090621/fe8f1a81-b381-4f21-88b7-3ece5e6a497d)
