### PR TITLE
TW-818: prevent inlineSpanEnd from getting main span styles

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -934,7 +934,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "6b39a253156120a4b5e341003a6cd277d95b0042"
+      resolved-ref: "eb0ac6c32cc3bdf33810c2f1440aa2e2e28418ee"
       url: "https://github.com/linagora/flutter_matrix_html.git"
     source: git
     version: "1.2.0"


### PR DESCRIPTION
Test PR to see my change https://github.com/linagora/flutter_matrix_html/pull/8
old : 
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/5869ea46-2414-49ae-b069-73d2196f034d)
new:
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/54453283-0279-4796-aeba-41af3293fe7c)
