### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@sherlockvn @hoangdat @dab246 @nqhhdev @imGok @drminh2807

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,7 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: "stable"
           cache: true
+          cache-key: "flutter-:os:-:channel:-:version:-:arch:-:hash:-${{ hashFiles('**/pubspec.lock') }}"
 
       - uses: webfactory/ssh-agent@v0.8.0
         with:


### PR DESCRIPTION
# Detail
These owners will be the default owners for everything in
the repo. Unless a later match takes precedence,
@global-owner1 and @global-owner2 will be requested for
review when someone opens a pull request.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file