### PR TITLE
TW-1329: shift enter not work well in middle of text

### DIFF
--- a/lib/presentation/extensions/text_editting_controller_extension.dart
+++ b/lib/presentation/extensions/text_editting_controller_extension.dart
@@ -45,7 +45,13 @@ extension TextEdittingControllerExtension on TextEditingController {
   }
 
   void addNewLine() {
-    text = '$text\n';
-    selection = TextSelection.collapsed(offset: text.length);
+    final start = selection.start;
+    final end = selection.end;
+    if (start != end) {
+      text = text.replaceRange(start, end, "\n");
+    } else {
+      text = "${text.substring(0, start)}\n${text.substring(end, text.length)}";
+    }
+    selection = TextSelection.collapsed(offset: start + 1);
   }
 }


### PR DESCRIPTION
### Demo:
https://github.com/linagora/twake-on-matrix/assets/43041967/e3883838-2ab4-4385-9ff7-0de747139b5e

