### PR TITLE
TW-825: Update context menu actions for chat list in web

### DIFF
--- a/lib/presentation/enum/chat_list/chat_list_enum.dart
+++ b/lib/presentation/enum/chat_list/chat_list_enum.dart
@@ -101,7 +101,11 @@ enum ChatListSelectionActions {
           return L10n.of(context)!.unmuteThisMessage;
         }
       case ChatListSelectionActions.pin:
-        return L10n.of(context)!.pinThisMessage;
+        if (room.isFavourite) {
+          return L10n.of(context)!.unpinThisMessage;
+        } else {
+          return L10n.of(context)!.pinThisMessage;
+        }
       case ChatListSelectionActions.more:
         return L10n.of(context)!.more;
     }


### PR DESCRIPTION
### Issue:
- #825 
- Hide actions (Pin/unpin and read/unread) for conversation is invited. Because if you can try to use actions (Pin/unpin and read/unread) homeserver will reject actions and maybe wrongly logic and behaviour 
### Resolved:

https://github.com/linagora/twake-on-matrix/assets/99852347/51b5c373-de8d-48d5-88b8-79676e6a1909

