### PR TITLE
fix: put ellipsis when display name is too long in members list

### DIFF
--- a/lib/pages/chat_details/participant_list_item.dart
+++ b/lib/pages/chat_details/participant_list_item.dart
@@ -39,7 +39,13 @@ class ParticipantListItem extends StatelessWidget {
         ),
         title: Row(
           children: <Widget>[
-            Text(user.calcDisplayname()),
+            Flexible(
+              child: Text(
+                user.calcDisplayname(),
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
+              ),
+            ),
             if (permissionBatch.isNotEmpty)
               Container(
                 padding: const EdgeInsets.symmetric(


### PR DESCRIPTION
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/be16bc3f-ac72-4818-a345-cef34ff537d5)
>
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/566a96b6-883e-4d28-8962-08f15b73a0f7)