### PR TITLE
fix-bug: can't see message of user havenot accept invite

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -232,6 +232,17 @@ class ChatListController extends State<ChatList>
     });
   }
 
+  void joinInviteDirectChats() {
+    Future.wait(Matrix.of(context).client.rooms.map(joinRoom));
+  }
+
+  Future<void> joinRoom(Room room) async {
+    final isRoomInvited = !room.isArchived && room.membership == Membership.invite;
+    if (isRoomInvited && room.isDirectChat) {
+      await room.join();
+    }
+  }
+
   void onSearchEnter(String text) {
     if (text.isEmpty) {
       cancelSearch(unfocus: false);

--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -63,6 +63,7 @@ class ChatListViewBody extends StatelessWidget {
             );
           }
           if (controller.waitForFirstSync && client.prevBatch != null) {
+            controller.joinInviteDirectChats();
             final rooms = controller.filteredRoomsForAll;
             const displayStoriesHeader = false;
             if (rooms.isEmpty && !controller.isSearchMode) {


### PR DESCRIPTION
# Description:
When user A invite a user B to a direct chat, if user B have not join the chat, user B can't receive new message from user A
# Solution: 
When user B receive the invite from user A, user B will be automatically joined chat with user A. In chat list screen, only display the the direct chat have at least one message and group chat have invited

https://github.com/linagora/twake-on-matrix/assets/43041967/72c2d7ff-6df1-49d9-98fa-45eddd31eff2

