### PR TITLE
TW-473 Fix error bubble is not showing in direct chat

### DIFF
--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -581,6 +581,9 @@ class Message extends StatelessWidget {
 
   Widget _placeHolderWidget(bool sameSender, bool ownMessage, Event event) {
     if (controller.selectMode || event.room.isDirectChat) {
+      if (event.status == EventStatus.error) {
+        return const Icon(Icons.error, color: Colors.red);
+      }
       return const SizedBox();
     }
 


### PR DESCRIPTION
# Related
- #473 
- #240 

# Before
<img src="https://github.com/linagora/twake-on-matrix/assets/12546908/11c10398-6b30-452e-9b9e-e55cb6f77734" width=360 />
<img src="https://github.com/linagora/twake-on-matrix/assets/12546908/28789f50-8021-43b6-8cd1-feba6c025833" width=360 />


# After
<img src="https://github.com/linagora/twake-on-matrix/assets/12546908/cc3a09c4-d9eb-475d-a54b-99c0f22b6f1c" width=360 />
<img src="https://github.com/linagora/twake-on-matrix/assets/12546908/c5715f6c-0448-4391-8351-715abc15d840" width=360 />
