### PR TITLE
Fix working directory for prepare scripts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,13 +73,11 @@ jobs:
 
       - name: Prepare iOS release
         if: matrix.os == 'ios'
-        run: ../scripts/prepare-ios.sh
-        working-directory: ${{ matrix.os }}
+        run: ./scripts/prepare-ios.sh
 
       - name: Release on Play Store internal track
         if: matrix.os == 'android'
-        run: ../scripts/release-playstore-beta.sh
-        working-directory: ${{ matrix.os }}
+        run: ./scripts/release-playstore-beta.sh
 
       - name: Release on TestFlight
         if: matrix.os == 'ios'

--- a/scripts/release-playstore-beta.sh
+++ b/scripts/release-playstore-beta.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
 flutter build appbundle --release
+cd android
 bundle exec fastlane deploy_internal_test


### PR DESCRIPTION
Since upgrading to flutter 3.16.5, prepare scripts need to run in project root, not in `ios` or `android` folders.