### PR TITLE
TW-977: quote indicator expand

### DIFF
--- a/lib/pages/chat/events/reply_content.dart
+++ b/lib/pages/chat/events/reply_content.dart
@@ -68,44 +68,57 @@ class ReplyContent extends StatelessWidget {
       padding: ReplyContentStyle.replyParentContainerPadding,
       decoration:
           ReplyContentStyle.replyParentContainerDecoration(context, ownMessage),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          Container(
-            width: ReplyContentStyle.prefixBarWidth,
-            height: ReplyContentStyle.fontSizeDisplayContent * 2,
-            decoration: ReplyContentStyle.prefixBarDecoration(context),
-          ),
-          const SizedBox(width: ReplyContentStyle.prefixAndDisplayNameSpacing),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                if (user != null)
-                  Text(
-                    user.calcDisplayname(),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: ReplyContentStyle.displayNameTextStyle(context),
-                  ),
-                if (displayEvent.getUser() == null)
-                  FutureBuilder<User?>(
-                    future: displayEvent.fetchSenderUser(),
-                    builder: (context, snapshot) {
-                      return Text(
-                        '${snapshot.data?.calcDisplayname() ?? displayEvent.senderFromMemoryOrFallback.calcDisplayname()}:',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: ReplyContentStyle.displayNameTextStyle(context),
-                      );
-                    },
-                  ),
-                replyBody,
-              ],
+      child: IntrinsicHeight(
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                vertical: ReplyContentStyle.prefixBarVerticalPadding,
+              ),
+              child: Container(
+                constraints: const BoxConstraints(
+                  minHeight: ReplyContentStyle.fontSizeDisplayContent * 2,
+                ),
+                width: ReplyContentStyle.prefixBarWidth,
+                decoration: ReplyContentStyle.prefixBarDecoration(context),
+              ),
             ),
-          ),
-        ],
+            const SizedBox(
+              width: ReplyContentStyle.prefixAndDisplayNameSpacing,
+            ),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  if (user != null)
+                    Text(
+                      user.calcDisplayname(),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: ReplyContentStyle.displayNameTextStyle(context),
+                    ),
+                  if (displayEvent.getUser() == null)
+                    FutureBuilder<User?>(
+                      future: displayEvent.fetchSenderUser(),
+                      builder: (context, snapshot) {
+                        return Text(
+                          '${snapshot.data?.calcDisplayname() ?? displayEvent.senderFromMemoryOrFallback.calcDisplayname()}:',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style:
+                              ReplyContentStyle.displayNameTextStyle(context),
+                        );
+                      },
+                    ),
+                  replyBody,
+                ],
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/chat/events/reply_content_style.dart
+++ b/lib/pages/chat/events/reply_content_style.dart
@@ -26,6 +26,7 @@ class ReplyContentStyle {
   }
 
   static const double prefixBarWidth = 3.0;
+  static const double prefixBarVerticalPadding = 4.0;
   static BoxDecoration prefixBarDecoration(BuildContext context) {
     return BoxDecoration(
       borderRadius: BorderRadius.circular(2),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -942,7 +942,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: eb0ac6c32cc3bdf33810c2f1440aa2e2e28418ee
+      resolved-ref: 608fb381790d068664f73e33c3277671e5e172ca
       url: "https://github.com/linagora/flutter_matrix_html.git"
     source: git
     version: "1.2.0"


### PR DESCRIPTION
html list in reply shows only one item now
https://github.com/linagora/flutter_matrix_html/pull/10

#977 

![image](https://github.com/linagora/twake-on-matrix/assets/48354990/1be1dc15-210e-4987-9df6-80bf5887f767)
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/4f7fd0f1-82cb-4a6b-8d00-e1af3e4af947)


# hotfix: preview reply html list
old : 
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/19d4b88a-b897-4048-9e89-9d7f2aaa2a5c)

new: 
![image](https://github.com/linagora/twake-on-matrix/assets/48354990/62136b8c-9631-4f74-a430-b312c0c4cbf3)
