### PR TITLE
TW-1349: fix reply to - input focus

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -768,11 +768,13 @@ class ChatController extends State<Chat>
   }
 
   void replyAction({Event? replyTo}) {
+    if (!inputFocus.hasFocus) {
+      FocusScope.of(context).requestFocus(inputFocus);
+    }
     setState(() {
       replyEvent = replyTo ?? selectedEvents.first;
       selectedEvents.clear();
     });
-    inputFocus.requestFocus();
   }
 
   Future<void> scrollToEventIdAndHighlight(String eventId) async {

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:fluffychat/pages/chat/chat_view_style.dart';
 import 'package:fluffychat/presentation/mixins/handle_clipboard_action_mixin.dart';
 import 'package:fluffychat/presentation/mixins/paste_image_mixin.dart';
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:universal_html/html.dart' as html;
 
 import 'package:adaptive_dialog/adaptive_dialog.dart';
@@ -1309,7 +1309,6 @@ class ChatController extends State<Chat>
     BuildContext context,
     ChatHorizontalActionMenu actions,
     Event event,
-    PointerDownEvent pointerDownEvent,
   ) {
     switch (actions) {
       case ChatHorizontalActionMenu.reply:
@@ -1323,7 +1322,6 @@ class ChatController extends State<Chat>
         handleContextMenuAction(
           context,
           event,
-          pointerDownEvent,
         );
         break;
     }
@@ -1393,20 +1391,11 @@ class ChatController extends State<Chat>
   void handleContextMenuAction(
     BuildContext context,
     Event event,
-    PointerDownEvent pointerDownEvent,
   ) {
-    final screenSize = MediaQuery.of(context).size;
-    final offset = pointerDownEvent.position;
-    final position = RelativeRect.fromLTRB(
-      offset.dx,
-      offset.dy + ChatViewStyle.paddingBottomContextMenu,
-      screenSize.width - offset.dx,
-      screenSize.height - offset.dy,
-    );
     _handleStateContextMenu();
     openPopupMenuAction(
       context,
-      position,
+      context.getCurrentRelativeRectOfWidget(),
       _popupMenuActionTile(context, event),
       onClose: () {
         _handleStateContextMenu();

--- a/lib/pages/chat/chat_view_style.dart
+++ b/lib/pages/chat/chat_view_style.dart
@@ -37,6 +37,4 @@ class ChatViewStyle {
       active
           ? Theme.of(context).colorScheme.primary
           : Theme.of(context).colorScheme.onBackground;
-
-  static const paddingBottomContextMenu = 16.0;
 }

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -25,7 +25,6 @@ typedef OnMenuAction = Function(
   BuildContext,
   ChatHorizontalActionMenu,
   Event,
-  PointerDownEvent,
 );
 
 class Message extends StatelessWidget {

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -224,18 +224,15 @@ class MessageContentWithTimestampBuilder extends StatelessWidget {
           children: listHorizontalActionMenu.map((item) {
             return Padding(
               padding: const EdgeInsetsDirectional.symmetric(horizontal: 4),
-              child: Listener(
-                onPointerDown: (pointerEvent) => onMenuAction!.call(
+              child: TwakeIconButton(
+                icon: item.action.getIcon(),
+                imagePath: item.action.getImagePath(),
+                tooltip: item.action.getTitle(context),
+                preferBelow: false,
+                onTapDown: (context) => onMenuAction!(
                   context,
                   item.action,
                   event,
-                  pointerEvent,
-                ),
-                child: TwakeIconButton(
-                  icon: item.action.getIcon(),
-                  imagePath: item.action.getImagePath(),
-                  tooltip: item.action.getTitle(context),
-                  preferBelow: false,
                 ),
               ),
             );


### PR DESCRIPTION
- TW-930 only needed 
```dart
 useRootNavigator: PlatformInfos.isWeb,
```
in `showMenu` fn - `popup_context_menu_action_mixin.dart` to fix the issue (https://github.com/linagora/twake-on-matrix/pull/1343)
The listener was overloading the view and making focus acts wrongly 

# Demo
## Firefox
### TW-930: Disable context menu when switching chats

https://github.com/linagora/twake-on-matrix/assets/48354990/4be8d36d-23dd-4d6c-a4f9-8c3b7a4f0410


### Reply to a message focus the composer 

https://github.com/linagora/twake-on-matrix/assets/48354990/0b19fa9c-1972-48da-a564-aa000ef33a58


## Chrome

### TW-930: Disable context menu when switching chats

https://github.com/linagora/twake-on-matrix/assets/48354990/d3326de4-c0da-4738-9069-ce1e595a0627

### Reply to a message focus the composer 

https://github.com/linagora/twake-on-matrix/assets/48354990/043acded-b9a0-44fe-bf0e-09b9b0150cd8


#1349 