### PR TITLE
TW-1308: crash app when reject the invitation

### DIFF
--- a/lib/pages/chat/dialog_reject_invite_widget.dart
+++ b/lib/pages/chat/dialog_reject_invite_widget.dart
@@ -1,5 +1,4 @@
 import 'package:fluffychat/pages/chat/dialog_reject_invite_style.dart';
-import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -17,84 +16,73 @@ class DialogRejectInviteWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Material(
       color: Colors.transparent,
-      child: PopScope(
-        canPop: false,
-        onPopInvoked: (didPop) async {
-          if (PlatformInfos.isWeb) {
-            return;
-          }
-          Navigator.of(context).pop(DialogRejectInviteResult.cancel);
-        },
-        child: Center(
-          child: UnconstrainedBox(
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(
-                  DialogAcceptInviteStyle.borderRadiusDialog,
+      child: Center(
+        child: UnconstrainedBox(
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(
+                DialogAcceptInviteStyle.borderRadiusDialog,
+              ),
+              color: Theme.of(context).colorScheme.surface,
+            ),
+            margin: DialogAcceptInviteStyle.marginDialog,
+            padding: DialogAcceptInviteStyle.paddingDialog,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Padding(
+                  padding: DialogAcceptInviteStyle.paddingTitle,
+                  child: Column(
+                    children: [
+                      Text(
+                        L10n.of(context)!.declineTheInvitation,
+                        style: Theme.of(context)
+                            .textTheme
+                            .headlineSmall
+                            ?.copyWith(
+                              color: Theme.of(context).colorScheme.onSurface,
+                            ),
+                      ),
+                      const SizedBox(height: 16.0),
+                      SizedBox(
+                        width: DialogAcceptInviteStyle.dialogTextWidth,
+                        child: Text(
+                          L10n.of(context)!
+                              .doYouReallyWantToDeclineThisInvitation,
+                          style:
+                              Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurfaceVariant,
+                                  ),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-                color: Theme.of(context).colorScheme.surface,
-              ),
-              margin: DialogAcceptInviteStyle.marginDialog,
-              padding: DialogAcceptInviteStyle.paddingDialog,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Padding(
-                    padding: DialogAcceptInviteStyle.paddingTitle,
-                    child: Column(
-                      children: [
-                        Text(
-                          L10n.of(context)!.declineTheInvitation,
-                          style: Theme.of(context)
-                              .textTheme
-                              .headlineSmall
-                              ?.copyWith(
-                                color: Theme.of(context).colorScheme.onSurface,
-                              ),
-                        ),
-                        const SizedBox(height: 16.0),
-                        SizedBox(
-                          width: DialogAcceptInviteStyle.dialogTextWidth,
-                          child: Text(
-                            L10n.of(context)!
-                                .doYouReallyWantToDeclineThisInvitation,
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyMedium
-                                ?.copyWith(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .onSurfaceVariant,
-                                ),
-                          ),
-                        ),
-                      ],
-                    ),
+                Padding(
+                  padding: DialogAcceptInviteStyle.paddingButton,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _ActionButton(
+                        context: context,
+                        text: L10n.of(context)!.declineAndRemove,
+                        onPressed: () => Navigator.of(context)
+                            .pop(DialogRejectInviteResult.reject),
+                      ),
+                      const SizedBox(width: 8),
+                      _ActionButton(
+                        context: context,
+                        text: L10n.of(context)!.cancel,
+                        onPressed: () => Navigator.of(context)
+                            .pop(DialogRejectInviteResult.cancel),
+                      ),
+                    ],
                   ),
-                  Padding(
-                    padding: DialogAcceptInviteStyle.paddingButton,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        _ActionButton(
-                          context: context,
-                          text: L10n.of(context)!.declineAndRemove,
-                          onPressed: () => Navigator.of(context)
-                              .pop(DialogRejectInviteResult.reject),
-                        ),
-                        const SizedBox(width: 8),
-                        _ActionButton(
-                          context: context,
-                          text: L10n.of(context)!.cancel,
-                          onPressed: () => Navigator.of(context)
-                              .pop(DialogRejectInviteResult.cancel),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ),

--- a/lib/pages/chat_search/chat_search_view.dart
+++ b/lib/pages/chat_search/chat_search_view.dart
@@ -39,7 +39,7 @@ class ChatSearchView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      canPop: true,
+      canPop: false,
       onPopInvoked: (isPop) async {
         if (PlatformInfos.isAndroid) {
           controller.onBack();

--- a/lib/pages/forward/forward_view.dart
+++ b/lib/pages/forward/forward_view.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/pages/forward/forward.dart';
 import 'package:fluffychat/pages/forward/recent_chat_list.dart';
 import 'package:fluffychat/pages/forward/recent_chat_title.dart';
 import 'package:fluffychat/pages/forward/forward_view_style.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/twake_components/twake_fab.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:fluffychat/resource/image_paths.dart';
@@ -35,9 +36,11 @@ class ForwardView extends StatelessWidget {
         ),
       ),
       body: PopScope(
-        canPop: true,
+        canPop: false,
         onPopInvoked: (didPop) async {
-          controller.popScreen();
+          if (PlatformInfos.isAndroid) {
+            controller.popScreen();
+          }
         },
         child: SingleChildScrollView(
           padding:

--- a/lib/pages/search/search_view.dart
+++ b/lib/pages/search/search_view.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/pages/search/search_view_style.dart';
 import 'package:fluffychat/pages/search/server_search_view.dart';
 import 'package:fluffychat/presentation/model/search/presentation_server_side_empty_search.dart';
 import 'package:fluffychat/presentation/model/search/presentation_server_side_search.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:fluffychat/widgets/twake_components/twake_loading/center_loading_indicator.dart';
 import 'package:flutter/material.dart' hide SearchController;
@@ -27,9 +28,11 @@ class SearchView extends StatelessWidget {
         child: _buildAppBarSearch(context),
       ),
       body: PopScope(
-        canPop: true,
+        canPop: false,
         onPopInvoked: (didPop) async {
-          searchController.goToRoomsShellBranch();
+          if (PlatformInfos.isAndroid) {
+            searchController.goToRoomsShellBranch();
+          }
         },
         child: CustomScrollView(
           physics: const ClampingScrollPhysics(),


### PR DESCRIPTION
### Root cause:
- #1308 
- The PopScope widget, within its onPopInvoked method (triggered as the page exits the screen), contains a redundant call to Navigator.pop(). This call should be exclusively reserved for instances where the user initiates a predictive back action on Android (identified by didPop = true).
### Demo:
- Firefox:

https://github.com/linagora/twake-on-matrix/assets/43041967/bae6acb8-4939-4b60-9e8d-a679f86e15fa


- Safari:

https://github.com/linagora/twake-on-matrix/assets/43041967/85052f56-1133-4f44-a89d-5eece26d3c61


- Chrome:

https://github.com/linagora/twake-on-matrix/assets/43041967/6bf796cf-c44c-429b-9246-bef841a9e9dc


- Android:

https://github.com/linagora/twake-on-matrix/assets/43041967/a022d29b-c053-472a-b543-dbc40844fae4





- IOS:

https://github.com/linagora/twake-on-matrix/assets/43041967/6a39442b-e376-4eaa-ad59-b6003523b24c

