### PR TITLE
TW-740: remove change avatar event when user first set his avatar

### DIFF
--- a/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
@@ -87,7 +87,6 @@ extension IsStateExtension on Event {
   bool isSomeoneChangeAvatar() {
     return stateKey != null &&
         prevContent?["membership"] == 'join' &&
-        prevContent?['avatar_url'] != null &&
         prevContent?['avatar_url'] != content['avatar_url'];
   }
 


### PR DESCRIPTION
### Problem:
Because user can delete their avatar, but the condition `isSomeoneChangeAvatar` check previous avatar != null, so it still show the event.

### Resolve:
Update condition for `isSomeoneChangeAvatar`

### Demo:

https://github.com/linagora/twake-on-matrix/assets/43041967/13e44b25-4309-4484-914b-626b869ee728

