### PR TITLE
TW-1283: Fix refresh pinned message page

### DIFF
--- a/lib/di/global/get_it_initializer.dart
+++ b/lib/di/global/get_it_initializer.dart
@@ -71,6 +71,7 @@ import 'package:fluffychat/domain/usecase/send_media_on_web_with_caption_interac
 import 'package:fluffychat/domain/usecase/settings/save_language_interactor.dart';
 import 'package:fluffychat/domain/usecase/settings/update_profile_interactor.dart';
 import 'package:fluffychat/event/twake_event_dispatcher.dart';
+import 'package:fluffychat/pages/chat/chat_pinned_events/pinned_events_controller.dart';
 import 'package:fluffychat/utils/famedlysdk_store.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:get_it/get_it.dart';
@@ -94,6 +95,7 @@ class GetItInitializer {
     bindingDatasourceImpl();
     bindingRepositories();
     bindingInteractor();
+    _bindingControllers();
   }
 
   void bindingGlobal() {
@@ -271,6 +273,12 @@ class GetItInitializer {
     );
     getIt.registerFactory<SendFilesOnWebWithCaptionInteractor>(
       () => SendFilesOnWebWithCaptionInteractor(),
+    );
+  }
+
+  void _bindingControllers() {
+    getIt.registerFactory<PinnedEventsController>(
+      () => PinnedEventsController(),
     );
   }
 }

--- a/lib/domain/app_state/room/chat_get_pinned_events_state.dart
+++ b/lib/domain/app_state/room/chat_get_pinned_events_state.dart
@@ -29,6 +29,11 @@ class ChatGetPinnedEventsNoResult extends Failure {
   List<Object?> get props => [];
 }
 
+class CannotGetPinnedMessages extends Failure {
+  @override
+  List<Object?> get props => [];
+}
+
 class ChatGetPinnedEventsFailure extends Failure {
   final dynamic exception;
 

--- a/lib/pages/chat/chat_pinned_events/pinned_events_view.dart
+++ b/lib/pages/chat/chat_pinned_events/pinned_events_view.dart
@@ -38,10 +38,6 @@ class PinnedEventsView extends StatelessWidget {
             switch (success.runtimeType) {
               case ChatGetPinnedEventsSuccess:
                 final data = success as ChatGetPinnedEventsSuccess;
-                if (data.pinnedEvents.isEmpty) {
-                  return child!;
-                }
-
                 return Material(
                   color: LinagoraSysColors.material().onPrimary,
                   child: InkWell(
@@ -76,7 +72,6 @@ class PinnedEventsView extends StatelessWidget {
                                                 .copyWith(scrollbars: false),
                                         child: ListView.separated(
                                           controller: controller
-                                              .pinnedEventsController
                                               .pinnedMessageScrollController,
                                           shrinkWrap: true,
                                           physics:
@@ -95,7 +90,6 @@ class PinnedEventsView extends StatelessWidget {
                                             return _PinnedEventsIndicator(
                                               currentEvent: currentEvent,
                                               scrollController: controller
-                                                  .pinnedEventsController
                                                   .pinnedMessageScrollController,
                                               color:
                                                   LinagoraSysColors.material()

--- a/lib/pages/chat/chat_pinned_events/pinned_messages.dart
+++ b/lib/pages/chat/chat_pinned_events/pinned_messages.dart
@@ -13,6 +13,8 @@ import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/widgets/mixins/popup_context_menu_action_mixin.dart';
 import 'package:fluffychat/widgets/mixins/popup_menu_widget_mixin.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -200,10 +202,29 @@ class PinnedMessagesController extends State<PinnedMessages>
     }
   }
 
+  void _initPinnedEvents() {
+    if (widget.pinnedEvents.isNotEmpty) {
+      eventsNotifier.value = widget.pinnedEvents;
+    } else {
+      final currentRoomId = GoRouterState.of(context).pathParameters['roomid'];
+      if (currentRoomId != null) {
+        context.go('/rooms/$currentRoomId');
+      }
+    }
+  }
+
+  void onClickBackButton() {
+    Navigator.of(context).pop(
+      eventsNotifier.value != widget.pinnedEvents ? eventsNotifier.value : null,
+    );
+  }
+
   @override
   void initState() {
     super.initState();
-    eventsNotifier.value = widget.pinnedEvents;
+    SchedulerBinding.instance.addPostFrameCallback((_) async {
+      _initPinnedEvents();
+    });
   }
 
   @override

--- a/lib/pages/chat/chat_pinned_events/pinned_messages_screen.dart
+++ b/lib/pages/chat/chat_pinned_events/pinned_messages_screen.dart
@@ -39,7 +39,7 @@ class PinnedMessagesScreen extends StatelessWidget {
         leading: TwakeIconButton(
           tooltip: L10n.of(context)!.back,
           icon: Icons.arrow_back,
-          onTap: () => Navigator.of(context).pop(),
+          onTap: controller.onClickBackButton,
         ),
         actions: [
           if (!responsiveUtils.isMobile(context))


### PR DESCRIPTION
### Ticket

- #1283 

### Resolved

- Improvement pinned events in chat: 
  - Remove `getPinnedMessageAction()` in `initState` because It is not certain that at that time the states in the room were set. It only works well for the first time going to room and wrong when reloading page
  - Fix rebuild pinned events in chat when pin/unpin

- iOS

https://github.com/linagora/twake-on-matrix/assets/99852347/aac15352-46ab-492c-b8d5-2f0aef4a893a


- Safari

https://github.com/linagora/twake-on-matrix/assets/99852347/e4128045-e696-4ec3-a2ca-70f9e59f80d3

- Firefox

https://github.com/linagora/twake-on-matrix/assets/99852347/c389836f-dd88-4c04-9474-f8ef8b569a0b

- Chrome

https://github.com/linagora/twake-on-matrix/assets/99852347/5e3a0693-f36d-4a5f-8914-3c376a85d28b


