### PR TITLE
TW-796: Can't jump to other room during play video

### DIFF
--- a/lib/pages/chat_list/chat_list_item_subtitle.dart
+++ b/lib/pages/chat_list/chat_list_item_subtitle.dart
@@ -31,14 +31,7 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
       children: <Widget>[
         Expanded(
           child: typingText.isNotEmpty
-              ? Column(
-                  children: [
-                    Expanded(
-                      child: typingTextWidget(typingText, context),
-                    ),
-                    const Spacer(),
-                  ],
-                )
+              ? typingTextWidget(typingText, context)
               : (isGroup
                   ? chatListItemSubtitleForGroup(
                       room: room,

--- a/lib/presentation/mixins/chat_list_item_mixin.dart
+++ b/lib/presentation/mixins/chat_list_item_mixin.dart
@@ -57,7 +57,7 @@ mixin ChatListItemMixin {
                     color: Theme.of(context).colorScheme.primary,
                   ),
                 ),
-            maxLines: 1,
+            maxLines: 2,
             softWrap: true,
           ),
         ),

--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -343,6 +343,7 @@ class BackgroundPush {
 
   Future<void> goToRoom(String? roomId) async {
     try {
+      _clearAllNavigatorAvailable();
       Logs().v('[Push] Attempting to go to room $roomId...');
       if (_matrixState == null || roomId == null) {
         return;
@@ -580,5 +581,9 @@ class BackgroundPush {
     await setupPusher(
       oldTokens: {_pushToken},
     );
+  }
+
+  void _clearAllNavigatorAvailable() {
+    TwakeApp.router.routerDelegate.pop();
   }
 }


### PR DESCRIPTION
### issue:
- #796 
- Reason

<img width="459" alt="Screenshot 2023-10-17 at 01 12 17" src="https://github.com/linagora/twake-on-matrix/assets/99852347/c423c4bc-cf89-4da8-a666-4c74ad1d9973">



```
1. When we click on a message to play the video we create a new `HeroPageRoute` different from `GoRoter`.
2. When we receive a new notification while playing a video and click on the notification.
3. Can't close `HeroPageRoute`.
```

### Resolved:
- Close all other routes, dialog, and bottom sheet before going to new Route of `GoRouter`.


https://github.com/linagora/twake-on-matrix/assets/99852347/ebe2bb8f-ac8c-4604-ab1b-0e375a454116
