### PR TITLE
WIP fix: fetch avatar after update

### DIFF
--- a/lib/utils/matrix_profiles_service.dart
+++ b/lib/utils/matrix_profiles_service.dart
@@ -31,17 +31,18 @@ class MatrixProfilesService {
     return _profileCache.keys.firstWhere((element) => element.clientName == clientName);
   }
 
-  void presenceEventHandler(String clientName, CachedPresence event) async {
-    Logs().v('MatrixProfilesService::presenceEventHandler():event: ${event.toString()}');
+  void syncEventHandler(String clientName, SyncUpdate update) async {
+    Logs().v('MatrixProfilesService::presenceEventHandler():event: ${update.toString()}');
     final client = _getClientByName(clientName);
-    if (_profileCache[client]?.userId == event.userid) {
-      _profileCache[client] =
-          await client.getProfileFromUserId(event.userid, cache: false, getFromRooms: false);
-    }
-  }
 
-  void roomStateHandler(Event event) {
-    Logs().v('MatrixProfilesService::roomStateHandler():event: ${event.toString()}');
+    // TODO : check if active user
+    if (update.hasPresenceUpdate) {
+      _profileCache[client] = await client.fetchOwnProfile();
+    }
+
+    if (update.hasRoomUpdate) {
+      _profileCache[client] = await client.fetchOwnProfile();
+    }
   }
 
   void clearProfileCache() {

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -245,8 +245,8 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   final onNotification = <String, StreamSubscription>{};
   final onLoginStateChanged = <String, StreamSubscription<LoginState>>{};
   final onUiaRequest = <String, StreamSubscription<UiaRequest>>{};
-  final onPresenceChanged = <String, StreamSubscription>{};
-  final onRoomState = <String, StreamSubscription>{};
+  final onSync = <String, StreamSubscription>{};
+  // final onRoomState = <String, StreamSubscription>{};
 
   StreamSubscription<html.Event>? onFocusSub;
   StreamSubscription<html.Event>? onBlurSub;
@@ -388,8 +388,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
       });
     }
 
-    onPresenceChanged[name] ??= c.onPresenceChanged.stream.listen((event) => profilesService.presenceEventHandler(name, event));
-    onRoomState[name] ??= c.onRoomState.stream.listen((event) => profilesService.roomStateHandler);
+    onSync[name] ??= c.onSync.stream.listen((event) => profilesService.syncEventHandler(name, event));
   }
 
   void _cancelSubs(String name) {
@@ -401,10 +400,8 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     onLoginStateChanged.remove(name);
     onNotification[name]?.cancel();
     onNotification.remove(name);
-    onPresenceChanged[name]?.cancel();
-    onPresenceChanged.remove(name);
-    onRoomState[name]?.cancel();
-    onRoomState.remove(name);
+    onSync[name]?.cancel();
+    onSync.remove(name);
   }
 
   void initMatrix() {


### PR DESCRIPTION
`client.dart - getProfileFromUserId()` only caches the profile on initialization, the avatar becomes outdated after changing during the session

Solution : need to do our own cache profiles (#159) 