### PR TITLE
hot-fix: remove try load when load image failed

### DIFF
--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -200,8 +200,6 @@ class _MxcImageState extends State<MxcImage>
       });
     } catch (_) {
       if (!mounted) return;
-      await Future.delayed(widget.retryDuration);
-      _tryLoad(_);
     }
   }
 


### PR DESCRIPTION
### Problem:
- mxcImage is failed to load in some cases, but it try to reload forever
### Resolved:
- now it only try to reload only 1 times


### Demo web:
https://github.com/linagora/twake-on-matrix/assets/43041967/b039b37a-268c-477a-adc1-d47db10a7feb