### PR TITLE
hotfix: Chat room cannot load more

### DIFF
--- a/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold.dart
+++ b/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold.dart
@@ -67,19 +67,15 @@ class ChatAdaptiveScaffoldController extends State<ChatAdaptiveScaffold> {
                   end: breakpoint,
                 ): SlotLayout.from(
                   key: AppAdaptiveScaffold.breakpointMobileKey,
-                  builder: (_) => Navigator(
-                    pages: [
-                      MaterialPage(
-                        child: body!,
-                      ),
+                  builder: (_) => Stack(
+                    children: [
+                      body!,
                       if (showRightPanel)
-                        MaterialPage(
-                          child: ChatSearch(
-                            roomId: widget.roomId,
-                            onBack: toggleRightPanel,
-                            jumpToEventId: jumpToEventId,
-                            isInStack: true,
-                          ),
+                        ChatSearch(
+                          roomId: widget.roomId,
+                          onBack: toggleRightPanel,
+                          jumpToEventId: jumpToEventId,
+                          isInStack: true,
                         ),
                     ],
                   ),


### PR DESCRIPTION
# Root cause
- GoRouter cannot get right context when inside Nested Navigator

# Before

https://github.com/linagora/twake-on-matrix/assets/12546908/b1ab86b2-2285-4f1e-a22f-2796cad442d7

# After

https://github.com/linagora/twake-on-matrix/assets/12546908/b8ecb7c7-6f75-424d-8388-d4a97cae9c87

