### PR TITLE
TW-274: Rename room to group chat

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -334,7 +334,7 @@
             "username": {}
         }
     },
-    "changedTheRoomAliases": "{username} changed the room aliases",
+    "changedTheRoomAliases": "{username} changed the group chat aliases",
     "@changedTheRoomAliases": {
         "type": "text",
         "placeholders": {
@@ -431,11 +431,11 @@
         "type": "text",
         "placeholders": {}
     },
-    "commandHint_markasdm": "Mark as direct message room",
+    "commandHint_markasdm": "Mark as direct chat",
     "@commandHint_markasdm": {},
     "commandHint_markasgroup": "Mark as group",
     "@commandHint_markasgroup": {},
-    "commandHint_ban": "Ban the given user from this room",
+    "commandHint_ban": "Ban the given user from this group chat",
     "@commandHint_ban": {
         "type": "text",
         "description": "Usage hint for the command /ban"
@@ -465,22 +465,22 @@
         "type": "text",
         "description": "Usage hint for the command /html"
     },
-    "commandHint_invite": "Invite the given user to this room",
+    "commandHint_invite": "Invite the given user to this group chat",
     "@commandHint_invite": {
         "type": "text",
         "description": "Usage hint for the command /invite"
     },
-    "commandHint_join": "Join the given room",
+    "commandHint_join": "Join the given group chat",
     "@commandHint_join": {
         "type": "text",
         "description": "Usage hint for the command /join"
     },
-    "commandHint_kick": "Remove the given user from this room",
+    "commandHint_kick": "Remove the given user from this group chat",
     "@commandHint_kick": {
         "type": "text",
         "description": "Usage hint for the command /kick"
     },
-    "commandHint_leave": "Leave this room",
+    "commandHint_leave": "Leave this group chat",
     "@commandHint_leave": {
         "type": "text",
         "description": "Usage hint for the command /leave"
@@ -490,12 +490,12 @@
         "type": "text",
         "description": "Usage hint for the command /me"
     },
-    "commandHint_myroomavatar": "Set your picture for this room (by mxc-uri)",
+    "commandHint_myroomavatar": "Set your picture for this group chat (by mxc-uri)",
     "@commandHint_myroomavatar": {
         "type": "text",
         "description": "Usage hint for the command /myroomavatar"
     },
-    "commandHint_myroomnick": "Set your display name for this room",
+    "commandHint_myroomnick": "Set your display name for this group chat",
     "@commandHint_myroomnick": {
         "type": "text",
         "description": "Usage hint for the command /myroomnick"
@@ -520,7 +520,7 @@
         "type": "text",
         "description": "Usage hint for the command /send"
     },
-    "commandHint_unban": "Unban the given user from this room",
+    "commandHint_unban": "Unban the given user from this group chat",
     "@commandHint_unban": {
         "type": "text",
         "description": "Usage hint for the command /unban"
@@ -758,12 +758,12 @@
         "type": "text",
         "placeholders": {}
     },
-    "editRoomAliases": "Edit room aliases",
+    "editRoomAliases": "Edit group chat aliases",
     "@editRoomAliases": {
         "type": "text",
         "placeholders": {}
     },
-    "editRoomAvatar": "Edit room avatar",
+    "editRoomAvatar": "Edit group chat avatar",
     "@editRoomAvatar": {
         "type": "text",
         "placeholders": {}
@@ -778,7 +778,7 @@
         "type": "text",
         "placeholders": {}
     },
-    "emotePacks": "Emote packs for room",
+    "emotePacks": "Emote packs for group chat",
     "@emotePacks": {
         "type": "text",
         "placeholders": {}
@@ -911,7 +911,7 @@
         "type": "text",
         "placeholders": {}
     },
-    "goToTheNewRoom": "Go to the new room",
+    "goToTheNewRoom": "Go to the new group chat",
     "@goToTheNewRoom": {
         "type": "text",
         "placeholders": {}
@@ -1006,7 +1006,7 @@
         "type": "text",
         "placeholders": {}
     },
-    "ignoreListDescription": "You can ignore users who are disturbing you. You won't be able to receive any messages or room invites from the users on your personal ignore list.",
+    "ignoreListDescription": "You can ignore users who are disturbing you. You won't be able to receive any messages or group chat invites from the users on your personal ignore list.",
     "@ignoreListDescription": {
         "type": "text",
         "placeholders": {}
@@ -1086,7 +1086,7 @@
             "username": {}
         }
     },
-    "joinRoom": "Join room",
+    "joinRoom": "Join group chat",
     "@joinRoom": {
         "type": "text",
         "placeholders": {}
@@ -1292,7 +1292,7 @@
         "type": "text",
         "placeholders": {}
     },
-    "noEncryptionForPublicRooms": "You can only activate encryption as soon as the room is no longer publicly accessible.",
+    "noEncryptionForPublicRooms": "You can only activate encryption as soon as the group chat is no longer publicly accessible.",
     "@noEncryptionForPublicRooms": {
         "type": "text",
         "placeholders": {}
@@ -1331,7 +1331,7 @@
         "type": "text",
         "placeholders": {}
     },
-    "noRoomsFound": "No rooms found…",
+    "noRoomsFound": "No group chats found…",
     "@noRoomsFound": {
         "type": "text",
         "placeholders": {}
@@ -1550,7 +1550,7 @@
         "type": "text",
         "placeholders": {}
     },
-    "publicRooms": "Public Rooms",
+    "publicRooms": "Public group chats",
     "@publicRooms": {
         "type": "text",
         "placeholders": {}
@@ -1641,7 +1641,7 @@
         "type": "text",
         "placeholders": {}
     },
-    "replaceRoomWithNewerVersion": "Replace room with newer version",
+    "replaceRoomWithNewerVersion": "Replace group chat with newer version",
     "@replaceRoomWithNewerVersion": {
         "type": "text",
         "placeholders": {}
@@ -1661,12 +1661,12 @@
         "type": "text",
         "placeholders": {}
     },
-    "roomHasBeenUpgraded": "Room has been upgraded",
+    "roomHasBeenUpgraded": "Group chat has been upgraded",
     "@roomHasBeenUpgraded": {
         "type": "text",
         "placeholders": {}
     },
-    "roomVersion": "Room version",
+    "roomVersion": "Group chat version",
     "@roomVersion": {
         "type": "text",
         "placeholders": {}
@@ -1954,7 +1954,7 @@
         "type": "text",
         "placeholders": {}
     },
-    "thisRoomHasBeenArchived": "This room has been archived.",
+    "thisRoomHasBeenArchived": "This group chat has been archived.",
     "@thisRoomHasBeenArchived": {
         "type": "text",
         "placeholders": {}


### PR DESCRIPTION
Kept "Room" if it's used for both Direct Message and Group Chat

This closes #274 