### PR TITLE
Tw 499/only show accepted event defined user story

### DIFF
--- a/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
@@ -27,7 +27,7 @@ extension IsStateExtension on Event {
           type != EventTypes.RoomMember ||
           room.joinRules != JoinRules.public ||
           content.tryGet<String>('membership') == 'ban' ||
-          stateKey != senderId);
+      !isSomeoneChangeDisplayName() &&
 
   static const Set<String> importantStateEvents = {
     EventTypes.Encryption,
@@ -42,4 +42,9 @@ extension IsStateExtension on Event {
         EventTypes.Sticker,
         EventTypes.Encrypted
       }.contains(type);
+  bool isSomeoneChangeDisplayName() {
+    return stateKey != null &&
+        prevContent?['displayname'] != null &&
+        prevContent!['displayname'] != content['displayname'];
+  }
 }

--- a/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
@@ -28,6 +28,7 @@ extension IsStateExtension on Event {
           room.joinRules != JoinRules.public ||
           content.tryGet<String>('membership') == 'ban' ||
       !isSomeoneChangeDisplayName() &&
+      !isSomeoneChangeAvatar() &&
 
   static const Set<String> importantStateEvents = {
     EventTypes.Encryption,
@@ -47,4 +48,11 @@ extension IsStateExtension on Event {
         prevContent?['displayname'] != null &&
         prevContent!['displayname'] != content['displayname'];
   }
+  bool isSomeoneChangeAvatar() {
+    return stateKey != null &&
+        prevContent?["membership"] == 'join' &&
+        prevContent?['avatar_url'] != null &&
+        prevContent?['avatar_url'] != content['avatar_url'];
+  }
+
 }

--- a/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
@@ -27,10 +27,12 @@ extension IsStateExtension on Event {
           type != EventTypes.RoomMember ||
           room.joinRules != JoinRules.public ||
           content.tryGet<String>('membership') == 'ban' ||
+          stateKey != senderId) &&
       !isSomeoneChangeDisplayName() &&
       !isSomeoneChangeAvatar() &&
       !isGroupNameChangeWhenCreate() &&
       !isGroupAvatarChangeWhenCreate() &&
+      !isJoinedByYourself() &&
       !isActivateEndToEndEncryption() &&
       !isInviteWhenCreate();
 
@@ -49,11 +51,13 @@ extension IsStateExtension on Event {
         EventTypes.Sticker,
         EventTypes.Encrypted
       }.contains(type);
+
   bool isSomeoneChangeDisplayName() {
     return stateKey != null &&
         prevContent?['displayname'] != null &&
         prevContent!['displayname'] != content['displayname'];
   }
+
   bool isGroupNameChangeWhenCreate() {
     return type == EventTypes.RoomName &&
         content['name'] != null &&
@@ -65,12 +69,21 @@ extension IsStateExtension on Event {
         content['url'] == null &&
         prevContent?['url'] == null;
   }
+
+  bool isJoinedByYourself() {
+    return type == EventTypes.RoomMember &&
+        content['membership'] == 'join' &&
+        senderId == stateKey &&
+        stateKey == room.client.userID;
+  }
+
   bool isInviteWhenCreate() {
     return type == EventTypes.RoomMember &&
         content['membership'] != null &&
         content['membership'] == 'invite' &&
         content['reason'] == null;
   }
+
   bool isSomeoneChangeAvatar() {
     return stateKey != null &&
         prevContent?["membership"] == 'join' &&

--- a/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
@@ -29,6 +29,7 @@ extension IsStateExtension on Event {
           content.tryGet<String>('membership') == 'ban' ||
       !isSomeoneChangeDisplayName() &&
       !isSomeoneChangeAvatar() &&
+      !isActivateEndToEndEncryption() &&
 
   static const Set<String> importantStateEvents = {
     EventTypes.Encryption,
@@ -55,4 +56,7 @@ extension IsStateExtension on Event {
         prevContent?['avatar_url'] != content['avatar_url'];
   }
 
+  bool isActivateEndToEndEncryption() {
+    return type == EventTypes.Encryption;
+  }
 }

--- a/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
@@ -29,6 +29,8 @@ extension IsStateExtension on Event {
           content.tryGet<String>('membership') == 'ban' ||
       !isSomeoneChangeDisplayName() &&
       !isSomeoneChangeAvatar() &&
+      !isGroupNameChangeWhenCreate() &&
+      !isGroupAvatarChangeWhenCreate() &&
       !isActivateEndToEndEncryption() &&
 
   static const Set<String> importantStateEvents = {
@@ -37,6 +39,8 @@ extension IsStateExtension on Event {
     EventTypes.RoomMember,
     EventTypes.RoomTombstone,
     EventTypes.CallInvite,
+    EventTypes.RoomName,
+    EventTypes.RoomAvatar,
   };
 
   bool get isState => !{
@@ -48,6 +52,17 @@ extension IsStateExtension on Event {
     return stateKey != null &&
         prevContent?['displayname'] != null &&
         prevContent!['displayname'] != content['displayname'];
+  }
+  bool isGroupNameChangeWhenCreate() {
+    return type == EventTypes.RoomName &&
+        content['name'] != null &&
+        prevContent?['name'] == null;
+  }
+
+  bool isGroupAvatarChangeWhenCreate() {
+    return type == EventTypes.RoomAvatar &&
+        content['url'] == null &&
+        prevContent?['url'] == null;
   }
   bool isSomeoneChangeAvatar() {
     return stateKey != null &&

--- a/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
@@ -32,6 +32,7 @@ extension IsStateExtension on Event {
       !isGroupNameChangeWhenCreate() &&
       !isGroupAvatarChangeWhenCreate() &&
       !isActivateEndToEndEncryption() &&
+      !isInviteWhenCreate();
 
   static const Set<String> importantStateEvents = {
     EventTypes.Encryption,
@@ -63,6 +64,12 @@ extension IsStateExtension on Event {
     return type == EventTypes.RoomAvatar &&
         content['url'] == null &&
         prevContent?['url'] == null;
+  }
+  bool isInviteWhenCreate() {
+    return type == EventTypes.RoomMember &&
+        content['membership'] != null &&
+        content['membership'] == 'invite' &&
+        content['reason'] == null;
   }
   bool isSomeoneChangeAvatar() {
     return stateKey != null &&

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1526,7 +1526,7 @@ packages:
     description:
       path: "."
       ref: twake-supported
-      resolved-ref: "954430a1296311db4b34eadeaf29ecfb4ff330df"
+      resolved-ref: "186ded3be6d5acbe3476e61a38f6aeb41cac5347"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.2"


### PR DESCRIPTION
### Blocker:
https://github.com/linagora/matrix-dart-sdk/pull/12
### What i'm doing:
- As you can see, when you first create the group chat, a lot of events which is not necessary for users. So, I have to remove that when first create the group chat and direct chat
<img width="929" alt="Screenshot 2023-09-16 at 00 05 42" src="https://github.com/linagora/twake-on-matrix/assets/43041967/f023d607-60ca-4c89-a209-62e65dcd334c">

### Solution:
- "Bạn đã tham gia cuộc trò chuyện", we can remove this event simply by checking the `senderId` and the `state_key` (receiverId). If senderId equals state_key, remove the event.
- "Bạn đã kích hoạt mã hoá đầu cuối", we can remove this event by checking type of event is `Encryption` type.
- "Bạn đã thay đổi tên của nhóm" we can remove this event by checking the previous content of event (prev_content) contains old name of room or not
- "Bạn đã thay đổi avatar của nhóm" the same
- "Bạn mời ai đó vào phòng", because the event content when first create the chat and later is not different at all. So, no condition to remove the events when create the chat. But we can do it by change the `inviteUser` APIs by adding default reason = `Welcome` and when creating the chat, the reason is null.

### Demo: 


https://github.com/linagora/twake-on-matrix/assets/43041967/36b8079f-1a7d-4792-8edd-21ef100816f8



https://github.com/linagora/twake-on-matrix/assets/43041967/e75c5f16-c702-4dae-b58a-4807303ebed6

