### PR TITLE
fix: Chat room duplicate action menu

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1146,6 +1146,7 @@ class ChatController extends State<Chat>
   }
 
   void onSelectMessage(Event event) {
+    closeSearch();
     if (!event.redacted) {
       if (selectedEvents.contains(event)) {
         setState(

--- a/lib/pages/chat/chat_room_search_mixin.dart
+++ b/lib/pages/chat/chat_room_search_mixin.dart
@@ -33,6 +33,11 @@ mixin ChatRoomSearchMixin {
     initialValue: '',
   );
 
+  void closeSearch() {
+    isSearchingNotifier.value = false;
+    clearSearch();
+  }
+
   void toggleSearch() {
     isSearchingNotifier.value = !isSearchingNotifier.value;
     clearSearch();

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -22,6 +22,8 @@ import 'chat_input_row.dart';
 
 enum _EventContextAction { info, report }
 
+enum _RoomContextAction { search }
+
 class ChatView extends StatelessWidget {
   final ChatController controller;
 
@@ -185,40 +187,8 @@ class ChatView extends StatelessWidget {
                   ),
                 ),
                 actions: [
-                  ValueListenableBuilder(
-                    valueListenable: controller.isSearchingNotifier,
-                    builder: (context, isSearching, child) {
-                      if (isSearching) {
-                        return const SizedBox();
-                      }
-                      return PopupMenuButton(
-                        itemBuilder: (context) => [
-                          PopupMenuItem(
-                            value: 'search',
-                            child: Row(
-                              children: [
-                                const Icon(Icons.search),
-                                const SizedBox(width: 12),
-                                Expanded(
-                                  child: Text(
-                                    L10n.of(context)!.search,
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          )
-                        ],
-                        onSelected: (item) {
-                          switch (item) {
-                            case "search":
-                              return controller.toggleSearch();
-                          }
-                        },
-                      );
-                    },
-                  ),
+                  if (!controller.selectMode)
+                    _SearchMenuItem(controller: controller),
                 ],
                 bottom: PreferredSize(
                   preferredSize: const Size(double.infinity, 4),
@@ -409,14 +379,14 @@ class ChatView extends StatelessWidget {
       );
 
   Widget _buildLeading(BuildContext context) {
+    if (controller.selectMode) {
+      return TwakeIconButton(
+        icon: Icons.close,
+        onTap: controller.clearSelectedEvents,
+        tooltip: L10n.of(context)!.close,
+      );
+    }
     if (controller.responsive.isMobile(context)) {
-      if (controller.selectMode) {
-        return TwakeIconButton(
-          icon: Icons.close,
-          onTap: controller.clearSelectedEvents,
-          tooltip: L10n.of(context)!.close,
-        );
-      }
       return _buildBackButton(context);
     }
     return ValueListenableBuilder(
@@ -426,6 +396,52 @@ class ChatView extends StatelessWidget {
           return _buildBackButton(context);
         }
         return const SizedBox.shrink();
+      },
+    );
+  }
+}
+
+class _SearchMenuItem extends StatelessWidget {
+  const _SearchMenuItem({
+    required this.controller,
+  });
+
+  final ChatController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: controller.isSearchingNotifier,
+      builder: (context, isSearching, child) {
+        if (isSearching) {
+          return const SizedBox();
+        }
+        return PopupMenuButton(
+          itemBuilder: (context) => [
+            PopupMenuItem(
+              value: _RoomContextAction.search,
+              child: Row(
+                children: [
+                  const Icon(Icons.search),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      L10n.of(context)!.search,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ],
+              ),
+            )
+          ],
+          onSelected: (item) {
+            switch (item) {
+              case _RoomContextAction.search:
+                return controller.toggleSearch();
+            }
+          },
+        );
       },
     );
   }


### PR DESCRIPTION
# Description
- Remove duplicate action menu
- Add close select mode button on web
- Close search when select mode active

# Web
## Before

https://github.com/linagora/twake-on-matrix/assets/12546908/86514776-5aaf-428f-8c59-b9135ed48dcb

## After
https://github.com/linagora/twake-on-matrix/assets/12546908/9e20dc4c-4c80-48c6-8cd3-c64864fb779e

# Mobile
## Before

https://github.com/linagora/twake-on-matrix/assets/12546908/f626b425-7cdb-4906-8f4c-5b4e31a0bc1a

## After

https://github.com/linagora/twake-on-matrix/assets/12546908/d1eb0d7c-8428-4642-8ec5-6e8230ba1a90


