### PR TITLE
Fixed macOS packaging

### DIFF
--- a/scripts/package-macos-debug.sh
+++ b/scripts/package-macos-debug.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Install setuptools so appdmg can be installed
+python3 -m pip install setuptools
+
 # Install appdmg for packaging
 echo "Installing appdmg."
 npm install -g appdmg

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Install setuptools so appdmg can be installed
+python3 -m pip install setuptools
+
 # Install appdmg for packaging
 echo "Installing appdmg."
 npm install -g appdmg


### PR DESCRIPTION
Python 3.12 removed `distutils`, so we have to reinstall it through `setuptools`