### PR TITLE
hot-fix: change folder of dio interceptor cache

### DIFF
--- a/lib/data/network/dio_cache_option.dart
+++ b/lib/data/network/dio_cache_option.dart
@@ -1,8 +1,6 @@
 import 'package:dio_cache_interceptor/dio_cache_interceptor.dart';
 import 'package:dio_cache_interceptor_hive_store/dio_cache_interceptor_hive_store.dart';
-import 'package:flutter/foundation.dart';
 import 'package:matrix/matrix.dart';
-import 'package:path_provider/path_provider.dart';
 
 class DioCacheOption {
   static const String _hiveBoxName = "twake_dio_cache_hive_store";
@@ -20,18 +18,10 @@ class DioCacheOption {
     return _instance;
   }
 
-  Future<String?> _getAppDirPath() async {
-    if (kIsWeb) return null;
-    final appDir = await getApplicationDocumentsDirectory();
-    Logs().d('DioCacheOption::_getAppDirPath() appDirPath ${appDir.path}');
-    return appDir.path;
-  }
-
   Future<void> setUpDioHiveCache() async {
     Logs().d('DioCacheOption::_setUpDioHiveCache() Start setup DioHiveCache');
-    final appDirPath = await _getAppDirPath();
     _hiveCacheStore = HiveCacheStore(
-      appDirPath,
+      null,
       hiveBoxName: _hiveBoxName,
     );
     Logs().d('DioCacheOption::_setUpDioHiveCache() DioHiveCache Ready');

--- a/lib/di/global/get_it_initializer.dart
+++ b/lib/di/global/get_it_initializer.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/data/datasource_impl/media/media_data_source_impl.dar
 import 'package:fluffychat/data/datasource_impl/recovery_words_data_source_impl.dart';
 import 'package:fluffychat/data/datasource_impl/tom_configurations_datasource_impl.dart';
 import 'package:fluffychat/data/network/contact/tom_contact_api.dart';
+import 'package:fluffychat/data/network/dio_cache_option.dart';
 import 'package:fluffychat/data/network/media/media_api.dart';
 import 'package:fluffychat/data/network/recovery_words/recovery_words_api.dart';
 import 'package:fluffychat/data/repository/contact/tom_contact_repository_impl.dart';
@@ -65,6 +66,7 @@ class GetItInitializer {
   }
 
   void bindingGlobal() {
+    setupDioCache();
     NetworkDI().bind();
     HiveDI().bind();
     NetworkConnectivityDI().bind();
@@ -73,6 +75,10 @@ class GetItInitializer {
 
   void bindingQueue() {
     getIt.registerFactory<Queue>(() => Queue());
+  }
+
+  void setupDioCache() {
+    DioCacheOption.instance.setUpDioHiveCache();
   }
 
   void bindingAPI() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/setting_keys.dart';
-import 'package:fluffychat/data/network/dio_cache_option.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/utils/client_manager.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -29,8 +28,6 @@ void main() async {
   final firstClient = clients.firstOrNull;
   await firstClient?.roomsLoading;
   await firstClient?.accountDataLoading;
-
-  await DioCacheOption.instance.setUpDioHiveCache();
 
   GetItInitializer().setUp();
 


### PR DESCRIPTION
### Problem:
- The hive database is initialized 2 times, first inside `setUpDioHiveCache` method, then later initialized inside FlutterHiveCollectionsDatabase class. So, the Hive will not be initialized the second time, making some boxes not created.
- Boxes are not created is the second initialization will not be closed.
### Resolved: 
- We just need to initialize the Hive database at different folder, and the problem will be resolved. So i changed the path of dio hive cache

### Demo:

https://github.com/linagora/twake-on-matrix/assets/43041967/afa927f9-41d3-4cc1-89dd-9e901c161fe9
