### PR TITLE
Bumped `desktop_drop` version to fix macOS builds

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -430,10 +430,10 @@ packages:
     dependency: "direct main"
     description:
       name: desktop_drop
-      sha256: "4ca4d960f4b11c032e9adfd2a0a8ac615bc3fddb4cbe73dcf840dd8077582186"
+      sha256: d55a010fe46c8e8fcff4ea4b451a9ff84a162217bdb3b2a0aa1479776205e15d
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.1"
+    version: "0.4.4"
   desktop_lifecycle:
     dependency: "direct main"
     description:
@@ -1534,7 +1534,7 @@ packages:
     description:
       path: "."
       ref: "twake-supported-0.22.6"
-      resolved-ref: "a2bb3edb413986207563c4d812b54e060809572f"
+      resolved-ref: a2bb3edb413986207563c4d812b54e060809572f
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 version: 2.4.14+2330
 
 environment:
-  sdk: '>=3.1.3 <4.0.0'
+  sdk: ">=3.1.3 <4.0.0"
 
 dependencies:
   adaptive_dialog: ^1.8.0+1
@@ -16,7 +16,7 @@ dependencies:
   collection: ^1.16.0
   connectivity_plus: ^3.0.2
   cupertino_icons: any
-  desktop_drop: ^0.4.0
+  desktop_drop: ^0.4.4
   desktop_lifecycle: ^0.1.0
   desktop_notifications: ^0.6.3
   device_info_plus: ^9.0.3


### PR DESCRIPTION
The build error:

```
[        ] 	CompileSwift normal x86_64 /Users/runner/hostedtoolcache/flutter/stable-3.16.5-x64/.pub-cache/hosted/pub.dev/desktop_drop-0.4.1/macos/Classes/DesktopDropPlugin.swift (in target 'desktop_drop' from project 'Pods')
[        ] 	SwiftCompile normal x86_64 Compiling\ DesktopDropPlugin.swift /Users/runner/hostedtoolcache/flutter/stable-3.16.5-x64/.pub-cache/hosted/pub.dev/desktop_drop-0.4.1/macos/Classes/DesktopDropPlugin.swift (in target 'desktop_drop' from project 'Pods')
[        ] 	CompileSwift normal arm64 /Users/runner/hostedtoolcache/flutter/stable-3.16.5-x64/.pub-cache/hosted/pub.dev/desktop_drop-0.4.1/macos/Classes/DesktopDropPlugin.swift (in target 'desktop_drop' from project 'Pods')
[        ] 	SwiftCompile normal arm64 Compiling\ DesktopDropPlugin.swift /Users/runner/hostedtoolcache/flutter/stable-3.16.5-x64/.pub-cache/hosted/pub.dev/desktop_drop-0.4.1/macos/Classes/DesktopDropPlugin.swift (in target 'desktop_drop' from project 'Pods')
```