### PR TITLE
TW-795: fixed link styles and center

### DIFF
--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -236,9 +236,6 @@ class MessageContent extends StatelessWidget with PlayVideoActionMixin {
               );
             }
 
-            final bigEmotes = event.onlyEmotes &&
-                event.numberEmotes > 0 &&
-                event.numberEmotes <= 10;
             return FutureBuilder<String>(
               future: event.calcLocalizedBody(
                 MatrixLocals(L10n.of(context)!),
@@ -263,11 +260,10 @@ class MessageContent extends StatelessWidget with PlayVideoActionMixin {
                           Theme.of(context).textTheme.bodyLarge?.copyWith(
                                 color: Theme.of(context).colorScheme.onSurface,
                               ),
-                      linkStyle: TextStyle(
-                        color: Theme.of(context).colorScheme.secondary,
-                        fontSize: bigEmotes ? fontSize * 3 : fontSize,
-                        decorationColor: textColor.withAlpha(150),
-                      ),
+                      linkStyle:
+                          Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                color: Theme.of(context).colorScheme.secondary,
+                              ),
                       childWidget: Visibility(
                         visible: false,
                         maintainSize: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1575,8 +1575,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "feat/add-text-span-builder"
-      resolved-ref: f159e4de7db4a70fa1830cf7c4a066979aa1464d
+      ref: twake-supported
+      resolved-ref: "326f4ef15303bbbd13971912fd84e936b60e521d"
       url: "https://github.com/linagora/matrix_link_text.git"
     source: git
     version: "2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,7 @@ dependencies:
   keyboard_shortcuts: ^0.1.4
   latlong2: ^0.8.1
   matrix:
-    git: 
+    git:
       url: git@github.com:linagora/matrix-dart-sdk.git
       ref: twake-supported-0.22.4
   matrix_homeserver_recommendations: ^0.3.0
@@ -269,12 +269,13 @@ dependency_overrides:
       url: https://github.com/chandrabezzo/wakelock.git
       ref: main
       path: wakelock_windows/
-  # TODO: Remove it after this PR merged
+  # TODO: Remove this part after upstream contribution is merged
   # https://github.com/Sorunome/matrix_link_text/pull/4
+  # https://github.com/Sorunome/matrix_link_text/pull/5
   matrix_link_text:
-    git: 
+    git:
       url: https://github.com/linagora/matrix_link_text.git
-      ref: feat/add-text-span-builder
+      ref: twake-supported
 
 cider:
   link_template:


### PR DESCRIPTION
Links in web do now display as in mobile version (no more inkwell)

related to https://github.com/linagora/matrix_link_text/pull/1

![image](https://github.com/linagora/twake-on-matrix/assets/48354990/e1b1fd64-5ba8-4c17-98f5-916d28f9d305)

https://github.com/linagora/twake-on-matrix/assets/48354990/b5704d7d-f610-4cb8-8334-bec5d6ce85af


