### PR TITLE
fix: unselect messages after pin event

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1126,6 +1126,7 @@ class ChatController extends State<Chat> with ImagePickerMixin, SendFilesMixin {
     } else {
       pinnedEventIds.addAll(selectedEventIds);
     }
+    clearSelectedEvents();
     showFutureLoadingDialog(
       context: context,
       future: () => room.setPinnedEvents(pinnedEventIds),


### PR DESCRIPTION
This Closes #385
![pinpin](https://github.com/linagora/twake-on-matrix/assets/48354990/46c999c6-f169-42ed-a25e-30396a980304)
