### PR TITLE
Only run pages workflow on web changes

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -1,5 +1,7 @@
 on:
   pull_request:
+    paths:
+      - "web/**"
 
 env:
   FLUTTER_VERSION: 3.10.6


### PR DESCRIPTION
This should limit the deploy pages workflow to only run on changes in `web` folder.