### PR TITLE
Tw 1308: twake chat crashed when reject an invitation

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -253,7 +253,7 @@ class ChatController extends State<Chat>
     context.go('/rooms/$roomId');
   }
 
-  void leaveChat() async {
+  Future<void> leaveChat() async {
     final room = this.room;
     if (room == null) {
       throw Exception(
@@ -1475,7 +1475,7 @@ class ChatController extends State<Chat>
   void onRejectInvitation(BuildContext context) async {
     final result = await showDialog<DialogRejectInviteResult>(
       context: TwakeApp.routerKey.currentContext ?? context,
-      useRootNavigator: false,
+      useRootNavigator: PlatformInfos.isWeb,
       builder: (c) => const DialogRejectInviteWidget(),
     );
 
@@ -1485,7 +1485,8 @@ class ChatController extends State<Chat>
       case DialogRejectInviteResult.cancel:
         return;
       case DialogRejectInviteResult.reject:
-        return leaveChat();
+        await leaveChat();
+        return;
     }
   }
 

--- a/lib/pages/chat/dialog_reject_invite_widget.dart
+++ b/lib/pages/chat/dialog_reject_invite_widget.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/pages/chat/dialog_reject_invite_style.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -19,6 +20,9 @@ class DialogRejectInviteWidget extends StatelessWidget {
       child: PopScope(
         canPop: false,
         onPopInvoked: (didPop) async {
+          if (PlatformInfos.isWeb) {
+            return;
+          }
           Navigator.of(context).pop(DialogRejectInviteResult.cancel);
         },
         child: Center(

--- a/lib/pages/chat_search/chat_search_view.dart
+++ b/lib/pages/chat_search/chat_search_view.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:collection/collection.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/config/app_config.dart';
@@ -16,6 +14,7 @@ import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/result_extension.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/string_extension.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
 import 'package:fluffychat/widgets/highlight_text.dart';
@@ -41,7 +40,7 @@ class ChatSearchView extends StatelessWidget {
     return PopScope(
       canPop: false,
       onPopInvoked: (isPop) async {
-        if (Platform.isAndroid) {
+        if (PlatformInfos.isAndroid) {
           controller.onBack();
         }
       },


### PR DESCRIPTION
### Problem:
- 2 consecutive call to `pop()` in Web will throw an exception
- Don't use `Platform.isAndroid` use `PlatformInfo.isAndroid` instead because the first one need to use `dart:io` or `dart:html` to import, but dart.io only support non-web platform, `dart:html` is for web only

### Demo: 

https://github.com/linagora/twake-on-matrix/assets/43041967/bf21ef79-8ed4-4754-988d-ccdd5c7a4763

