### PR TITLE
hot-fix: reenable context menu in mobile and other devices

### DIFF
--- a/lib/pages/chat/input_bar/input_bar.dart
+++ b/lib/pages/chat/input_bar/input_bar.dart
@@ -403,7 +403,12 @@ class InputBar extends StatelessWidget with PasteImageMixin {
                 onChanged!(text);
               }
             },
-            contextMenuBuilder: null,
+            contextMenuBuilder: PlatformInfos.isWeb
+                ? null
+                : (_, editableTextState) =>
+                    AdaptiveTextSelectionToolbar.editableText(
+                      editableTextState: editableTextState,
+                    ),
             onTap: () async {
               await Future.delayed(debounceDurationTap);
               FocusScope.of(context).requestFocus(focusNode);


### PR DESCRIPTION
### Desc:
- enable the context menu on mobile, because it's sometimes convenient.
- disable in web because of the limited in copy/paste


### Demo: 

https://github.com/linagora/twake-on-matrix/assets/43041967/77ec244c-bb1f-4654-90ca-624f9c1d3e0b

