### PR TITLE
Hotfix: Can't pin a message in appbar action

### DIFF
--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -50,8 +50,11 @@ class ChatView extends StatelessWidget with MessageContentMixin {
             TwakeIconButton(
               icon: Icons.push_pin_outlined,
               tooltip: L10n.of(context)!.pinMessage,
-              onTap: () => controller
-                  .actionWithClearSelections(controller.pinEventAction),
+              onTap: () => controller.actionWithClearSelections(
+                () => controller.pinEventAction(
+                  controller.selectedEvents.single,
+                ),
+              ),
             ),
           if (controller.selectedEvents.length == 1)
             PopupMenuButton<_EventContextAction>(


### PR DESCRIPTION
### Issue: 

- Selected a message => click on pin message action in appbar action => No happened.

https://github.com/linagora/twake-on-matrix/assets/99852347/a408f19b-464a-44bf-83e1-90c51699aebc

### Resolved

https://github.com/linagora/twake-on-matrix/assets/99852347/0dad4b97-1b71-4a7c-8f3d-7d6ce42646d1


https://github.com/linagora/twake-on-matrix/assets/99852347/59f3d369-6327-45e5-81a3-9432406ca5f4

