### PR TITLE
TW-367: hot-fix/load-more-is-not-correct-behavior

### DIFF
--- a/lib/mixin/comparable_presentation_contact_mixin.dart
+++ b/lib/mixin/comparable_presentation_contact_mixin.dart
@@ -7,15 +7,15 @@ class ComparablePresentationContactMixin {
     final buffer2 = StringBuffer();
     
     buffer1.writeAll([
-      contact1.displayName ?? "",
       contact1.matrixId ?? "",
+      contact1.displayName ?? "",
       contact1.email ?? "",
       contact1.status ?? "",
     ]);
 
     buffer2.writeAll([
-      contact2.displayName ?? "",
       contact2.matrixId ?? "",
+      contact2.displayName ?? "",
       contact2.email ?? "",
       contact2.status ?? "",
     ]);

--- a/lib/pages/new_private_chat/search_contacts_controller.dart
+++ b/lib/pages/new_private_chat/search_contacts_controller.dart
@@ -45,8 +45,8 @@ class SearchContactsController {
         if (onSearchKeywordChanged != null) {
           onSearchKeywordChanged!(textEditingController.text);
         }
-        fetchLookupContacts();
       }
+      fetchLookupContacts();
     });
   }
 


### PR DESCRIPTION
### Issue:
#367 

## Cause: 
- Because the load more API return contacts sorted by uid, but the app client is sorted as displayName, so the order is not correct when loadMore is called
## Resolved:
- Sort the contacts in client app by uuid not by displayName.

https://github.com/linagora/twake-on-matrix/assets/43041967/f8e745fa-ab0e-4272-92f4-0f8048381cdd

## Cause: 
- When the user search contacts, the user clicks X button, and the contact list is not reloaded.
- 
https://github.com/linagora/twake-on-matrix/assets/43041967/7f4a99f6-2fa3-4856-9d2e-f5e521d815a8



