### PR TITLE
TW-1351: add draft chat catch phrase

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -2994,5 +2994,15 @@
     "placeholders": {
       "count": {}
     }
-  }
+  },
+  "draftChatHookPhrase": "Hi {user}! I would like to chat with you.",
+  "@draftChatHookPhrase": {
+    "placeholders": {
+      "user": {
+        "type": "String",
+        "example": "John"
+      }
+    }
+  },
+  "twakeChatUser": "Twake Chat User"
 }

--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -1,5 +1,5 @@
 import 'package:fluffychat/pages/chat/group_chat_empty_view.dart';
-import 'package:fluffychat/pages/chat_draft/draft_chat_empty_view.dart';
+import 'package:fluffychat/pages/chat_draft/draft_chat_empty_widget.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
@@ -165,7 +165,7 @@ class ChatEventList extends StatelessWidget {
 
   Widget _chatEmptyBuilder(Timeline timeline) {
     if (controller.room?.isDirectChat ?? true) {
-      return DirectDraftChatView(
+      return DraftChatEmpty(
         onTap: () => controller.inputFocus.requestFocus(),
       );
     } else {

--- a/lib/pages/chat_draft/draft_chat.dart
+++ b/lib/pages/chat_draft/draft_chat.dart
@@ -345,6 +345,16 @@ class DraftChatController extends State<DraftChat>
     widget.onChangeRightColumnType?.call(RightColumnType.profileInfo);
   }
 
+  void handleDraftAction(BuildContext context) {
+    inputFocus.requestFocus();
+
+    sendController.value = TextEditingValue(
+      text: L10n.of(context)!.draftChatHookPhrase(
+        presentationContact!.displayName ?? L10n.of(context)!.twakeChatUser,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return DraftChatView(controller: this);

--- a/lib/pages/chat_draft/draft_chat_empty_widget.dart
+++ b/lib/pages/chat_draft/draft_chat_empty_widget.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
-class DirectDraftChatView extends StatelessWidget {
+class DraftChatEmpty extends StatelessWidget {
   final void Function()? onTap;
 
-  const DirectDraftChatView({
+  const DraftChatEmpty({
     Key? key,
     this.onTap,
   }) : super(key: key);

--- a/lib/pages/chat_draft/draft_chat_view.dart
+++ b/lib/pages/chat_draft/draft_chat_view.dart
@@ -8,7 +8,7 @@ import 'package:fluffychat/pages/chat/chat_app_bar_title_style.dart';
 import 'package:fluffychat/pages/chat/chat_input_row_style.dart';
 import 'package:fluffychat/pages/chat/input_bar/input_bar.dart';
 import 'package:fluffychat/pages/chat_draft/draft_chat.dart';
-import 'package:fluffychat/pages/chat_draft/draft_chat_empty_view.dart';
+import 'package:fluffychat/pages/chat_draft/draft_chat_empty_widget.dart';
 import 'package:fluffychat/pages/chat_draft/draft_chat_view_style.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -100,8 +100,8 @@ class DraftChatView extends StatelessWidget {
                             controller.handleDragDone(details),
                         onDragEntered: controller.onDragEntered,
                         onDragExited: controller.onDragExited,
-                        child: DirectDraftChatView(
-                          onTap: controller.inputFocus.requestFocus,
+                        child: DraftChatEmpty(
+                          onTap: () => controller.handleDraftAction(context),
                         ),
                       ),
                     ),


### PR DESCRIPTION
#1351 

- [ ] Renamed DraftChatEmptyWidget according to convention
- [ ] Add a catch phrase on draft chat view

~`DraftChatEmptyView`~ -> `DraftChatEmptyWidget` because it's a button and not a view

https://github.com/linagora/twake-on-matrix/assets/48354990/15de204a-5e87-4e2c-aa01-0e7b9505963f

