### PR TITLE
TW-725: Fix auto hide keyboard when scrolling and send msg

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -261,7 +261,6 @@ class ChatController extends State<Chat>
     if (!mounted) {
       return;
     }
-    hideKeyboardChatScreen();
     hideSearchKeyboardIfNeeded();
     setReadMarker();
     if (!scrollController.hasClients) return;

--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/pages/chat/group_chat_empty_view.dart';
 import 'package:fluffychat/pages/chat_draft/draft_chat_empty_view.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -59,7 +60,9 @@ class ChatEventList extends StatelessWidget {
       ),
       reverse: true,
       controller: controller.scrollController,
-      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      keyboardDismissBehavior: PlatformInfos.isMobile
+          ? ScrollViewKeyboardDismissBehavior.manual
+          : ScrollViewKeyboardDismissBehavior.onDrag,
       childrenDelegate: SliverChildBuilderDelegate(
         (BuildContext context, int index) {
           // Footer to display typing indicator and read receipts:

--- a/lib/pages/new_private_chat/new_private_chat_view.dart
+++ b/lib/pages/new_private_chat/new_private_chat_view.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/pages/new_private_chat/new_private_chat.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/expansion_list.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/app_bars/searchable_app_bar.dart';
 import 'package:fluffychat/widgets/app_bars/searchable_app_bar_style.dart';
 import 'package:flutter/material.dart';
@@ -24,7 +25,9 @@ class NewPrivateChatView extends StatelessWidget {
         ),
       ),
       body: SingleChildScrollView(
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+        keyboardDismissBehavior: PlatformInfos.isMobile
+            ? ScrollViewKeyboardDismissBehavior.manual
+            : ScrollViewKeyboardDismissBehavior.onDrag,
         padding: const EdgeInsets.only(left: 8.0, right: 10.0),
         controller: controller.scrollController,
         child: controller.contactsNotifier == null


### PR DESCRIPTION
### Issue:
- #725 

### Resolved:

```
enum ScrollViewKeyboardDismissBehavior {
  /// `manual` means there is no automatic dismissal of the on-screen keyboard.
  /// It is up to the client to dismiss the keyboard.
  manual,
  /// `onDrag` means that the [ScrollView] will dismiss an on-screen keyboard
  /// when a drag begins.
  onDrag,
}

```

```
  if (keyboardDismissBehavior == ScrollViewKeyboardDismissBehavior.onDrag) {
       return NotificationListener<ScrollUpdateNotification>(
         child: scrollableResult,
         onNotification: (ScrollUpdateNotification notification) {
           final FocusScopeNode focusScope = FocusScope.of(context);
           if (notification.dragDetails != null && focusScope.hasFocus) {
             focusScope.unfocus();
           }
           return false;
         },
       );
     } else {
       return scrollableResult;
     }
```


If on mobile use `ScrollViewKeyboardDismissBehavior.onDrag,` it will be unfocused and cause blinking. Should only support platforms other than mobile.

https://github.com/linagora/twake-on-matrix/assets/99852347/7e826484-d46a-418f-a39d-620c39947327
