### PR TITLE
Hotfix cant use context menu in chat list

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1496,7 +1496,7 @@ class ChatController extends State<Chat>
     return listAction.map((action) {
       return PopupMenuItem(
         padding: EdgeInsets.zero,
-        child: popupItem(
+        child: popupItemByTwakeAppRouter(
           context,
           action.getTitle(
             context,

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -546,7 +546,7 @@ class ChatListController extends State<ChatList>
     return listAction.map((action) {
       return PopupMenuItem(
         padding: EdgeInsets.zero,
-        child: popupItem(
+        child: popupItemByNavigator(
           context,
           action.getTitleContextMenuSelection(context, room),
           iconAction: action.getIconContextMenuSelection(room),

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
@@ -252,7 +252,7 @@ class SettingsProfileController extends State<SettingsProfile>
     return listAction.map((action) {
       return PopupMenuItem(
         padding: EdgeInsets.zero,
-        child: popupItem(
+        child: popupItemByTwakeAppRouter(
           context,
           action.getTitle(context),
           iconAction: action.getIcon(),

--- a/lib/widgets/mixins/popup_menu_widget_mixin.dart
+++ b/lib/widgets/mixins/popup_menu_widget_mixin.dart
@@ -5,7 +5,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
 
 mixin PopupMenuWidgetMixin {
-  Widget popupItem(
+  Widget popupItemByTwakeAppRouter(
     BuildContext context,
     String nameAction, {
     IconData? iconAction,
@@ -26,36 +26,90 @@ mixin PopupMenuWidgetMixin {
         }
         onCallbackAction!.call();
       },
-      child: Padding(
-        padding: padding ?? const EdgeInsetsDirectional.all(12),
-        child: SizedBox(
-          child: Row(
-            children: [
-              if (iconAction != null)
-                Icon(
-                  iconAction,
-                  size: iconSize ?? 20,
-                  color: colorIcon ?? Colors.black,
-                ),
-              if (imagePath != null)
-                SvgPicture.asset(
-                  imagePath,
-                  width: iconSize ?? 20,
-                  height: iconSize ?? 20,
-                  fit: BoxFit.fill,
-                ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  nameAction,
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyLarge!
-                      .copyWith(color: LinagoraSysColors.material().onSurface),
-                ),
+      child: _popupItemBuilder(
+        context,
+        nameAction,
+        iconAction: iconAction,
+        imagePath: imagePath,
+        colorIcon: colorIcon,
+        iconSize: iconSize,
+        styleName: styleName,
+        padding: padding,
+      ),
+    );
+  }
+
+  Widget popupItemByNavigator(
+    BuildContext context,
+    String nameAction, {
+    IconData? iconAction,
+    String? imagePath,
+    Color? colorIcon,
+    double? iconSize,
+    TextStyle? styleName,
+    EdgeInsets? padding,
+    OnTapIconButtonCallbackAction? onCallbackAction,
+    bool isClearCurrentPage = true,
+  }) {
+    return InkWell(
+      onTap: () {
+        if (isClearCurrentPage) {
+          Navigator.pop(context);
+        }
+        onCallbackAction!.call();
+      },
+      child: _popupItemBuilder(
+        context,
+        nameAction,
+        iconAction: iconAction,
+        imagePath: imagePath,
+        colorIcon: colorIcon,
+        iconSize: iconSize,
+        styleName: styleName,
+        padding: padding,
+      ),
+    );
+  }
+
+  Widget _popupItemBuilder(
+    BuildContext context,
+    String nameAction, {
+    IconData? iconAction,
+    String? imagePath,
+    Color? colorIcon,
+    double? iconSize,
+    TextStyle? styleName,
+    EdgeInsets? padding,
+  }) {
+    return Padding(
+      padding: padding ?? const EdgeInsetsDirectional.all(12),
+      child: SizedBox(
+        child: Row(
+          children: [
+            if (iconAction != null)
+              Icon(
+                iconAction,
+                size: iconSize ?? 20,
+                color: colorIcon ?? Colors.black,
               ),
-            ],
-          ),
+            if (imagePath != null)
+              SvgPicture.asset(
+                imagePath,
+                width: iconSize ?? 20,
+                height: iconSize ?? 20,
+                fit: BoxFit.fill,
+              ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                nameAction,
+                style: styleName ??
+                    Theme.of(context).textTheme.bodyLarge!.copyWith(
+                          color: LinagoraSysColors.material().onSurface,
+                        ),
+              ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
### Issue:

https://github.com/linagora/twake-on-matrix/assets/99852347/1832461e-fddd-45d8-8ac1-06b0c257744f

- Click on any action → nothing happen
- Try to click many times, if it is ok → action can not be close

### Root case:
- In chat list screen use `context` of `Navigator`.
- When context item is opening and click on  context item, We will use the `context` of that screen to trigger closing the context menu. However, in chat list screen that trigger is using the context of `Gouter`. So the two contexts here are wrong.

### Resolved:

- Create popup items specific to different routes

https://github.com/linagora/twake-on-matrix/assets/99852347/38d3516f-ffb4-4464-a8ad-2db213c5cdc2

