### PR TITLE
TW-181: avatar not change after update

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:adaptive_dialog/adaptive_dialog.dart';
-import 'package:async/async.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/recovery_words/recovery_words.dart';
@@ -80,21 +79,6 @@ class ChatListController extends State<ChatList>
   bool get displayNavigationBar => false;
 
   String? activeSpaceId;
-
-  late final profileMemoizers = <Client?, AsyncMemoizer<Profile>>{};
-
-  Future<Profile?> fetchOwnProfile({required Client client}) {
-    if (!profileMemoizers.containsKey(client)) {
-      profileMemoizers[client] = AsyncMemoizer();
-    }
-    return profileMemoizers[client]!.runOnce(() async {
-      return await client.fetchOwnProfile();
-    });
-  }
-
-  void updateProfile(Client? client) {
-    profileMemoizers[client] = AsyncMemoizer<Profile>();
-  }
 
   void resetActiveSpaceId() {
     setState(() {

--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -77,7 +77,7 @@ class ChatListViewBody extends StatelessWidget {
                   const SizedBox(height: 16),
                   FutureBuilder<Profile?>(
                     // ignore: unnecessary_cast
-                    future: controller.fetchOwnProfile(client: client),
+                    future: client.fetchOwnProfile(getFromRooms: false),
                     builder: (context, snapshotProfile) {
                       if (snapshotProfile.connectionState !=
                           ConnectionState.done) {

--- a/lib/pages/chat_list/client_chooser_button.dart
+++ b/lib/pages/chat_list/client_chooser_button.dart
@@ -123,7 +123,7 @@ class ClientChooserButton extends StatelessWidget {
     int clientCount = 0;
     matrix.accountBundles.forEach((key, value) => clientCount += value.length);
     return FutureBuilder<Profile?>(
-      future: controller.fetchOwnProfile(client: matrix.client),
+      future: matrix.client.fetchOwnProfile(getFromRooms: false),
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator.adaptive());
@@ -338,7 +338,7 @@ class _ProfileWidgetState extends State<ProfileWidget> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<Profile?>(
-      future: widget.controller.fetchOwnProfile(client: widget.client),
+      future: widget.client.fetchOwnProfile(getFromRooms: false),
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator.adaptive());

--- a/lib/pages/settings/settings.dart
+++ b/lib/pages/settings/settings.dart
@@ -213,7 +213,7 @@ class SettingsController extends State<Settings> with ConnectPageMixin {
     profileFuture ??= client.getProfileFromUserId(
       client.userID!,
       cache: !profileUpdated,
-      getFromRooms: !profileUpdated,
+      getFromRooms: false,
     );
     return SettingsView(this);
   }


### PR DESCRIPTION
### Solution:
When changing avatar, it stores in the server cache inside the client class, but when using avatar in chat list, it uses the avatar cache from room, so now we need only change to using cache from server. Then when back from setting, it will auto update the avatar.

### Demo:

https://github.com/linagora/twake-on-matrix/assets/43041967/7df61f22-e3fd-43e0-a546-0cfda397fe9c



https://github.com/linagora/twake-on-matrix/assets/43041967/c59a9cf7-631b-453f-b864-40cf933f7591




https://github.com/linagora/twake-on-matrix/assets/43041967/6b7b5305-3d9a-4823-a81c-1aa2ff8a72af
