### PR TITLE
Run builds on PR, instead of scheduled

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,10 @@
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 11 * * *"
+  workflow_run:
+    types:
+      - completed
+    workflows:
+      - "Tests"
 
 name: Build
 


### PR DESCRIPTION
Testing alternate strategy for building debug binaries.