### PR TITLE
TW-1356: Reword accounts picker

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3060,6 +3060,8 @@
       "user": {}
     }
   },
+  "switchAccounts": "Switch accounts",
+  "selectAccount": "Select account",
   "privacyPolicy": "Privacy Policy",
   "byContinuingYourAgreeingToOur": "By continuing, you're agreeing to our"
 }

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -9,7 +9,6 @@ import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/recovery_words/recovery_words.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/domain/usecase/recovery/get_recovery_words_interactor.dart';
-import 'package:fluffychat/pages/multiple_accounts/multiple_accounts_picker.dart';
 import 'package:fluffychat/presentation/mixins/comparable_presentation_contact_mixin.dart';
 import 'package:fluffychat/pages/bootstrap/bootstrap_dialog.dart';
 import 'package:fluffychat/pages/bootstrap/tom_bootstrap_dialog.dart';
@@ -760,16 +759,8 @@ class ChatListController extends State<ChatList>
     currentProfileNotifier.value = profile;
   }
 
-  void onGoToAccountSettings() {
-    widget.onOpenSettings?.call();
-  }
-
   void onClickAvatar() {
-    MultipleAccountsPickerController(context: context)
-        .showMultipleAccountsPicker(
-      activeClient,
-      onGoToAccountSettings: onGoToAccountSettings,
-    );
+    context.push('/rooms/profile');
   }
 
   void _handleRecovery() {

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -84,10 +84,6 @@ class ChatListController extends State<ChatList>
   final ValueNotifier<SelectMode> selectModeNotifier =
       ValueNotifier(SelectMode.normal);
 
-  final ValueNotifier<Profile> currentProfileNotifier = ValueNotifier(
-    Profile(userId: ''),
-  );
-
   final ValueNotifier<List<ConversationSelectionPresentation>>
       conversationSelectionNotifier = ValueNotifier([]);
 
@@ -748,17 +744,6 @@ class ChatListController extends State<ChatList>
     }
   }
 
-  void _getCurrentProfile(Client client) async {
-    final profile = await client.getProfileFromUserId(
-      client.userID!,
-      getFromRooms: false,
-    );
-    Logs().d(
-      'ChatList::_getCurrentProfile() - currentProfile: $profile',
-    );
-    currentProfileNotifier.value = profile;
-  }
-
   void onClickAvatar() {
     context.push('/rooms/profile');
   }
@@ -783,7 +768,6 @@ class ChatListController extends State<ChatList>
     );
     if (newActiveClient != null && newActiveClient.userID != null) {
       setState(() {
-        _getCurrentProfile(newActiveClient);
         _clientStream.add(newActiveClient);
         _handleRecovery();
       });
@@ -800,14 +784,12 @@ class ChatListController extends State<ChatList>
     scrollController.addListener(_onScroll);
     _waitForFirstSync();
     _hackyWebRTCFixForWeb();
-    _getCurrentProfile(activeClient);
     // TODO: 28Dec2023 Disable callkeep for util we support audio/video calls
     // CallKeepManager().initialize();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (mounted) {
         Matrix.of(context).backgroundPush?.setupPush();
         await matrixState.retrievePersistedActiveClient();
-        _getCurrentProfile(activeClient);
       }
     });
     _checkTorBrowser();

--- a/lib/pages/chat_list/chat_list_header.dart
+++ b/lib/pages/chat_list/chat_list_header.dart
@@ -22,8 +22,12 @@ class ChatListHeader extends StatelessWidget {
     return Column(
       children: [
         TwakeHeader(
-          controller: controller,
           onClearSelection: controller.onClickClearSelection,
+          client: controller.activeClient,
+          selectModeNotifier: controller.selectModeNotifier,
+          conversationSelectionNotifier:
+              controller.conversationSelectionNotifier,
+          onClickAvatar: controller.onClickAvatar,
         ),
         Container(
           height: ChatListHeaderStyle.searchBarContainerHeight,

--- a/lib/pages/homeserver_picker/homeserver_picker.dart
+++ b/lib/pages/homeserver_picker/homeserver_picker.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:fluffychat/presentation/mixins/connect_page_mixin.dart';
 import 'package:fluffychat/pages/homeserver_picker/homeserver_state.dart';
+import 'package:fluffychat/utils/client_manager.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:flutter/foundation.dart';
@@ -145,9 +146,12 @@ class HomeserverPickerController extends State<HomeserverPicker>
         homeserver = Uri.https(homeserverController.text, '');
       }
       final matrix = Matrix.of(context);
-
+      final allHomeserverLoggedIn = (await ClientManager.getClients())
+          .map((client) => client.homeserver.toString())
+          .toList();
+      Logs().i('All homeservers: $allHomeserverLoggedIn');
       final homeserverExists =
-          homeserver == matrix.client.homeserver && matrix.client.isLogged();
+          allHomeserverLoggedIn.contains(homeserver.toString());
 
       if (homeserverExists &&
           !AppConfig.supportMultipleAccountsInTheSameHomeserver) {

--- a/lib/pages/multiple_accounts/multiple_accounts_picker.dart
+++ b/lib/pages/multiple_accounts/multiple_accounts_picker.dart
@@ -13,6 +13,8 @@ import 'package:linagora_design_flutter/multiple_account/models/twake_presentati
 import 'package:matrix/matrix.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
+typedef OnGoToAccountSettings = void Function(TwakePresentationAccount account);
+
 class MultipleAccountsPickerController {
   final BuildContext context;
 

--- a/lib/pages/multiple_accounts/multiple_accounts_picker.dart
+++ b/lib/pages/multiple_accounts/multiple_accounts_picker.dart
@@ -1,7 +1,5 @@
 import 'package:collection/collection.dart';
 import 'package:fluffychat/pages/twake_welcome/twake_welcome.dart';
-import 'package:fluffychat/presentation/extensions/multiple_accounts/client_profile_extension.dart';
-import 'package:fluffychat/presentation/multiple_account/client_profile_presentation.dart';
 import 'package:fluffychat/presentation/multiple_account/twake_chat_presentation_account.dart';
 import 'package:fluffychat/widgets/layouts/agruments/switch_active_account_body_args.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -17,65 +15,30 @@ typedef OnGoToAccountSettings = void Function(TwakePresentationAccount account);
 
 class MultipleAccountsPickerController {
   final BuildContext context;
+  final List<TwakeChatPresentationAccount> multipleAccounts;
 
   MultipleAccountsPickerController({
     required this.context,
+    required this.multipleAccounts,
   });
 
   MatrixState get _matrixState => Matrix.of(context);
-
-  Future<List<ClientProfilePresentation?>> _getClientProfiles() async {
-    final profiles = await Future.wait(
-      _matrixState.widget.clients.map((client) async {
-        final profileBundle = await client.fetchOwnProfile();
-        Logs().d(
-          'MultipleAccountsPicker::getProfileBundles() - ClientName - ${client.clientName}',
-        );
-        Logs().d(
-          'MultipleAccountsPicker::getProfileBundles() - UserId - ${client.userID}',
-        );
-        return ClientProfilePresentation(
-          profile: profileBundle,
-          client: client,
-        );
-      }),
-    );
-
-    return profiles.toList();
-  }
-
-  Future<List<TwakeChatPresentationAccount>> _getMultipleAccounts(
-    Client currentActiveClient,
-  ) async {
-    final profileBundles = await _getClientProfiles();
-    return profileBundles
-        .where((clientProfile) => clientProfile != null)
-        .map(
-          (clientProfile) => clientProfile!.toTwakeChatPresentationAccount(
-            currentActiveClient,
-          ),
-        )
-        .toList();
-  }
 
   void showMultipleAccountsPicker(
     Client currentActiveClient, {
     required VoidCallback onGoToAccountSettings,
   }) async {
-    final multipleAccount = await _getMultipleAccounts(
-      currentActiveClient,
-    );
-    multipleAccount.sort((pre, next) {
+    multipleAccounts.sort((pre, next) {
       return pre.accountActiveStatus.index
           .compareTo(next.accountActiveStatus.index);
     });
     MultipleAccountPicker.showMultipleAccountPicker(
-      accounts: multipleAccount,
+      accounts: multipleAccounts,
       context: context,
       onAddAnotherAccount: _onAddAnotherAccount,
       onGoToAccountSettings: onGoToAccountSettings,
-      onSetAccountAsActive: (account) => _onSetAccountAsActive.call(
-        multipleAccounts: multipleAccount,
+      onSetAccountAsActive: (account) => _onSetAccountAsActive(
+        multipleAccounts: multipleAccounts,
         account: account,
       ),
       titleAddAnotherAccount: L10n.of(context)!.addAnotherAccount,
@@ -113,11 +76,11 @@ class MultipleAccountsPickerController {
         )
         ?.clientAccount;
     if (client == null || client == _matrixState.client) return;
-    _setActiveClient(client);
+    await _setActiveClient(client);
   }
 
   void _onAddAnotherAccount() {
-    context.go(
+    context.push(
       '/rooms/addaccount',
       extra: const TwakeWelcomeArg(
         twakeIdType: TwakeWelcomeType.otherAccounts,
@@ -125,7 +88,7 @@ class MultipleAccountsPickerController {
     );
   }
 
-  void _setActiveClient(Client newClient) async {
+  Future<void> _setActiveClient(Client newClient) async {
     final result = await _matrixState.setActiveClient(newClient);
     if (result.isSuccess) {
       context.go(

--- a/lib/pages/multiple_accounts/multiple_accounts_picker.dart
+++ b/lib/pages/multiple_accounts/multiple_accounts_picker.dart
@@ -3,12 +3,10 @@ import 'package:fluffychat/pages/twake_welcome/twake_welcome.dart';
 import 'package:fluffychat/presentation/extensions/multiple_accounts/client_profile_extension.dart';
 import 'package:fluffychat/presentation/multiple_account/client_profile_presentation.dart';
 import 'package:fluffychat/presentation/multiple_account/twake_chat_presentation_account.dart';
-import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/widgets/layouts/agruments/switch_active_account_body_args.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/twake_components/twake_header_style.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:linagora_design_flutter/multiple_account/models/twake_presentation_account.dart';
@@ -82,10 +80,9 @@ class MultipleAccountsPickerController {
       titleAccountSettings: L10n.of(context)!.accountSettings,
       logoApp: Padding(
         padding: TwakeHeaderStyle.logoAppOfMultiplePadding,
-        child: SvgPicture.asset(
-          ImagePaths.icTwakeImageLogo,
-          width: TwakeHeaderStyle.logoAppOfMultipleWidth,
-          height: TwakeHeaderStyle.logoAppOfMultipleHeight,
+        child: Text(
+          L10n.of(context)!.selectAccount,
+          style: TwakeHeaderStyle.selectAccountTextStyle(context),
         ),
       ),
       accountNameStyle: Theme.of(context).textTheme.bodyLarge!.copyWith(

--- a/lib/pages/settings_dashboard/settings/settings.dart
+++ b/lib/pages/settings_dashboard/settings/settings.dart
@@ -306,6 +306,14 @@ class SettingsController extends State<Settings> with ConnectPageMixin {
   }
 
   @override
+  void didUpdateWidget(Settings oldWidget) {
+    if (oldWidget != widget) {
+      _getCurrentProfile(client);
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
   void dispose() {
     onAccountDataSubscription?.cancel();
     if (avatarUriNotifier.value != null) {

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_state/get_clients_ui_state.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_state/get_clients_ui_state.dart
@@ -1,0 +1,35 @@
+import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/app_state/success.dart';
+import 'package:fluffychat/presentation/multiple_account/twake_chat_presentation_account.dart';
+
+class GetClientsInitialUIState extends Success {
+  @override
+  List<Object?> get props => [];
+}
+
+class GetClientsLoadingUIState extends Success {
+  @override
+  List<Object?> get props => [];
+}
+
+class GetClientsSuccessUIState extends Success {
+  final List<TwakeChatPresentationAccount> multipleAccounts;
+
+  const GetClientsSuccessUIState({
+    required this.multipleAccounts,
+  });
+
+  bool get haveMultipleAccounts => multipleAccounts.length > 1;
+
+  @override
+  List<Object?> get props => [multipleAccounts];
+}
+
+class GetClientsFailureUIState extends Failure {
+  final dynamic exception;
+
+  const GetClientsFailureUIState({this.exception});
+
+  @override
+  List<Object?> get props => [exception];
+}

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_view.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_view.dart
@@ -88,9 +88,12 @@ class SettingsProfileView extends StatelessWidget {
                   client: controller.client,
                   settingsProfileUIState: controller.settingsProfileUIState,
                   onTapAvatar: controller.onTapAvatarInMobile,
-                  onBottomButtonTap: controller.onBottomButtonTap,
-                  haveMultipleAccountsNotifier:
-                      controller.haveMultipleAccountsNotifier,
+                  onTapMultipleAccountsButton: (multipleAccounts) =>
+                      controller.onBottomButtonTap(
+                    multipleAccounts: multipleAccounts,
+                  ),
+                  settingsMultiAccountsUIState:
+                      controller.settingsMultiAccountsUIState,
                   menuChildren: controller.listContextMenuBuilder(context),
                   menuController: controller.menuController,
                   settingsProfileOptions: ListView.separated(

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_view.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_view.dart
@@ -75,7 +75,7 @@ class SettingsProfileView extends StatelessWidget {
       backgroundColor: responsive.isWebDesktop(context)
           ? Theme.of(context).colorScheme.surface
           : LinagoraSysColors.material().onPrimary,
-      body: SingleChildScrollView(
+      body: Padding(
         padding: SettingsProfileViewStyle.paddingBody,
         child: SlotLayout(
           config: <Breakpoint, SlotLayoutConfig>{
@@ -88,6 +88,9 @@ class SettingsProfileView extends StatelessWidget {
                   client: controller.client,
                   settingsProfileUIState: controller.settingsProfileUIState,
                   onTapAvatar: controller.onTapAvatarInMobile,
+                  onBottomButtonTap: controller.onBottomButtonTap,
+                  haveMultipleAccountsNotifier:
+                      controller.haveMultipleAccountsNotifier,
                   menuChildren: controller.listContextMenuBuilder(context),
                   menuController: controller.menuController,
                   settingsProfileOptions: ListView.separated(

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_view_mobile.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_view_mobile.dart
@@ -12,13 +12,16 @@ import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
 import 'package:wechat_camera_picker/wechat_camera_picker.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 class SettingsProfileViewMobile extends StatelessWidget {
   final ValueNotifier<Either<Failure, Success>> settingsProfileUIState;
+  final VoidCallback onBottomButtonTap;
   final Widget settingsProfileOptions;
   final VoidCallback? onTapAvatar;
   final List<Widget>? menuChildren;
   final MenuController? menuController;
+  final ValueNotifier<bool> haveMultipleAccountsNotifier;
   final Client client;
 
   const SettingsProfileViewMobile({
@@ -27,6 +30,8 @@ class SettingsProfileViewMobile extends StatelessWidget {
     required this.onTapAvatar,
     required this.settingsProfileUIState,
     required this.client,
+    required this.onBottomButtonTap,
+    required this.haveMultipleAccountsNotifier,
     this.menuChildren,
     this.menuController,
   });
@@ -35,167 +40,218 @@ class SettingsProfileViewMobile extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        Divider(
-          height: SettingsProfileViewMobileStyle.dividerHeight,
-          color: LinagoraStateLayer(
-            LinagoraSysColors.material().surfaceTint,
-          ).opacityLayer3,
-        ),
-        Padding(
-          padding: SettingsProfileViewMobileStyle.padding,
-          child: Stack(
-            alignment: AlignmentDirectional.center,
-            children: [
-              const SizedBox(
-                width: SettingsProfileViewMobileStyle.widthSize,
-              ),
-              ValueListenableBuilder(
-                valueListenable: settingsProfileUIState,
-                builder: (context, uiState, child) => uiState.fold(
-                  (failure) => child!,
-                  (success) {
-                    if (success is GetAvatarInStreamUIStateSuccess &&
-                        PlatformInfos.isMobile) {
-                      if (success.assetEntity == null) {
-                        return child!;
-                      }
-                      return ClipOval(
-                        child: SizedBox.fromSize(
-                          size: const Size.fromRadius(
-                            AvatarStyle.defaultSize,
-                          ),
-                          child: AssetEntityImage(
-                            width: AvatarStyle.defaultSize,
-                            height: AvatarStyle.defaultSize,
-                            success.assetEntity!,
-                            thumbnailSize: const ThumbnailSize(
-                              SettingsProfileViewMobileStyle.thumbnailSize,
-                              SettingsProfileViewMobileStyle.thumbnailSize,
+        Column(
+          children: [
+            Divider(
+              height: SettingsProfileViewMobileStyle.dividerHeight,
+              color: LinagoraStateLayer(
+                LinagoraSysColors.material().surfaceTint,
+              ).opacityLayer3,
+            ),
+            Padding(
+              padding: SettingsProfileViewMobileStyle.padding,
+              child: Stack(
+                alignment: AlignmentDirectional.center,
+                children: [
+                  const SizedBox(
+                    width: SettingsProfileViewMobileStyle.widthSize,
+                  ),
+                  ValueListenableBuilder(
+                    valueListenable: settingsProfileUIState,
+                    builder: (context, uiState, child) => uiState.fold(
+                      (failure) => child!,
+                      (success) {
+                        if (success is GetAvatarInStreamUIStateSuccess &&
+                            PlatformInfos.isMobile) {
+                          if (success.assetEntity == null) {
+                            return child!;
+                          }
+                          return ClipOval(
+                            child: SizedBox.fromSize(
+                              size: const Size.fromRadius(
+                                AvatarStyle.defaultSize,
+                              ),
+                              child: AssetEntityImage(
+                                width: AvatarStyle.defaultSize,
+                                height: AvatarStyle.defaultSize,
+                                success.assetEntity!,
+                                thumbnailSize: const ThumbnailSize(
+                                  SettingsProfileViewMobileStyle.thumbnailSize,
+                                  SettingsProfileViewMobileStyle.thumbnailSize,
+                                ),
+                                fit: BoxFit.cover,
+                                loadingBuilder:
+                                    (context, child, loadingProgress) {
+                                  if (loadingProgress != null &&
+                                      loadingProgress.cumulativeBytesLoaded !=
+                                          loadingProgress.expectedTotalBytes) {
+                                    return const Center(
+                                      child:
+                                          CircularProgressIndicator.adaptive(),
+                                    );
+                                  }
+                                  return child;
+                                },
+                                errorBuilder: (context, error, stackTrace) {
+                                  return const Center(
+                                    child: Icon(Icons.error_outline),
+                                  );
+                                },
+                              ),
                             ),
-                            fit: BoxFit.cover,
-                            loadingBuilder: (context, child, loadingProgress) {
-                              if (loadingProgress != null &&
-                                  loadingProgress.cumulativeBytesLoaded !=
-                                      loadingProgress.expectedTotalBytes) {
-                                return const Center(
-                                  child: CircularProgressIndicator.adaptive(),
-                                );
-                              }
-                              return child;
-                            },
-                            errorBuilder: (context, error, stackTrace) {
-                              return const Center(
-                                child: Icon(Icons.error_outline),
-                              );
-                            },
-                          ),
-                        ),
-                      );
-                    }
-                    if (success is GetAvatarInBytesUIStateSuccess &&
-                        PlatformInfos.isWeb) {
-                      if (success.filePickerResult == null ||
-                          success.filePickerResult?.files.single.bytes ==
-                              null) {
-                        return child!;
-                      }
-                      return ClipOval(
-                        child: SizedBox.fromSize(
-                          size: const Size.fromRadius(
-                            AvatarStyle.defaultSize,
-                          ),
-                          child: Image.memory(
-                            success.filePickerResult!.files.single.bytes!,
-                            fit: BoxFit.cover,
-                            errorBuilder: (context, error, stackTrace) {
-                              return const Center(
-                                child: Icon(Icons.error_outline),
-                              );
-                            },
-                          ),
-                        ),
-                      );
-                    }
-                    if (success is GetProfileUIStateSuccess) {
-                      final displayName = success.profile.displayName ??
-                          client.mxid(context).localpart ??
-                          client.mxid(context);
-                      return Material(
-                        elevation: Theme.of(context)
-                                .appBarTheme
-                                .scrolledUnderElevation ??
-                            4,
-                        shadowColor: Theme.of(context).appBarTheme.shadowColor,
-                        shape: RoundedRectangleBorder(
-                          side: BorderSide(
-                            color: Theme.of(context).dividerColor,
-                          ),
-                          borderRadius: BorderRadius.circular(
-                            AvatarStyle.defaultSize,
-                          ),
-                        ),
-                        child: Avatar(
-                          mxContent: success.profile.avatarUrl,
-                          name: displayName,
-                          size: SettingsProfileViewMobileStyle.avatarSize,
-                          fontSize:
-                              SettingsProfileViewMobileStyle.avatarFontSize,
-                        ),
-                      );
-                    }
-                    return child!;
-                  },
-                ),
-                child: const SizedBox.shrink(),
-              ),
-              Positioned(
-                bottom: SettingsProfileViewMobileStyle.positionedBottomSize,
-                right: SettingsProfileViewMobileStyle.positionedRightSize,
-                child: MenuAnchor(
-                  controller: menuController,
-                  builder: (
-                    BuildContext context,
-                    MenuController menuController,
-                    Widget? child,
-                  ) {
-                    return GestureDetector(
-                      onTap: () {
-                        if (PlatformInfos.isWeb) {
-                          menuController.isOpen
-                              ? menuController.close()
-                              : menuController.open();
-                        } else {
-                          onTapAvatar?.call();
+                          );
                         }
+                        if (success is GetAvatarInBytesUIStateSuccess &&
+                            PlatformInfos.isWeb) {
+                          if (success.filePickerResult == null ||
+                              success.filePickerResult?.files.single.bytes ==
+                                  null) {
+                            return child!;
+                          }
+                          return ClipOval(
+                            child: SizedBox.fromSize(
+                              size: const Size.fromRadius(
+                                AvatarStyle.defaultSize,
+                              ),
+                              child: Image.memory(
+                                success.filePickerResult!.files.single.bytes!,
+                                fit: BoxFit.cover,
+                                errorBuilder: (context, error, stackTrace) {
+                                  return const Center(
+                                    child: Icon(Icons.error_outline),
+                                  );
+                                },
+                              ),
+                            ),
+                          );
+                        }
+                        if (success is GetProfileUIStateSuccess) {
+                          final displayName = success.profile.displayName ??
+                              client.mxid(context).localpart ??
+                              client.mxid(context);
+                          return Material(
+                            elevation: Theme.of(context)
+                                    .appBarTheme
+                                    .scrolledUnderElevation ??
+                                4,
+                            shadowColor:
+                                Theme.of(context).appBarTheme.shadowColor,
+                            shape: RoundedRectangleBorder(
+                              side: BorderSide(
+                                color: Theme.of(context).dividerColor,
+                              ),
+                              borderRadius: BorderRadius.circular(
+                                AvatarStyle.defaultSize,
+                              ),
+                            ),
+                            child: Avatar(
+                              mxContent: success.profile.avatarUrl,
+                              name: displayName,
+                              size: SettingsProfileViewMobileStyle.avatarSize,
+                              fontSize:
+                                  SettingsProfileViewMobileStyle.avatarFontSize,
+                            ),
+                          );
+                        }
+                        return child!;
                       },
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.primary,
-                          borderRadius: BorderRadius.circular(
-                            SettingsProfileViewMobileStyle.avatarSize,
+                    ),
+                    child: const SizedBox.shrink(),
+                  ),
+                  Positioned(
+                    bottom: SettingsProfileViewMobileStyle.positionedBottomSize,
+                    right: SettingsProfileViewMobileStyle.positionedRightSize,
+                    child: MenuAnchor(
+                      controller: menuController,
+                      builder: (
+                        BuildContext context,
+                        MenuController menuController,
+                        Widget? child,
+                      ) {
+                        return GestureDetector(
+                          onTap: () {
+                            if (PlatformInfos.isWeb) {
+                              menuController.isOpen
+                                  ? menuController.close()
+                                  : menuController.open();
+                            } else {
+                              onTapAvatar?.call();
+                            }
+                          },
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Theme.of(context).colorScheme.primary,
+                              borderRadius: BorderRadius.circular(
+                                SettingsProfileViewMobileStyle.avatarSize,
+                              ),
+                              border: Border.all(
+                                color: Theme.of(context).colorScheme.onPrimary,
+                                width: SettingsProfileViewMobileStyle
+                                    .iconEditBorderWidth,
+                              ),
+                            ),
+                            padding:
+                                SettingsProfileViewMobileStyle.editIconPadding,
+                            child: Icon(
+                              Icons.edit,
+                              size: SettingsProfileViewMobileStyle.iconEditSize,
+                              color: Theme.of(context).colorScheme.onPrimary,
+                            ),
                           ),
-                          border: Border.all(
-                            color: Theme.of(context).colorScheme.onPrimary,
-                            width: SettingsProfileViewMobileStyle
-                                .iconEditBorderWidth,
-                          ),
-                        ),
-                        padding: SettingsProfileViewMobileStyle.editIconPadding,
-                        child: Icon(
-                          Icons.edit,
-                          size: SettingsProfileViewMobileStyle.iconEditSize,
-                          color: Theme.of(context).colorScheme.onPrimary,
-                        ),
-                      ),
-                    );
-                  },
-                  menuChildren: menuChildren ?? [],
-                ),
+                        );
+                      },
+                      menuChildren: menuChildren ?? [],
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
+            settingsProfileOptions,
+          ],
+        ),
+        const Expanded(child: SizedBox()),
+        InkWell(
+          onTap: onBottomButtonTap,
+          child: Container(
+            width: double.infinity,
+            height: SettingsProfileViewMobileStyle.bottomButtonHeight,
+            padding: SettingsProfileViewMobileStyle.paddingBottomButton,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(
+                SettingsProfileViewMobileStyle.bottomButtonRadius,
+              ),
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            alignment: Alignment.center,
+            child: ValueListenableBuilder(
+              valueListenable: haveMultipleAccountsNotifier,
+              builder: (context, haveMultipleAccounts, child) {
+                return Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      haveMultipleAccounts
+                          ? Icons.group_outlined
+                          : Icons.person_add_alt_outlined,
+                      size: SettingsProfileViewMobileStyle.iconSize,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    SettingsProfileViewMobileStyle.paddingIconAndText,
+                    Text(
+                      haveMultipleAccounts
+                          ? L10n.of(context)!.switchAccounts
+                          : L10n.of(context)!.addAnotherAccount,
+                      style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                            color: Theme.of(context).colorScheme.onPrimary,
+                          ),
+                    ),
+                  ],
+                );
+              },
+            ),
           ),
         ),
-        settingsProfileOptions,
+        SettingsProfileViewMobileStyle.paddingBottomBottomButton,
       ],
     );
   }

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_view_mobile_style.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_view_mobile_style.dart
@@ -19,10 +19,11 @@ class SettingsProfileViewMobileStyle {
 
   static const bottomButtonHeight = 48.0;
   static const paddingBottomButton = EdgeInsets.only(left: 16.0, right: 16.0);
+  static const marginBottomButton = EdgeInsets.only(bottom: 32.0);
   static const bottomButtonRadius = 100.0;
   static const iconSize = 18.0;
+  static const indicatorStrokeWidth = 2.0;
+  static const indicatorScale = 0.7;
 
   static const paddingIconAndText = SizedBox(width: 8.0);
-
-  static const paddingBottomBottomButton = SizedBox(height: 32.0);
 }

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_view_mobile_style.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_view_mobile_style.dart
@@ -16,4 +16,13 @@ class SettingsProfileViewMobileStyle {
 
   static EdgeInsetsDirectional editIconPadding =
       const EdgeInsetsDirectional.all(8);
+
+  static const bottomButtonHeight = 48.0;
+  static const paddingBottomButton = EdgeInsets.only(left: 16.0, right: 16.0);
+  static const bottomButtonRadius = 100.0;
+  static const iconSize = 18.0;
+
+  static const paddingIconAndText = SizedBox(width: 8.0);
+
+  static const paddingBottomBottomButton = SizedBox(height: 32.0);
 }

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_view_web.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_view_web.dart
@@ -34,7 +34,8 @@ class SettingsProfileViewWeb extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: SettingsProfileViewWebStyle.paddingBody,
-      child: Center(
+      child: Align(
+        alignment: Alignment.topCenter,
         child: SingleChildScrollView(
           physics: const NeverScrollableScrollPhysics(),
           child: Column(

--- a/lib/widgets/avatar/avatar.dart
+++ b/lib/widgets/avatar/avatar.dart
@@ -45,6 +45,7 @@ class Avatar extends StatelessWidget {
           height: size,
           cacheWidth: (size * MediaQuery.devicePixelRatioOf(context)).round(),
           cacheKey: mxContent.toString(),
+          animated: true,
           placeholder: (context) => _fallbackAvatar(),
         ),
       ),

--- a/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body.dart
+++ b/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body_view.dart';
 import 'package:fluffychat/widgets/layouts/agruments/app_adaptive_scaffold_body_args.dart';
 import 'package:fluffychat/widgets/layouts/agruments/logout_body_args.dart';
+import 'package:fluffychat/widgets/layouts/agruments/switch_active_account_body_args.dart';
 import 'package:fluffychat/widgets/layouts/enum/adaptive_destinations_enum.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
@@ -114,16 +115,13 @@ class AppAdaptiveScaffoldBodyController extends State<AppAdaptiveScaffoldBody>
   }
 
   void _handleLogout(AppAdaptiveScaffoldBody oldWidget) {
-    Logs().d(
-      'AppAdaptiveScaffoldBodyController::_onLogoutMultipleAccountSuccess():oldWidget - ${oldWidget.args}',
-    );
-    Logs().d(
-      'AppAdaptiveScaffoldBodyController::_onLogoutMultipleAccountSuccess():newWidget - ${widget.args}',
-    );
-    if (oldWidget.args != widget.args && widget.args is LogoutBodyArgs) {
-      activeNavigationBarNotifier.value = AdaptiveDestinationEnum.rooms;
-      pageController.jumpToPage(AdaptiveDestinationEnum.rooms.index);
-    }
+    activeNavigationBarNotifier.value = AdaptiveDestinationEnum.rooms;
+    pageController.jumpToPage(AdaptiveDestinationEnum.rooms.index);
+  }
+
+  void _handleSwitchAccount(AppAdaptiveScaffoldBody oldWidget) {
+    activeNavigationBarNotifier.value = AdaptiveDestinationEnum.rooms;
+    pageController.jumpToPage(AdaptiveDestinationEnum.rooms.index);
   }
 
   MatrixState get matrix => Matrix.of(context);
@@ -138,7 +136,20 @@ class AppAdaptiveScaffoldBodyController extends State<AppAdaptiveScaffoldBody>
   @override
   void didUpdateWidget(covariant AppAdaptiveScaffoldBody oldWidget) {
     activeRoomIdNotifier.value = widget.activeRoomId;
-    _handleLogout(oldWidget);
+    Logs().d(
+      'AppAdaptiveScaffoldBodyController::didUpdateWidget():oldWidget - ${oldWidget.args}',
+    );
+    Logs().d(
+      'AppAdaptiveScaffoldBodyController::didUpdateWidget():newWidget - ${widget.args}',
+    );
+    if (oldWidget.args != widget.args && widget.args is LogoutBodyArgs) {
+      _handleLogout(oldWidget);
+    }
+
+    if (oldWidget.args != widget.args &&
+        widget.args is SwitchActiveAccountBodyArgs) {
+      _handleSwitchAccount(oldWidget);
+    }
     super.didUpdateWidget(oldWidget);
   }
 

--- a/lib/widgets/twake_components/twake_header_style.dart
+++ b/lib/widgets/twake_components/twake_header_style.dart
@@ -1,6 +1,6 @@
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 class TwakeHeaderStyle {
   static ResponsiveUtils responsive = getIt.get<ResponsiveUtils>();
@@ -16,8 +16,6 @@ class TwakeHeaderStyle {
 
   static double get avatarFontSizeInAppBar => 14.0;
   static const double avatarOfMultipleAccountSize = 48.0;
-  static const double logoAppOfMultipleHeight = 28.0;
-  static const double logoAppOfMultipleWidth = 152.0;
 
   static bool isDesktop(BuildContext context) => responsive.isDesktop(context);
 
@@ -46,4 +44,9 @@ class TwakeHeaderStyle {
 
   static const EdgeInsetsDirectional counterSelectionPadding =
       EdgeInsetsDirectional.only(start: 4);
+
+  static TextStyle? selectAccountTextStyle(BuildContext context) =>
+      Theme.of(context).textTheme.titleLarge?.copyWith(
+            color: Theme.of(context).colorScheme.onSurface,
+          );
 }


### PR DESCRIPTION
### Root cause:
The currentProfileNotifier is updated multiple times during the build of chat list, and when its first build, the `_activeClient` default is first client in the all clients.

-> Solution: move `currentProfileNotifier` to only the TwakeHeader, and make sure it avatar updated only one if have the new change in avatar or the inital build. Add the condition for check the `_activeClient` for update the avatar correctly

### Resolved (23 - May)


https://github.com/linagora/twake-on-matrix/assets/99852347/db435564-50bf-4998-b886-3e3109f6b1d6

- Switch and logout


https://github.com/linagora/twake-on-matrix/assets/99852347/d5b83890-204e-42d4-a0da-42661bbbfe25


