### PR TITLE
TW-1240: Use try catch for `ValueNotifier`

### DIFF
--- a/lib/pages/chat/chat_pinned_events/pinned_events_controller.dart
+++ b/lib/pages/chat/chat_pinned_events/pinned_events_controller.dart
@@ -46,25 +46,31 @@ class PinnedEventsController {
       isInitial: isInitial,
     )
         .listen((event) {
-      getPinnedMessageNotifier.value = event;
-      event.fold((_) => null, (success) {
-        if (success is ChatGetPinnedEventsSuccess) {
-          if (success.pinnedEvents.isNotEmpty) {
-            if (isInitial || isUnpin) {
-              updatePinnedMessage(
-                success.pinnedEvents,
-                jumpToPinnedMessageCallback: jumpToPinnedMessageCallback,
-              );
-            } else {
-              jumpToCurrentMessage(
-                success.pinnedEvents,
-                eventId: eventId,
-                jumpToPinnedMessageCallback: jumpToPinnedMessageCallback,
-              );
+      try {
+        getPinnedMessageNotifier.value = event;
+        event.fold((_) => null, (success) {
+          if (success is ChatGetPinnedEventsSuccess) {
+            if (success.pinnedEvents.isNotEmpty) {
+              if (isInitial || isUnpin) {
+                updatePinnedMessage(
+                  success.pinnedEvents,
+                  jumpToPinnedMessageCallback: jumpToPinnedMessageCallback,
+                );
+              } else {
+                jumpToCurrentMessage(
+                  success.pinnedEvents,
+                  eventId: eventId,
+                  jumpToPinnedMessageCallback: jumpToPinnedMessageCallback,
+                );
+              }
             }
           }
-        }
-      });
+        });
+      } on FlutterError catch (error) {
+        Logs().e(
+          "PinnedEventsController()::getPinnedMessageAction(): FlutterError: $error",
+        );
+      }
     });
   }
 

--- a/lib/pages/chat/input_bar/focus_suggestion_controller.dart
+++ b/lib/pages/chat/input_bar/focus_suggestion_controller.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
 
 class FocusSuggestionController {
   List<Map<String, String?>> _suggestions = List.empty();
@@ -15,16 +16,28 @@ class FocusSuggestionController {
   final currentIndex = ValueNotifier(0);
 
   void up() {
-    currentIndex.value--;
-    if (currentIndex.value < 0) {
-      currentIndex.value = _suggestions.length - 1;
+    try {
+      currentIndex.value--;
+      if (currentIndex.value < 0) {
+        currentIndex.value = _suggestions.length - 1;
+      }
+    } on FlutterError catch (error) {
+      Logs().e(
+        "FocusSuggestionController()::up(): FlutterError: $error",
+      );
     }
   }
 
   void down() {
-    currentIndex.value++;
-    if (currentIndex.value >= _suggestions.length) {
-      currentIndex.value = 0;
+    try {
+      currentIndex.value++;
+      if (currentIndex.value >= _suggestions.length) {
+        currentIndex.value = 0;
+      }
+    } on FlutterError catch (error) {
+      Logs().e(
+        "FocusSuggestionController()::down(): FlutterError: $error",
+      );
     }
   }
 


### PR DESCRIPTION
### Ticket 

- #1240

### Resolved
- When I disposed of a `ValueNotifier` but still listen to value from it. So need to check if a `ValueNotifier` has been disposed, you can use a try-catch block to catch the `FlutterError` that is thrown when you try to access a disposed `ValueNotifier`.