### PR TITLE
TW-991: creating DM with no encryption by default, hiding create chat on web

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -2606,8 +2606,6 @@
   "@inactive": {},
   "newGroupChat": "New Group Chat",
   "@newGroupChat": {},
-  "getHelp": "Get help",
-  "@getHelp": {},
   "twakeUsers": "Twake users",
   "@twakeUsers": {},
   "expand": "Expand",

--- a/assets/l10n/intl_fr.arb
+++ b/assets/l10n/intl_fr.arb
@@ -2683,8 +2683,6 @@
   },
   "invite": "Inviter",
   "@invite": {},
-  "getHelp": "Obtenir de l'aide",
-  "@getHelp": {},
   "errorPageTitle": "Il y a un problème",
   "@errorPageTitle": {},
   "forwardTo": "Transmettre à...",

--- a/assets/l10n/intl_ru.arb
+++ b/assets/l10n/intl_ru.arb
@@ -2566,8 +2566,6 @@
   "@inactive": {},
   "newGroupChat": "Новый групповой чат",
   "@newGroupChat": {},
-  "getHelp": "Помощь",
-  "@getHelp": {},
   "expand": "Развернуть",
   "@expand": {},
   "shrink": "Свернуть",

--- a/assets/l10n/intl_vi.arb
+++ b/assets/l10n/intl_vi.arb
@@ -2733,8 +2733,6 @@
     "type": "text",
     "placeholders": {}
   },
-  "getHelp": "Trợ giúp",
-  "@getHelp": {},
   "pleaseChooseAUsername": "Vui lòng chọn tên đăng nhập",
   "@pleaseChooseAUsername": {
     "type": "text",

--- a/lib/pages/chat_draft/draft_chat.dart
+++ b/lib/pages/chat_draft/draft_chat.dart
@@ -155,7 +155,7 @@ class DraftChatController extends State<DraftChat>
         .execute(
       contactMxId: presentationContact!.matrixId!,
       client: Matrix.of(context).client,
-      enableEncryption: true,
+      enableEncryption: false,
     )
         .listen((event) {
       event.fold((failure) {

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/pages/chat_list/chat_list_view.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_security/settings_security.dart';
 import 'package:fluffychat/presentation/enum/chat_list/chat_list_enum.dart';
 import 'package:fluffychat/presentation/extensions/client_extension.dart';
+import 'package:fluffychat/presentation/mixins/go_to_group_chat_mixin.dart';
 import 'package:fluffychat/presentation/model/chat_list/chat_selection_actions.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
@@ -62,7 +63,8 @@ class ChatListController extends State<ChatList>
         RouteAware,
         ComparablePresentationContactMixin,
         PopupContextMenuActionMixin,
-        PopupMenuWidgetMixin {
+        PopupMenuWidgetMixin,
+        GoToGroupChatMixin {
   final _getRecoveryWordsInteractor = getIt.get<GetRecoveryWordsInteractor>();
 
   final responsive = getIt.get<ResponsiveUtils>();
@@ -703,14 +705,6 @@ class ChatListController extends State<ChatList>
   void goToNewPrivateChat() {
     if (FirstColumnInnerRoutes.instance.goRouteAvailableInFirstColumn()) {
       context.go('/rooms/newprivatechat');
-    } else {
-      context.pushInner('innernavigator/newprivatechat');
-    }
-  }
-
-  void goToNewGroupChat() {
-    if (FirstColumnInnerRoutes.instance.goRouteAvailableInFirstColumn()) {
-      context.go('/rooms/newprivatechat/newgroup');
     } else {
       context.pushInner('innernavigator/newprivatechat');
     }

--- a/lib/pages/chat_list/chat_list_view.dart
+++ b/lib/pages/chat_list/chat_list_view.dart
@@ -89,7 +89,7 @@ class ChatListView extends StatelessWidget {
                       ),
                       MenuItemButton(
                         leadingIcon: const Icon(Icons.group),
-                        onPressed: () => controller.goToNewGroupChat(),
+                        onPressed: () => controller.goToNewGroupChat(context),
                         child: Text(L10n.of(context)!.newChat),
                       ),
                     ],

--- a/lib/pages/new_private_chat/new_private_chat.dart
+++ b/lib/pages/new_private_chat/new_private_chat.dart
@@ -1,12 +1,11 @@
-import 'package:fluffychat/config/first_column_inner_routes.dart';
 import 'package:fluffychat/presentation/mixins/comparable_presentation_contact_mixin.dart';
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
+import 'package:fluffychat/presentation/mixins/go_to_group_chat_mixin.dart';
 import 'package:fluffychat/presentation/mixins/invite_external_contact_mixin.dart';
 import 'package:fluffychat/pages/new_private_chat/new_private_chat_view.dart';
 import 'package:fluffychat/presentation/mixins/go_to_direct_chat_mixin.dart';
 import 'package:fluffychat/presentation/model/presentation_contact.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
-import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -23,7 +22,8 @@ class NewPrivateChatController extends State<NewPrivateChat>
         ComparablePresentationContactMixin,
         ContactsViewControllerMixin,
         GoToDraftChatMixin,
-        InviteExternalContactMixin {
+        InviteExternalContactMixin,
+        GoToGroupChatMixin {
   final isShowContactsNotifier = ValueNotifier(true);
   final scrollController = ScrollController();
 
@@ -39,14 +39,6 @@ class NewPrivateChatController extends State<NewPrivateChat>
 
   void toggleContactsList() {
     isShowContactsNotifier.value = !isShowContactsNotifier.value;
-  }
-
-  void goToNewGroupChat() {
-    if (!FirstColumnInnerRoutes.instance.goRouteAvailableInFirstColumn()) {
-      context.pushInner('innernavigator/newgroup');
-    } else {
-      context.push('/rooms/newprivatechat/newgroup');
-    }
   }
 
   void onContactAction(

--- a/lib/pages/new_private_chat/new_private_chat_view.dart
+++ b/lib/pages/new_private_chat/new_private_chat_view.dart
@@ -33,7 +33,7 @@ class NewPrivateChatView extends StatelessWidget {
         controller: controller.scrollController,
         child: ExpansionList(
           presentationContactsNotifier: controller.presentationContactNotifier,
-          goToNewGroupChat: controller.goToNewGroupChat,
+          goToNewGroupChat: () => controller.goToNewGroupChat(context),
           isShowContactsNotifier: controller.isShowContactsNotifier,
           onContactTap: controller.onContactAction,
           onExternalContactTap: controller.onExternalContactAction,

--- a/lib/pages/new_private_chat/widget/expansion_list.dart
+++ b/lib/pages/new_private_chat/widget/expansion_list.dart
@@ -1,11 +1,13 @@
 import 'package:dartz/dartz.dart';
 import 'package:fluffychat/app_state/failure.dart';
 import 'package:fluffychat/app_state/success.dart';
+import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/loading_contact_widget.dart';
 import 'package:fluffychat/presentation/enum/contacts/warning_contacts_banner_enum.dart';
 import 'package:fluffychat/presentation/model/presentation_contact.dart';
 import 'package:fluffychat/presentation/model/presentation_contact_success.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/contacts_warning_banner/contacts_warning_banner_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -55,11 +57,8 @@ class ExpansionList extends StatelessWidget {
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _NewGroupButton(
-                    onPressed: goToNewGroupChat,
-                  ),
+                  ..._buildResponsiveButtons(context),
                   const LoadingContactWidget(),
-                  _GetHelpButton(),
                 ],
               );
             }
@@ -68,9 +67,7 @@ class ExpansionList extends StatelessWidget {
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _NewGroupButton(
-                    onPressed: goToNewGroupChat,
-                  ),
+                  ..._buildResponsiveButtons(context),
                   InkWell(
                     onTap: () {
                       onContactTap(
@@ -84,7 +81,6 @@ class ExpansionList extends StatelessWidget {
                       highlightKeyword: textEditingController.text,
                     ),
                   ),
-                  _GetHelpButton(),
                 ],
               );
             }
@@ -103,10 +99,7 @@ class ExpansionList extends StatelessWidget {
                       keyword: textEditingController.text,
                     ),
                     _MoreListTile(),
-                    _NewGroupButton(
-                      onPressed: goToNewGroupChat,
-                    ),
-                    _GetHelpButton(),
+                    ..._buildResponsiveButtons(context),
                   ],
                 );
               }
@@ -154,18 +147,12 @@ class ExpansionList extends StatelessWidget {
                       height: 12,
                     ),
                     _contactsWarningBannerViewBuilder(),
-                    _NewGroupButton(
-                      onPressed: goToNewGroupChat,
-                    ),
+                    ..._buildResponsiveButtons(context),
                     for (final child in expansionList) ...[child],
-                    _GetHelpButton(),
                   ] else ...[
                     for (final child in expansionList) ...[child],
                     _MoreListTile(),
-                    _NewGroupButton(
-                      onPressed: goToNewGroupChat,
-                    ),
-                    _GetHelpButton(),
+                    ..._buildResponsiveButtons(context),
                   ],
                 ],
               );
@@ -177,10 +164,7 @@ class ExpansionList extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _NewGroupButton(
-            onPressed: goToNewGroupChat,
-          ),
-          _GetHelpButton(),
+          ..._buildResponsiveButtons(context),
         ],
       ),
     );
@@ -236,6 +220,16 @@ class ExpansionList extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  List<Widget> _buildResponsiveButtons(BuildContext context) {
+    if (!getIt.get<ResponsiveUtils>().isSingleColumnLayout(context)) return [];
+
+    return [
+      _NewGroupButton(
+        onPressed: goToNewGroupChat,
+      ),
+    ];
   }
 }
 
@@ -303,18 +297,6 @@ class _NewGroupButton extends StatelessWidget {
       onPressed: onPressed,
       iconData: Icons.supervisor_account_outlined,
       text: L10n.of(context)!.newGroupChat,
-    );
-  }
-}
-
-class _GetHelpButton extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return _IconTextTileButton(
-      context: context,
-      onPressed: () => {},
-      iconData: Icons.question_mark,
-      text: L10n.of(context)!.getHelp,
     );
   }
 }

--- a/lib/presentation/mixins/go_to_group_chat_mixin.dart
+++ b/lib/presentation/mixins/go_to_group_chat_mixin.dart
@@ -1,0 +1,14 @@
+import 'package:fluffychat/config/first_column_inner_routes.dart';
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+mixin GoToGroupChatMixin {
+  void goToNewGroupChat(BuildContext context) {
+    if (!FirstColumnInnerRoutes.instance.goRouteAvailableInFirstColumn()) {
+      context.pushInner('innernavigator/newgroup');
+    } else {
+      context.push('/rooms/newprivatechat/newgroup');
+    }
+  }
+}


### PR DESCRIPTION
#991

- Disable Encryption by default
- Hide new group chat on web only
- Fix new group chat redirection with mixin

# WEB

## Unencrypted DM

https://github.com/linagora/twake-on-matrix/assets/48354990/f5797c43-7fd6-47ba-bc80-ad447776bd23

## New Group Chat

https://github.com/linagora/twake-on-matrix/assets/48354990/9c859293-f076-4845-b72a-c3d470e54628




# MOBILE

![image](https://github.com/linagora/twake-on-matrix/assets/48354990/85246224-f15d-42bf-81a4-5be50b252a1e)
