### PR TITLE
TW-494: profile is called everytime when rebuild

### DIFF
--- a/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/domain/model/contact/contact_status.dart';
 import 'package:fluffychat/presentation/model/presentation_contact.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/contact_status_widget.dart';
 import 'package:fluffychat/utils/display_name_widget.dart';
@@ -25,7 +26,8 @@ class ExpansionContactListTile extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(left: 8.0, top: 8.0, bottom: 12.0),
       child: FutureBuilder<Profile?>(
-        future: getProfile(context),
+        future:
+            contact.status == ContactStatus.active ? getProfile(context) : null,
         builder: (context, snapshot) {
           return Row(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -117,7 +119,10 @@ class ExpansionContactListTile extends StatelessWidget {
       return Future.error(Exception("MatrixId is null"));
     }
     try {
-      final profile = await client.getProfileFromUserId(contact.matrixId!);
+      final profile = await client.getProfileFromUserId(
+        contact.matrixId!,
+        getFromRooms: false,
+      );
       Logs()
           .d("ExpansionContactListTile()::getProfiles(): ${profile.avatarUrl}");
       return profile;

--- a/lib/presentation/extensions/search/presentation_search_extensions.dart
+++ b/lib/presentation/extensions/search/presentation_search_extensions.dart
@@ -7,7 +7,10 @@ extension PresentationSearchExtensions on ContactPresentationSearch {
       return Future.error(Exception("MatrixId is null"));
     }
     try {
-      final profile = await client.getProfileFromUserId(matrixId!);
+      final profile = await client.getProfileFromUserId(
+        matrixId!,
+        getFromRooms: false,
+      );
       Logs().d("SearchController()::getProfiles(): ${profile.avatarUrl}");
       return profile;
     } catch (e) {

--- a/lib/widgets/avatar/avatar_with_bottom_icon_widget.dart
+++ b/lib/widgets/avatar/avatar_with_bottom_icon_widget.dart
@@ -32,9 +32,10 @@ class AvatarWithBottomIconWidget extends StatelessWidget {
         children: [
           if (presentationContact.matrixId != null)
             FutureBuilder<Profile>(
-              future: Matrix.of(context)
-                  .client
-                  .getProfileFromUserId(presentationContact.matrixId!),
+              future: Matrix.of(context).client.getProfileFromUserId(
+                    presentationContact.matrixId!,
+                    getFromRooms: false,
+                  ),
               builder: ((context, snapshot) {
                 return Avatar(
                   mxContent: snapshot.data?.avatarUrl,


### PR DESCRIPTION
### Causing:
The non-activated contact doesn't have profiles, so it will not be stored in the cache, and the default cache mode is to store only contacts in rooms.

### Resolved:
- Don't call getProfile API on non-activated contact, because it doesn't contain any information in server
- Change cache mode from room cache to server Cache

### Demo:
https://github.com/linagora/twake-on-matrix/assets/43041967/e8a4435b-ff0a-433d-8496-b295e92456c5

