### PR TITLE
hot-fix: Wrong index when rebuild events in chat

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1283,8 +1283,8 @@ class ChatController extends State<Chat>
   }
 
   void onHover(bool isHovered, int index, Event event) {
-    if (index >= 0 &&
-        timeline!.events[index].eventId == event.eventId &&
+    if (index > 0 &&
+        timeline!.events[index - 1].eventId == event.eventId &&
         responsive.isDesktop(context) &&
         !selectMode &&
         !openingPopupMenu.value) {

--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -29,9 +29,7 @@ class ChatEventList extends StatelessWidget {
   Widget build(BuildContext context) {
     final horizontalPadding = TwakeThemes.isColumnMode(context) ? 8.0 : 0.0;
 
-    final events = controller.timeline!.events
-        .where((event) => event.isVisibleInGui)
-        .toList();
+    final events = controller.timeline!.events;
     // create a map of eventId --> index to greatly improve performance of
     // ListView's findChildIndexCallback
     final thisEventsKeyMap = <String, int>{};

--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -112,12 +112,14 @@ class ChatEventList extends StatelessWidget {
               }
               return const SizedBox.shrink();
             }
-            index--;
-            // The message at this index:
-            final event = events[index];
-            final previousEvent = index > 0 ? events[index - 1] : null;
-            final nextEvent =
-                index + 1 < events.length ? events[index + 1] : null;
+            final currentEventIndex = index - 1;
+            final event = controller.timeline!.events[currentEventIndex];
+            final previousEvent = currentEventIndex > 0
+                ? controller.timeline!.events[currentEventIndex - 1]
+                : null;
+            final nextEvent = index < controller.timeline!.events.length
+                ? controller.timeline!.events[currentEventIndex + 1]
+                : null;
             return AutoScrollTag(
               key: ValueKey(event.eventId),
               index: index,

--- a/lib/pages/chat/chat_pinned_events/pinned_events_view.dart
+++ b/lib/pages/chat/chat_pinned_events/pinned_events_view.dart
@@ -41,8 +41,10 @@ class PinnedEventsView extends StatelessWidget {
                     onTap: () => controller.pinnedEventsController
                         .jumpToPinnedMessageAction(
                       data.pinnedEvents,
-                      scrollToEventId: (eventId) =>
-                          controller.scrollToEventId(eventId),
+                      scrollToEventId: (eventId) => controller.scrollToEventId(
+                        eventId,
+                        highlight: true,
+                      ),
                     ),
                     child: Container(
                       margin: PinnedEventsStyle.marginPinnedEventsWidget,

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -132,8 +132,8 @@ class ChatView extends StatelessWidget with MessageContentMixin {
       child: StreamBuilder(
         stream: controller.room!.onUpdate.stream
             .rateLimit(const Duration(seconds: 1)),
-        builder: (context, snapshot) => FutureBuilder<bool>(
-          future: controller.getTimeline(),
+        builder: (context, snapshot) => FutureBuilder(
+          future: controller.loadTimelineFuture,
           builder: (BuildContext context, snapshot) {
             return Scaffold(
               backgroundColor: LinagoraSysColors.material().onPrimary,


### PR DESCRIPTION
### Change back to old logic:

- The new logic is not correct, because `index--` can be run multiple times if widget is rebuild multiple times
- 
<img width="1112" alt="image" src="https://github.com/linagora/twake-on-matrix/assets/43041967/7f093f99-d794-48ee-a4a8-2a72e8f19dc6">


### The problem:

https://github.com/linagora/twake-on-matrix/assets/43041967/73b89f7a-2a28-4e12-a681-2ee89054f5b3


### After fix:

https://github.com/linagora/twake-on-matrix/assets/43041967/41fb0d42-93b6-4d76-a6ae-266eecf4ae12

