### PR TITLE
fix: search menu item overflow

### DIFF
--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -198,7 +198,13 @@ class ChatView extends StatelessWidget {
                               children: [
                                 const Icon(Icons.search),
                                 const SizedBox(width: 12),
-                                Text(L10n.of(context)!.search),
+                                Expanded(
+                                  child: Text(
+                                    L10n.of(context)!.search,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
                               ],
                             ),
                           )


### PR DESCRIPTION
Old : 

<img width="960" alt="image" src="https://github.com/linagora/twake-on-matrix/assets/48354990/2add1971-e2cc-45ad-a471-9beddf6471b1">


New : 

<img width="960" alt="image" src="https://github.com/linagora/twake-on-matrix/assets/48354990/31945b05-2a7f-4477-af99-7dda402e4995">
