### PR TITLE
fix: check if scroll is attached before scrolling on sending

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -772,7 +772,11 @@ class ChatController extends State<Chat> {
     _updateScrollController();
   }
 
-  void scrollDown() => scrollController.jumpTo(0);
+  void scrollDown() {
+    if (scrollController.hasClients) {
+      scrollController.jumpTo(0);
+    }
+  }
 
   void onEmojiSelected(_, Emoji? emoji) {
     switch (emojiPickerType) {


### PR DESCRIPTION
- Check if the elements are attached to scroll view before scrolling (preventing bugs)

Chat without message
![scrollsansmessage](https://github.com/linagora/twake-on-matrix/assets/48354990/d6639bbb-e7ac-40d2-a939-a148ca077fb8)

Chat with messages
![scrollavecmessages](https://github.com/linagora/twake-on-matrix/assets/48354990/71651c4f-cb08-4d43-9668-5b223c548338)
