### PR TITLE
TW-1140: fix show image downloaded in image viewer

### DIFF
--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -62,21 +62,23 @@ class ImageViewerView extends StatelessWidget {
     }
 
     return Center(
-      child: GestureDetector(
-        onTap: () {
-          if (PlatformInfos.isWeb) {
-            Navigator.of(context).pop();
-          } else {
-            controller.toggleAppbarPreview();
-          }
-        },
-        onDoubleTapDown: (details) => controller.onDoubleTapDown(details),
-        onDoubleTap: () => controller.onDoubleTap(),
-        child: Stack(
-          children: [
-            interactiveViewer,
-            _buildAppBarPreview(),
-          ],
+      child: Scaffold(
+        body: GestureDetector(
+          onTap: () {
+            if (PlatformInfos.isWeb) {
+              Navigator.of(context).pop();
+            } else {
+              controller.toggleAppbarPreview();
+            }
+          },
+          onDoubleTapDown: (details) => controller.onDoubleTapDown(details),
+          onDoubleTap: () => controller.onDoubleTap(),
+          child: Stack(
+            children: [
+              interactiveViewer,
+              _buildAppBarPreview(),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### Problem:
- When downloading image in the image viewer in mobile, the snackbar have shown, but it's under the `ImageViewer` widget. It's because snackbar will be shown on the nearest `Scaffold`. The solution is simple, wrap ImageViewer inside Scaffold


### Demo:

https://github.com/linagora/twake-on-matrix/assets/43041967/4e1cfacd-49b3-454a-9c3d-3e9c35d5350e

