### PR TITLE
hot-fix/remove black background when swipe video

### DIFF
--- a/lib/pages/chat/events/message_content_style.dart
+++ b/lib/pages/chat/events/message_content_style.dart
@@ -66,7 +66,5 @@ class MessageContentStyle {
   static const BorderRadiusGeometry borderRadiusBubble =
       BorderRadius.all(Radius.circular(12.0));
 
-  static const backgroundColorVideo = Colors.black;
-
   static const backIconColor = Colors.white;
 }

--- a/lib/presentation/mixins/play_video_action_mixin.dart
+++ b/lib/presentation/mixins/play_video_action_mixin.dart
@@ -16,7 +16,10 @@ mixin PlayVideoActionMixin {
         builder: (context) {
           return InteractiveViewerGallery(
             itemBuilder: PlatformInfos.isMobile
-                ? VideoViewerMobileTheme(path: uriOrFilePath)
+                ? VideoViewerMobileTheme(
+                    path: uriOrFilePath,
+                    eventId: eventId,
+                  )
                 : VideoViewerDesktopTheme(path: uriOrFilePath),
           );
         },

--- a/lib/widgets/video_player.dart
+++ b/lib/widgets/video_player.dart
@@ -1,4 +1,3 @@
-import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
@@ -17,7 +16,6 @@ class VideoPlayer extends StatefulWidget {
 
 class _VideoPlayerState extends State<VideoPlayer> {
   final VideoController videoController = VideoController(Player());
-  bool isFullScreen = false;
 
   @override
   void initState() {
@@ -33,15 +31,11 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: const BoxDecoration(
-        color: MessageContentStyle.backgroundColorVideo,
-      ),
-      child: Video(
-        pauseUponEnteringBackgroundMode: true,
-        resumeUponEnteringForegroundMode: true,
-        controller: videoController,
-      ),
+    return Video(
+      fill: Colors.transparent,
+      pauseUponEnteringBackgroundMode: true,
+      resumeUponEnteringForegroundMode: true,
+      controller: videoController,
     );
   }
 }


### PR DESCRIPTION
### Problem:
- missing eventId in when passing to mobile video player
- when swipe video in mobile it have black background

### Demo mobile:

https://github.com/linagora/twake-on-matrix/assets/43041967/206fab32-48d8-4463-95b7-c41f01f53ab1

### Demo web (no change):

https://github.com/linagora/twake-on-matrix/assets/43041967/a32c2c85-fef9-461b-863e-0e33db342030

