### PR TITLE
fix: reduce width of bubble messages

### DIFF
--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -117,8 +117,10 @@ class Message extends StatelessWidget {
               children: [
                 // if (ownMessage && event.messageType == MessageTypes.Image)
                 //   ReplyIconWidget(isOwnMessage: ownMessage),
-                Expanded(
-                  flex: MessageStyle.messageFlexMobile,
+                Container(
+                  constraints: BoxConstraints(
+                    maxWidth: MessageStyle.messageBubbleWidth(context),
+                  ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/config/app_config.dart';
 import 'package:flutter/material.dart';
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
 
 class MessageStyle {
   static final bubbleBorderRadius = BorderRadius.circular(20);
@@ -47,4 +48,17 @@ class MessageStyle {
   static double get forwardContainerSize => 40.0;
   static Color? forwardColorBackground(context) =>
       Theme.of(context).colorScheme.surfaceTint.withOpacity(0.08);
+
+  static const double messageBubbleLargeMaxWidth = 620.0;
+  static const double messageBubbleWatchMaxWidth = 240.0;
+  static const double messageBubbleMobileRatioMaxWidth = 0.80;
+  static double messageBubbleWidth(BuildContext context) {
+    return context.responsiveValue<double>(
+      desktop: messageBubbleLargeMaxWidth,
+      tablet: messageBubbleLargeMaxWidth,
+      mobile:
+          MediaQuery.of(context).size.width * messageBubbleMobileRatioMaxWidth,
+      watch: messageBubbleWatchMaxWidth,
+    );
+  }
 }


### PR DESCRIPTION
Design : 
web version (620px)
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/0c881acb-91c7-40f6-a36a-c3e9efbf15c7)
mobile (272px)
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/4a0ae968-3dfb-4079-9442-90ca8013eeb4)

Direct message : 
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/fd37f1d4-990b-441d-970f-661c76a06d2c)
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/897cd281-886d-486e-8a58-9aa7b3f37924)

Group : 
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/d3b44cb8-4ce4-4929-8b3f-b2963ecff15e)
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/191c4b8c-3374-41da-b4b3-30c3456ce029)

Web :
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/87ace08f-dc2a-485a-a86b-36b672b61794)


This Closes #411