### PR TITLE
hot-fix/missing ecrypt/decrypt function in web

### DIFF
--- a/lib/utils/matrix_sdk_extensions/matrix_file_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/matrix_file_extension.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:ffi';
 import 'dart:io';
 import 'dart:typed_data';
 

--- a/lib/utils/resize_image.dart
+++ b/lib/utils/resize_image.dart
@@ -1,4 +1,3 @@
-import 'dart:ffi';
 import 'dart:io';
 import 'dart:typed_data';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1446,7 +1446,7 @@ packages:
     description:
       path: "."
       ref: improve-matrix-file
-      resolved-ref: b8762469be46d3ec6ee782ccdc035a597202c2f4
+      resolved-ref: "01144ab3a0b7fd88970c35e9d572ed7f3f5ccf74"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.20.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -97,7 +97,7 @@ dependencies:
       url: git@github.com:SpectoraSoftware/VideoCompress.git
       ref: master
   video_player: ^2.2.18
-  go_router: 10.0.0
+  go_router: ^10.0.0
   wakelock: ^0.6.2
   webrtc_interface: ^1.0.10
   linagora_design_flutter:


### PR DESCRIPTION
### modifying in SDK:

https://github.com/linagora/matrix-dart-sdk/pull/6/


https://github.com/linagora/twake-on-matrix/assets/43041967/75651e36-61c1-43bf-ba70-90d13d430b5d


https://github.com/linagora/twake-on-matrix/assets/43041967/f6512c3a-5fc8-4bf4-9ea2-e7cdfdc631e8


https://github.com/linagora/twake-on-matrix/assets/43041967/b77975e4-e66a-40a1-9057-54308b9b7378



