### PR TITLE
Tw 540/set different size for image

### DIFF
--- a/lib/data/network/upload_file/file_info_extension.dart
+++ b/lib/data/network/upload_file/file_info_extension.dart
@@ -36,7 +36,7 @@ extension ImageFileInfoExtension on ImageFileInfo {
   Map<String, dynamic> get metadata => ({
         'mimetype': mimeType,
         'size': fileSize,
-        'width': width?.toDouble(),
-        'height': height?.toDouble(),
+        'w': width?.toDouble(),
+        'h': height?.toDouble(),
       });
 }

--- a/lib/data/network/upload_file/file_info_extension.dart
+++ b/lib/data/network/upload_file/file_info_extension.dart
@@ -31,3 +31,12 @@ extension FileInfoExtension on FileInfo {
     return MessageTypes.File;
   }
 }
+
+extension ImageFileInfoExtension on ImageFileInfo {
+  Map<String, dynamic> get metadata => ({
+        'mimetype': mimeType,
+        'size': fileSize,
+        'width': width?.toDouble(),
+        'height': height?.toDouble(),
+      });
+}

--- a/lib/domain/usecase/send_file_on_web_interactor.dart
+++ b/lib/domain/usecase/send_file_on_web_interactor.dart
@@ -15,7 +15,7 @@ class SendFileOnWebInteractor {
     try {
       final matrixFiles = filePickerResult.files
           .map(
-            (xFile) => MatrixFile(
+            (xFile) => MatrixFile.fromMimeType(
               bytes: xFile.bytes,
               name: xFile.name,
               filePath: '',

--- a/lib/pages/chat/events/image_bubble.dart
+++ b/lib/pages/chat/events/image_bubble.dart
@@ -1,5 +1,7 @@
+import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:matrix/matrix.dart';
@@ -74,6 +76,8 @@ class ImageBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bubbleWidth = max(MessageContentStyle.imageBubbleMinWidth, width);
+    final bubbleHeight = max(MessageContentStyle.imageBubbleMinHeight, height);
     return Hero(
       tag: event.eventId,
       child: AnimatedSwitcher(
@@ -84,24 +88,37 @@ class ImageBubble extends StatelessWidget {
           ),
           constraints: maxSize
               ? BoxConstraints(
-                  maxWidth: width,
-                  maxHeight: height,
+                  maxWidth: bubbleWidth,
+                  maxHeight: bubbleHeight,
                 )
               : null,
-          child: MxcImage(
-            rounded: true,
-            event: event,
-            width: width,
-            height: height,
-            fit: fit,
-            animated: animated,
-            isThumbnail: thumbnailOnly,
-            placeholder: _buildPlaceholder,
-            onTapPreview: onTapPreview,
-            onTapSelectMode: onTapSelectMode,
-            imageData: imageData,
-            isPreview: true,
-            animationDuration: animationDuration,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(16.0),
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                SizedBox(
+                  width: bubbleWidth,
+                  height: bubbleHeight,
+                  child:
+                      const BlurHash(hash: MessageContentStyle.defaultBlurHash),
+                ),
+                MxcImage(
+                  event: event,
+                  width: width,
+                  height: height,
+                  fit: fit,
+                  animated: animated,
+                  isThumbnail: thumbnailOnly,
+                  placeholder: _buildPlaceholder,
+                  onTapPreview: onTapPreview,
+                  onTapSelectMode: onTapSelectMode,
+                  imageData: imageData,
+                  isPreview: true,
+                  animationDuration: animationDuration,
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/pages/chat/events/image_bubble.dart
+++ b/lib/pages/chat/events/image_bubble.dart
@@ -1,4 +1,3 @@
-import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
@@ -76,8 +75,8 @@ class ImageBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bubbleWidth = max(MessageContentStyle.imageBubbleMinWidth, width);
-    final bubbleHeight = max(MessageContentStyle.imageBubbleMinHeight, height);
+    final bubbleWidth = MessageContentStyle.imageBubbleWidth(width);
+    final bubbleHeight = MessageContentStyle.imageBubbleWidth(height);
     return Hero(
       tag: event.eventId,
       child: AnimatedSwitcher(

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -444,15 +444,14 @@ class _MessageImageBuilder extends StatelessWidget {
     DisplayImageInfo? displayImageInfo =
         event.getThumbnailSize()?.getDisplayImageInfo(context);
 
-    if (matrixFile != null &&
-        matrixFile.filePath != null &&
-        matrixFile is MatrixImageFile) {
+    if (isSendingImageInMobile(matrixFile)) {
+      final file = matrixFile as MatrixImageFile;
       displayImageInfo = Size(
-        matrixFile.width!.toDouble(),
-        matrixFile.height!.toDouble(),
+        file.width?.toDouble() ?? MessageContentStyle.imageWidth(context),
+        file.height?.toDouble() ?? MessageContentStyle.imageHeight(context),
       ).getDisplayImageInfo(context);
       return SendingImageInfoWidget(
-        matrixFile: matrixFile,
+        matrixFile: file,
         event: event,
         onTapPreview: onTapPreview,
         displayImageInfo: displayImageInfo,
@@ -460,11 +459,18 @@ class _MessageImageBuilder extends StatelessWidget {
     }
     displayImageInfo ??= DisplayImageInfo(
       size: Size(
-        MessageContentStyle.imageBubbleWidth(context),
-        MessageContentStyle.imageBubbleHeight(context),
+        MessageContentStyle.imageWidth(context),
+        MessageContentStyle.imageHeight(context),
       ),
       hasBlur: true,
     );
+    if (isSendingImageInWeb(matrixFile)) {
+      final file = matrixFile as MatrixImageFile;
+      displayImageInfo = Size(
+        file.width?.toDouble() ?? MessageContentStyle.imageWidth(context),
+        file.height?.toDouble() ?? MessageContentStyle.imageHeight(context),
+      ).getDisplayImageInfo(context);
+    }
     return ImageBubble(
       event,
       width: displayImageInfo.size.width,
@@ -474,5 +480,17 @@ class _MessageImageBuilder extends StatelessWidget {
       onTapPreview: onTapPreview,
       animated: true,
     );
+  }
+
+  bool isSendingImageInWeb(MatrixFile? matrixFile) {
+    return matrixFile != null &&
+        matrixFile.bytes != null &&
+        matrixFile is MatrixImageFile;
+  }
+
+  bool isSendingImageInMobile(MatrixFile? matrixFile) {
+    return matrixFile != null &&
+        matrixFile.filePath != null &&
+        matrixFile is MatrixImageFile;
   }
 }

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -5,6 +5,8 @@ import 'package:fluffychat/pages/bootstrap/bootstrap_dialog.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:fluffychat/pages/chat/events/sending_image_info_widget.dart';
 import 'package:fluffychat/pages/chat/events/sending_video_widget.dart';
+import 'package:fluffychat/presentation/model/file/display_image_info.dart';
+import 'package:fluffychat/utils/extension/image_size_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/string_extension.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
@@ -438,20 +440,35 @@ class _MessageImageBuilder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final matrixFile = event.getMatrixFile();
+
+    DisplayImageInfo? displayImageInfo =
+        event.getThumbnailSize()?.getDisplayImageInfo(context);
+
     if (matrixFile != null &&
         matrixFile.filePath != null &&
         matrixFile is MatrixImageFile) {
+      displayImageInfo = Size(
+        matrixFile.width!.toDouble(),
+        matrixFile.height!.toDouble(),
+      ).getDisplayImageInfo(context);
       return SendingImageInfoWidget(
         matrixFile: matrixFile,
         event: event,
         onTapPreview: onTapPreview,
+        displayImageInfo: displayImageInfo,
       );
     }
-
+    displayImageInfo ??= DisplayImageInfo(
+      size: Size(
+        MessageContentStyle.imageBubbleWidth(context),
+        MessageContentStyle.imageBubbleHeight(context),
+      ),
+      hasBlur: true,
+    );
     return ImageBubble(
       event,
-      width: MessageContentStyle.imageBubbleWidth(context),
-      height: MessageContentStyle.imageBubbleHeight(context),
+      width: displayImageInfo.size.width,
+      height: displayImageInfo.size.height,
       fit: BoxFit.cover,
       onTapSelectMode: onTapSelectMode,
       onTapPreview: onTapPreview,

--- a/lib/pages/chat/events/message_content_style.dart
+++ b/lib/pages/chat/events/message_content_style.dart
@@ -1,4 +1,7 @@
+import 'dart:math';
+
 import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:flutter/material.dart';
 
@@ -8,14 +11,14 @@ class MessageContentStyle {
   static const int maxLengthTextInline = 180;
   static const double appBarFontSize = 16.0;
 
-  static double imageBubbleWidth(BuildContext context) {
+  static double imageWidth(BuildContext context) {
     if (responsiveUtils.isDesktop(context)) {
       return imageBubbleWidthForWeb;
     }
     return imageBubbleWidthForMobileAndTablet;
   }
 
-  static double imageBubbleHeight(BuildContext context) {
+  static double imageHeight(BuildContext context) {
     if (responsiveUtils.isDesktop(context)) {
       return imageBubbleHeightForWeb;
     }
@@ -32,6 +35,18 @@ class MessageContentStyle {
   static const double imageBubbleDefaultHeight = 340;
   static Color backgroundColorButton = Colors.white.withAlpha(64);
   static const String defaultBlurHash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
+
+  static double imageBubbleWidth(double displayWidth) => max(
+        MessageContentStyle.imageBubbleMinWidth,
+        displayWidth,
+      );
+
+  static double imageBubbleHeight(double displayHeight) => PlatformInfos.isWeb
+      ? displayHeight
+      : max(
+          MessageContentStyle.imageBubbleMinHeight,
+          displayHeight,
+        );
 
   static const double letterSpacingMessageContent = -0.15;
 }

--- a/lib/pages/chat/events/message_content_style.dart
+++ b/lib/pages/chat/events/message_content_style.dart
@@ -26,7 +26,12 @@ class MessageContentStyle {
   static const double imageBubbleHeightForMobileAndTable = 320;
   static const double imageBubbleWidthForMobileAndTablet = 256;
   static const double imageBubbleWidthForWeb = 500;
+  static const double imageBubbleMinWidth = 120;
+  static const double imageBubbleMinHeight = 100;
+  static const double imageBubbleDefaultWidth = 292;
+  static const double imageBubbleDefaultHeight = 340;
   static Color backgroundColorButton = Colors.white.withAlpha(64);
+  static const String defaultBlurHash = 'LEHV6nWB2yk8pyo0adR*.7kCMdnj';
 
   static const double letterSpacingMessageContent = -0.15;
 }

--- a/lib/pages/chat/events/sending_image_info_widget.dart
+++ b/lib/pages/chat/events/sending_image_info_widget.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:math';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:fluffychat/pages/image_viewer/image_viewer.dart';
 import 'package:fluffychat/presentation/model/file/display_image_info.dart';
@@ -79,12 +78,10 @@ class SendingImageInfoWidget extends StatelessWidget {
             children: [
               if (displayImageInfo.hasBlur)
                 SizedBox(
-                  width: max(
-                    MessageContentStyle.imageBubbleMinWidth,
+                  width: MessageContentStyle.imageBubbleWidth(
                     displayImageInfo.size.width,
                   ),
-                  height: max(
-                    MessageContentStyle.imageBubbleMinHeight,
+                  height: MessageContentStyle.imageBubbleHeight(
                     displayImageInfo.size.height,
                   ),
                   child:

--- a/lib/pages/chat/events/sending_image_info_widget.dart
+++ b/lib/pages/chat/events/sending_image_info_widget.dart
@@ -1,7 +1,10 @@
 import 'dart:io';
+import 'dart:math';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:fluffychat/pages/image_viewer/image_viewer.dart';
+import 'package:fluffychat/presentation/model/file/display_image_info.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 
@@ -10,6 +13,7 @@ class SendingImageInfoWidget extends StatelessWidget {
     super.key,
     required this.matrixFile,
     required this.event,
+    required this.displayImageInfo,
     this.onTapPreview,
   });
 
@@ -20,6 +24,8 @@ class SendingImageInfoWidget extends StatelessWidget {
   final void Function()? onTapPreview;
 
   final ValueNotifier<double> sendingFileProgressNotifier = ValueNotifier(0);
+
+  final DisplayImageInfo displayImageInfo;
 
   void _onTap(BuildContext context) async {
     if (onTapPreview != null) {
@@ -68,14 +74,32 @@ class SendingImageInfoWidget extends StatelessWidget {
         onTap: () => _onTap(context),
         child: ClipRRect(
           borderRadius: BorderRadius.circular(12.0),
-          child: Image.file(
-            File(matrixFile.filePath!),
-            width: MessageContentStyle.imageBubbleWidth(context),
-            height: MessageContentStyle.imageBubbleHeight(context),
-            cacheHeight: MessageContentStyle.imageBubbleHeight(context).toInt(),
-            cacheWidth: MessageContentStyle.imageBubbleWidth(context).toInt(),
-            fit: BoxFit.cover,
-            filterQuality: FilterQuality.medium,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              if (displayImageInfo.hasBlur)
+                SizedBox(
+                  width: max(
+                    MessageContentStyle.imageBubbleMinWidth,
+                    displayImageInfo.size.width,
+                  ),
+                  height: max(
+                    MessageContentStyle.imageBubbleMinHeight,
+                    displayImageInfo.size.height,
+                  ),
+                  child:
+                      const BlurHash(hash: MessageContentStyle.defaultBlurHash),
+                ),
+              Image.file(
+                File(matrixFile.filePath!),
+                width: displayImageInfo.size.width,
+                height: displayImageInfo.size.height,
+                cacheHeight: displayImageInfo.size.height.toInt(),
+                cacheWidth: displayImageInfo.size.width.toInt(),
+                fit: BoxFit.cover,
+                filterQuality: FilterQuality.medium,
+              )
+            ],
           ),
         ),
       ),

--- a/lib/pages/chat/events/sending_video_widget.dart
+++ b/lib/pages/chat/events/sending_video_widget.dart
@@ -130,23 +130,20 @@ class _SendingVideoWidgetState extends State<SendingVideoWidget>
   (double, double) _getImageSize(int? imageWidth, int? imageHeight) {
     if (imageWidth == null || imageHeight == null) {
       return (
-        MessageContentStyle.imageBubbleWidth(context),
-        MessageContentStyle.imageBubbleHeight(context)
+        MessageContentStyle.imageWidth(context),
+        MessageContentStyle.imageHeight(context)
       );
     }
 
-    final ratio = MessageContentStyle.imageBubbleWidth(context) / imageWidth;
+    final ratio = MessageContentStyle.imageWidth(context) / imageWidth;
 
     if (imageWidth <= imageHeight) {
       return (
-        MessageContentStyle.imageBubbleWidth(context),
-        MessageContentStyle.imageBubbleHeight(context)
+        MessageContentStyle.imageWidth(context),
+        MessageContentStyle.imageHeight(context)
       );
     } else {
-      return (
-        MessageContentStyle.imageBubbleWidth(context),
-        imageHeight * ratio
-      );
+      return (MessageContentStyle.imageWidth(context), imageHeight * ratio);
     }
   }
 

--- a/lib/pages/chat/events/video_player.dart
+++ b/lib/pages/chat/events/video_player.dart
@@ -110,8 +110,8 @@ class EventVideoPlayerState extends State<EventVideoPlayer> {
       child: Material(
         color: Colors.black,
         child: SizedBox(
-          width: MessageContentStyle.imageBubbleWidth(context),
-          height: MessageContentStyle.imageBubbleHeight(context),
+          width: MessageContentStyle.imageWidth(context),
+          height: MessageContentStyle.imageHeight(context),
           child: chewieManager != null
               ? FittedBox(
                   fit: BoxFit.contain,

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -18,8 +18,6 @@ typedef MessageType = String;
 typedef FakeImageEvent = SyncUpdate;
 
 extension SendFileExtension on Room {
-  static const maxImagesCacheInRoom = 10;
-
   Future<String?> sendFileEvent(
     FileInfo fileInfo, {
     String msgType = MessageTypes.Image,
@@ -190,8 +188,7 @@ extension SendFileExtension on Room {
           'thumbnail_url': thumbnailUploadResp.toString(),
         if (thumbnail != null && encryptedThumbnail != null)
           'thumbnail_file': encryptedThumbnail.toJson(),
-        if (thumbnail != null) 'thumbnail_info': thumbnail.metadata,
-      },
+      }..addAll(thumbnail?.metadata ?? {}),
       if (extraContent != null) ...extraContent,
     };
     final eventId = await sendEvent(

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -28,7 +28,7 @@ extension SendFileExtension on Room {
     Event? inReplyTo,
     String? editEventId,
     int? shrinkImageMaxDimension,
-    FileInfo? thumbnail,
+    ImageFileInfo? thumbnail,
     Map<String, dynamic>? extraContent,
   }) async {
     FileInfo tempfileInfo = fileInfo;
@@ -311,7 +311,7 @@ extension SendFileExtension on Room {
     return getParticipants().firstWhereOrNull((user) => user.id == mxId);
   }
 
-  Future<FileInfo?> _generateThumbnail(
+  Future<ImageFileInfo?> _generateThumbnail(
     ImageFileInfo originalFile, {
     required String targetPath,
   }) async {
@@ -323,7 +323,13 @@ extension SendFileExtension on Room {
       );
       if (result == null) return null;
       final size = await result.length();
-      return FileInfo(result.name, result.path, size);
+      return ImageFileInfo(
+        result.name,
+        result.path,
+        size,
+        width: originalFile.width,
+        height: originalFile.height,
+      );
     } catch (e) {
       Logs().e('Error while generating thumbnail', e);
       return null;

--- a/lib/presentation/model/file/display_image_info.dart
+++ b/lib/presentation/model/file/display_image_info.dart
@@ -1,0 +1,15 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/widgets.dart';
+
+class DisplayImageInfo with EquatableMixin {
+  final Size size;
+  final bool hasBlur;
+
+  DisplayImageInfo({
+    required this.size,
+    required this.hasBlur,
+  });
+
+  @override
+  List<Object?> get props => [size, hasBlur];
+}

--- a/lib/utils/extension/image_size_extension.dart
+++ b/lib/utils/extension/image_size_extension.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+import 'package:fluffychat/pages/chat/events/message_content_style.dart';
+import 'package:fluffychat/presentation/model/file/display_image_info.dart';
+
+typedef ImageSize = Size;
+
+extension DisplayImageInfoExtension on ImageSize {
+  DisplayImageInfo getDisplayImageInfo(BuildContext context) {
+    Size displayImageSize = Size(
+      MessageContentStyle.imageBubbleWidth(context),
+      MessageContentStyle.imageBubbleHeight(context),
+    );
+    displayImageSize = _getDisplaySizeForImage(
+      width.toDouble(),
+      height.toDouble(),
+      context: context,
+    );
+    bool hasBlur = false;
+    if (displayImageSize.width < MessageContentStyle.imageBubbleMinWidth ||
+        displayImageSize.height < MessageContentStyle.imageBubbleMinHeight) {
+      hasBlur = true;
+    }
+    return DisplayImageInfo(size: displayImageSize, hasBlur: hasBlur);
+  }
+
+  Size _getDisplaySizeForImage(
+    double width,
+    double height, {
+    required BuildContext context,
+  }) {
+    double displayHeight = MessageContentStyle.imageBubbleHeight(context);
+    double displayWidth = MessageContentStyle.imageBubbleWidth(context);
+    if (height == 0 || width == 0) {
+      return Size(displayWidth, displayHeight);
+    }
+    final ratio = width / height;
+
+    if (width < height) {
+      displayHeight = MessageContentStyle.imageBubbleDefaultHeight;
+      displayWidth = displayHeight * ratio;
+    } else {
+      displayWidth = MessageContentStyle.imageBubbleDefaultWidth;
+      displayHeight = displayWidth / ratio;
+    }
+    return Size(displayWidth, displayHeight);
+  }
+}

--- a/lib/utils/extension/image_size_extension.dart
+++ b/lib/utils/extension/image_size_extension.dart
@@ -7,8 +7,8 @@ typedef ImageSize = Size;
 extension DisplayImageInfoExtension on ImageSize {
   DisplayImageInfo getDisplayImageInfo(BuildContext context) {
     Size displayImageSize = Size(
-      MessageContentStyle.imageBubbleWidth(context),
-      MessageContentStyle.imageBubbleHeight(context),
+      MessageContentStyle.imageWidth(context),
+      MessageContentStyle.imageHeight(context),
     );
     displayImageSize = _getDisplaySizeForImage(
       width.toDouble(),
@@ -28,8 +28,8 @@ extension DisplayImageInfoExtension on ImageSize {
     double height, {
     required BuildContext context,
   }) {
-    double displayHeight = MessageContentStyle.imageBubbleHeight(context);
-    double displayWidth = MessageContentStyle.imageBubbleWidth(context);
+    double displayHeight = MessageContentStyle.imageHeight(context);
+    double displayWidth = MessageContentStyle.imageWidth(context);
     if (height == 0 || width == 0) {
       return Size(displayWidth, displayHeight);
     }

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -74,13 +74,10 @@ extension LocalizedBody on Event {
   }
 
   Size? getThumbnailSize() {
-    final thumbnailInfo = infoMap['thumbnail_info'];
-    if (thumbnailInfo is Map &&
-        thumbnailInfo['width'] != null &&
-        thumbnailInfo['height'] != null) {
+    if (infoMap['w'] != null && infoMap['h'] != null) {
       return Size(
-        thumbnailInfo['width'],
-        thumbnailInfo['height'],
+        double.tryParse(infoMap['w'].toString()) ?? 0,
+        double.tryParse(infoMap['h'].toString()) ?? 0,
       );
     }
     return null;

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -73,6 +73,19 @@ extension LocalizedBody on Event {
     return room.sendingFilePlaceholders[txId];
   }
 
+  Size? getThumbnailSize() {
+    final thumbnailInfo = infoMap['thumbnail_info'];
+    if (thumbnailInfo is Map &&
+        thumbnailInfo['width'] != null &&
+        thumbnailInfo['height'] != null) {
+      return Size(
+        thumbnailInfo['width'],
+        thumbnailInfo['height'],
+      );
+    }
+    return null;
+  }
+
   User? getUser() {
     return room
         .getParticipants()

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1526,7 +1526,7 @@ packages:
     description:
       path: "."
       ref: twake-supported
-      resolved-ref: "6768740728e153a7a76948cd19131c5239501800"
+      resolved-ref: "954430a1296311db4b34eadeaf29ecfb4ff330df"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.2"


### PR DESCRIPTION
### Blocker:
https://github.com/linagora/matrix-dart-sdk/pull/14

### Status:
Ready to review
### Solution:
- In mobile, the image resolution can be easily get from `photo_manager` package, using the image resolution, we can determine the display resolution of image in chat. The details of how to determine in `image_size_extension.file`
- In Web, because we pick files from devices, we can't get the resolution of the image at the time we picked the image, we have to decode the image first to determine its size, it is relatively fast in even MB images. The next step is the same with mobile
- In order to store width and height of image in server, set it in `thumbnail_info` field of event

### Demo mobile:

https://github.com/linagora/twake-on-matrix/assets/43041967/e74fde66-8d68-4c14-a928-8276e281a79f




### Demo Web:



https://github.com/linagora/twake-on-matrix/assets/43041967/fe894df5-05c6-4ba9-b920-66a1029a753c







