### PR TITLE
Hot fix/detail chat screen

### DIFF
--- a/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_builder.dart
+++ b/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_builder.dart
@@ -1,7 +1,7 @@
-import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_style.dart';
 import 'package:fluffychat/presentation/enum/chat/right_column_type_enum.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/layouts/adaptive_layout/app_adaptive_scaffold.dart';
 import 'package:flutter/cupertino.dart';
@@ -32,16 +32,15 @@ class ChatAdaptiveScaffoldBuilderController
   final rightColumnTypeNotifier = ValueNotifier<RightColumnType?>(null);
 
   void hideRightColumn() {
-    rightColumnTypeNotifier.value = null;
-    if (responsiveUtils.isMobile(context)) {
+    if (PlatformInfos.isMobile) {
       Navigator.of(context).pop();
+    } else {
+      rightColumnTypeNotifier.value = null;
     }
   }
 
-  final responsiveUtils = getIt.get<ResponsiveUtils>();
-
   void setRightColumnType(RightColumnType type) {
-    if (responsiveUtils.isMobile(context)) {
+    if (PlatformInfos.isMobile) {
       Navigator.of(context).push(
         CupertinoPageRoute(
           builder: (context) => widget.rightBuilder(
@@ -78,9 +77,17 @@ class ChatAdaptiveScaffoldBuilderController
                   end: breakpoint,
                 ): SlotLayout.from(
                   key: AppAdaptiveScaffold.breakpointMobileKey,
-                  builder: (_) {
-                    return body!;
-                  },
+                  builder: (_) => Stack(
+                    children: [
+                      body!,
+                      if (rightColumnType != null && PlatformInfos.isWeb)
+                        widget.rightBuilder(
+                          this,
+                          isInStack: true,
+                          type: rightColumnType,
+                        ),
+                    ],
+                  ),
                 ),
                 const WidthPlatformBreakpoint(
                   begin: breakpoint,

--- a/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_builder.dart
+++ b/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_builder.dart
@@ -1,8 +1,10 @@
+import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_style.dart';
 import 'package:fluffychat/presentation/enum/chat/right_column_type_enum.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/layouts/adaptive_layout/app_adaptive_scaffold.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
 
@@ -31,10 +33,27 @@ class ChatAdaptiveScaffoldBuilderController
 
   void hideRightColumn() {
     rightColumnTypeNotifier.value = null;
+    if (responsiveUtils.isMobile(context)) {
+      Navigator.of(context).pop();
+    }
   }
 
+  final responsiveUtils = getIt.get<ResponsiveUtils>();
+
   void setRightColumnType(RightColumnType type) {
-    rightColumnTypeNotifier.value = type;
+    if (responsiveUtils.isMobile(context)) {
+      Navigator.of(context).push(
+        CupertinoPageRoute(
+          builder: (context) => widget.rightBuilder(
+            this,
+            isInStack: true,
+            type: type,
+          ),
+        ),
+      );
+    } else {
+      rightColumnTypeNotifier.value = type;
+    }
   }
 
   @override
@@ -59,17 +78,9 @@ class ChatAdaptiveScaffoldBuilderController
                   end: breakpoint,
                 ): SlotLayout.from(
                   key: AppAdaptiveScaffold.breakpointMobileKey,
-                  builder: (_) => Stack(
-                    children: [
-                      body!,
-                      if (rightColumnType != null)
-                        widget.rightBuilder(
-                          this,
-                          isInStack: true,
-                          type: rightColumnType,
-                        ),
-                    ],
-                  ),
+                  builder: (_) {
+                    return body!;
+                  },
                 ),
                 const WidthPlatformBreakpoint(
                   begin: breakpoint,

--- a/lib/pages/chat_details/chat_details.dart
+++ b/lib/pages/chat_details/chat_details.dart
@@ -1,6 +1,6 @@
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
-import 'package:fluffychat/pages/chat_details/chat_details_navigator.dart';
+import 'package:fluffychat/pages/chat_details/chat_details_edit.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_page_view/chat_details_members_page.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_page_view/chat_details_page_enum.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_page_view/links/chat_details_links_page.dart';
@@ -20,6 +20,7 @@ import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/utils/scroll_controller_extension.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_adaptive_scaffold/flutter_adaptive_scaffold.dart';
@@ -180,6 +181,16 @@ class ChatDetailsController extends State<ChatDetails>
   }
 
   void openDialogInvite() {
+    if (PlatformInfos.isMobile) {
+      Navigator.of(context).push(
+        CupertinoPageRoute(
+          builder: (_) => InvitationSelection(
+            roomId: roomId!,
+          ),
+        ),
+      );
+      return;
+    }
     showDialog(
       context: context,
       barrierDismissible: false,
@@ -284,7 +295,15 @@ class ChatDetailsController extends State<ChatDetails>
   }
 
   void onTapEditButton() {
-    Navigator.pushNamed(context, ChatDetailsRoutes.chatDetailsEdit);
+    Navigator.of(context).push(
+      CupertinoPageRoute(
+        builder: (context) {
+          return ChatDetailsEdit(
+            roomId: roomId!,
+          );
+        },
+      ),
+    );
   }
 
   void onTapInviteLink(BuildContext context, String inviteLink) async {

--- a/lib/pages/chat_details/chat_details_navigator.dart
+++ b/lib/pages/chat_details/chat_details_navigator.dart
@@ -1,8 +1,9 @@
 import 'package:fluffychat/pages/chat_details/chat_details.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_edit.dart';
-import 'package:flutter/material.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 
 import 'package:fluffychat/presentation/model/presentation_contact.dart';
+import 'package:flutter/material.dart';
 
 class ChatDetailsRoutes {
   static const String chatDetails = '/groupChatDetails';
@@ -25,6 +26,13 @@ class ChatDetailsNavigator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (PlatformInfos.isMobile) {
+      return ChatDetails(
+        roomId: roomId!,
+        onBack: onBack,
+        isInStack: isInStack,
+      );
+    }
     return Navigator(
       initialRoute: ChatDetailsRoutes.chatDetails,
       onGenerateRoute: (settings) => MaterialPageRoute(

--- a/lib/pages/chat_profile_info/chat_profile_info.dart
+++ b/lib/pages/chat_profile_info/chat_profile_info.dart
@@ -6,11 +6,11 @@ import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/contact/lookup_match_contact_state.dart';
 import 'package:fluffychat/domain/usecase/contacts/lookup_match_contact_interactor.dart';
-import 'package:fluffychat/pages/chat_profile_info/chat_profile_info_navigator.dart';
+import 'package:fluffychat/pages/chat_profile_info/chat_profile_info_shared/chat_profile_info_shared.dart';
 import 'package:fluffychat/pages/chat_profile_info/chat_profile_info_view.dart';
 import 'package:fluffychat/presentation/model/presentation_contact.dart';
 import 'package:fluffychat/widgets/matrix.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:matrix/matrix.dart';
 
 class ProfileInfo extends StatefulWidget {
@@ -62,10 +62,15 @@ class ProfileInfoController extends State<ProfileInfo> {
   }
 
   void goToProfileShared() {
-    if (widget.isDraftInfo) return;
-    Navigator.of(context).pushNamed(
-      ProfileInfoRoutes.profileInfoShared,
-      arguments: widget.roomId,
+    if (widget.isDraftInfo || widget.roomId == null) return;
+    Navigator.of(context).push(
+      CupertinoPageRoute(
+        builder: (context) {
+          return ProfileInfoShared(
+            roomId: widget.roomId!,
+          );
+        },
+      ),
     );
   }
 

--- a/lib/pages/chat_profile_info/chat_profile_info_navigator.dart
+++ b/lib/pages/chat_profile_info/chat_profile_info_navigator.dart
@@ -1,5 +1,5 @@
 import 'package:fluffychat/pages/chat_profile_info/chat_profile_info_shared/chat_profile_info_shared.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 import 'package:fluffychat/pages/chat_profile_info/chat_profile_info.dart';
 import 'package:fluffychat/presentation/model/presentation_contact.dart';
@@ -29,7 +29,7 @@ class ProfileInfoNavigator extends StatelessWidget {
   Widget build(BuildContext context) {
     return Navigator(
       initialRoute: ProfileInfoRoutes.profileInfo,
-      onGenerateRoute: (route) => MaterialPageRoute(
+      onGenerateRoute: (route) => CupertinoPageRoute(
         builder: (context) {
           switch (route.name) {
             case ProfileInfoRoutes.profileInfo:

--- a/lib/pages/chat_profile_info/chat_profile_info_navigator.dart
+++ b/lib/pages/chat_profile_info/chat_profile_info_navigator.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/pages/chat_profile_info/chat_profile_info_shared/chat_profile_info_shared.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/cupertino.dart';
 
 import 'package:fluffychat/pages/chat_profile_info/chat_profile_info.dart';
@@ -27,6 +28,15 @@ class ProfileInfoNavigator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (PlatformInfos.isMobile) {
+      return ProfileInfo(
+        onBack: onBack,
+        isInStack: isInStack,
+        roomId: roomId,
+        contact: contact,
+        isDraftInfo: isDraftInfo,
+      );
+    }
     return Navigator(
       initialRoute: ProfileInfoRoutes.profileInfo,
       onGenerateRoute: (route) => CupertinoPageRoute(

--- a/lib/pages/chat_search/chat_search_view.dart
+++ b/lib/pages/chat_search/chat_search_view.dart
@@ -38,7 +38,7 @@ class ChatSearchView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      canPop: false,
+      canPop: true,
       onPopInvoked: (isPop) async {
         if (PlatformInfos.isAndroid) {
           controller.onBack();

--- a/lib/widgets/app_bars/searchable_app_bar.dart
+++ b/lib/widgets/app_bars/searchable_app_bar.dart
@@ -62,8 +62,8 @@ class SearchableAppBar extends StatelessWidget {
                           .goRouteAvailableInFirstColumn()) {
                         Navigator.of(context).maybePop();
                       } else {
-                        if (context.canPop()) {
-                          context.pop();
+                        if (Navigator.of(context).canPop()) {
+                          Navigator.of(context).pop();
                         } else {
                           context.go('/rooms');
                         }


### PR DESCRIPTION
### Problem:
In mobile: if using multiple Navigator, when the user swipes to close a page, multiple navigators will receive the swipe and react to that, result in it pop 2 times, so in mobile use only 1 navigator with Go_router is enough
### Demo mobile chat details screen:
https://github.com/linagora/twake-on-matrix/assets/43041967/3fcf6256-efc9-4054-a77c-235ac7ad17ed
### Demo web chat details screen:


https://github.com/linagora/twake-on-matrix/assets/43041967/882c76f8-b10f-47af-acfd-b1bf84a9e6d8

### Demo mobile profile screen:

https://github.com/linagora/twake-on-matrix/assets/43041967/661c73f5-5a70-464b-ac6c-4817d9758ff7

### Demo web profile screen:


https://github.com/linagora/twake-on-matrix/assets/43041967/d3476c7f-b663-49c8-af6c-8972486e607e

