### PR TITLE
[TW-1153] Duplicated contacts from device's address book

### DIFF
--- a/lib/data/datasource_impl/contact/phonebook_contact_datasource_impl.dart
+++ b/lib/data/datasource_impl/contact/phonebook_contact_datasource_impl.dart
@@ -7,7 +7,8 @@ class PhonebookContactDatasourceImpl implements PhonebookContactDatasource {
   Future<List<Contact>> fetchContacts() async {
     final phonebookContacts =
         await FlutterContacts.getContacts(withProperties: true);
-    return phonebookContacts
+
+    final listAllContacts = phonebookContacts
         .expand(
           (contact) => [
             ...contact.emails.map(
@@ -25,5 +26,45 @@ class PhonebookContactDatasourceImpl implements PhonebookContactDatasource {
           ],
         )
         .toList();
+
+    return removeDuplicatedPhoneNumbers(listAllContacts);
+  }
+
+  List<Contact> removeDuplicatedPhoneNumbers(List<Contact> listContacts) {
+    final listVisitedPhoneNumbers = <String>[];
+    final listFilteredContacts = <Contact>[];
+
+    for (final contact in listContacts) {
+      final phoneNumber = contact.phoneNumber;
+      if (phoneNumber != null) {
+        final normalizedPhoneNumber = normalizePhoneNumber(phoneNumber);
+        if (listVisitedPhoneNumbers.contains(normalizedPhoneNumber)) {
+          final contactsWithSamePhoneNumber =
+              listFilteredContacts.where((filteredContact) {
+            final filteredPhoneNumber = filteredContact.phoneNumber;
+            if (filteredPhoneNumber != null) {
+              return filteredContact.displayName == contact.displayName &&
+                  normalizePhoneNumber(filteredPhoneNumber) ==
+                      normalizedPhoneNumber;
+            }
+            return false;
+          });
+          if (contactsWithSamePhoneNumber.isEmpty) {
+            listFilteredContacts.add(contact);
+          } else {
+            continue;
+          }
+        } else {
+          listVisitedPhoneNumbers.add(normalizedPhoneNumber);
+          listFilteredContacts.add(contact);
+        }
+      }
+    }
+
+    return listFilteredContacts;
+  }
+
+  String normalizePhoneNumber(String phoneNumber) {
+    return phoneNumber.replaceAll(RegExp(r'\D'), '');
   }
 }

--- a/lib/utils/string_extension.dart
+++ b/lib/utils/string_extension.dart
@@ -337,4 +337,8 @@ extension StringCasingExtension on String {
   String get sha256Hash {
     return sha256.convert(utf8.encode(this)).toString();
   }
+
+  String normalizePhoneNumber() {
+    return replaceAll(RegExp(r'\D'), '');
+  }
 }

--- a/test/data/datasource_impl/contact/phonebook_contact_datasource_impl_test.dart
+++ b/test/data/datasource_impl/contact/phonebook_contact_datasource_impl_test.dart
@@ -1,0 +1,190 @@
+import 'package:fluffychat/data/datasource_impl/contact/phonebook_contact_datasource_impl.dart';
+import 'package:fluffychat/domain/model/contact/contact.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late PhonebookContactDatasourceImpl dataSource;
+  const MethodChannel channel =
+      MethodChannel('github.com/QuisApp/flutter_contacts');
+
+  group('[PhonebookContactDatasourceImpl]', () {
+    final listAllContacts = [
+      {
+        'displayName': 'Alice',
+        'phones': [
+          {'number': '(212)555-6789'},
+          {'number': '2125556789'},
+        ],
+      },
+      {
+        'displayName': 'Bob',
+        'phones': [
+          {'number': '2124678190'},
+          {'number': '(212)467-8190'},
+        ],
+      },
+      {
+        'displayName': 'Charlie',
+        'phones': [
+          {'number': '212 555-6789'},
+          {'number': '2125556789'},
+        ],
+      },
+      {
+        'displayName': 'David',
+        'phones': [
+          {'number': '2124678190'},
+          {'number': '212 467-8190'},
+        ],
+      },
+      {
+        'displayName': 'Eve',
+        'phones': [
+          {'number': '+1.123.456.7890'},
+          {'number': '11234567890'},
+        ],
+      },
+      {
+        'displayName': 'Frank',
+        'phones': [
+          {'number': '81234977890'},
+          {'number': '+8.123.497.7890'},
+        ],
+      },
+      {
+        'displayName': 'Grace',
+        'phones': [
+          {'number': '+1 (800)-555-1234 ext. 123'},
+          {'number': '18005551234123'},
+        ],
+      },
+      {
+        'displayName': 'Hank',
+        'phones': [
+          {'number': '18005879106234'},
+          {'number': '+1 (800)-587-9106 ext. 234'},
+        ],
+      },
+      {
+        'displayName': 'Ivy',
+        'phones': [
+          {'number': '+1 (800)-555.1234'},
+          {'number': '18005551234'},
+        ],
+      },
+      {
+        'displayName': 'Karl',
+        'phones': [
+          {'number': '18005873456'},
+          {'number': '+1 (800)-587.3456'},
+        ],
+      },
+      {
+        'displayName': 'Liam',
+        'phones': [
+          {'number': '(212) 555-6789'},
+          {'number': '2125556789'},
+        ],
+      },
+      {
+        'displayName': 'Mia',
+        'phones': [
+          {'number': '2125556789'},
+          {'number': '(212) 555-6789'},
+        ],
+      },
+      {
+        'displayName': 'Nina',
+        'emails': [
+          {
+            'address': 'nina@domain.com',
+          }
+        ],
+      }
+    ];
+
+    setUp(() {
+      final getIt = GetIt.instance;
+      getIt.registerFactory(
+        () => PhonebookContactDatasourceImpl(),
+      );
+      dataSource = getIt.get<PhonebookContactDatasourceImpl>();
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        if (methodCall.method == 'select') {
+          return listAllContacts;
+        }
+        return null;
+      });
+    });
+
+    test(
+        'fetchContacts should return a list of contacts without duplicated phone number',
+        () async {
+      final List<Contact> expectedListContact = [
+        const Contact(
+          displayName: 'Alice',
+          phoneNumber: '(212)555-6789',
+        ),
+        const Contact(
+          displayName: 'Bob',
+          phoneNumber: '2124678190',
+        ),
+        const Contact(
+          displayName: 'Charlie',
+          phoneNumber: '212 555-6789',
+        ),
+        const Contact(
+          displayName: 'David',
+          phoneNumber: '2124678190',
+        ),
+        const Contact(
+          displayName: 'Eve',
+          phoneNumber: '+1.123.456.7890',
+        ),
+        const Contact(
+          displayName: 'Frank',
+          phoneNumber: '81234977890',
+        ),
+        const Contact(
+          displayName: 'Grace',
+          phoneNumber: '+1 (800)-555-1234 ext. 123',
+        ),
+        const Contact(
+          displayName: 'Hank',
+          phoneNumber: '18005879106234',
+        ),
+        const Contact(
+          displayName: 'Ivy',
+          phoneNumber: '+1 (800)-555.1234',
+        ),
+        const Contact(
+          displayName: 'Karl',
+          phoneNumber: '18005873456',
+        ),
+        const Contact(
+          displayName: 'Liam',
+          phoneNumber: '(212) 555-6789',
+        ),
+        const Contact(
+          displayName: 'Mia',
+          phoneNumber: '2125556789',
+        ),
+        const Contact(
+          displayName: 'Nina',
+          email: 'nina@domain.com',
+        ),
+      ];
+
+      final result = await dataSource.fetchContacts();
+
+      expect(result, isA<List<Contact>>());
+      expect(result, equals(expectedListContact));
+    });
+  });
+}

--- a/test/utils/string_extension_test.dart
+++ b/test/utils/string_extension_test.dart
@@ -1,0 +1,52 @@
+import 'package:fluffychat/utils/string_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('[normalizePhoneNumber]', () {
+    test('should return phone number without any Hyphens or Parentheses', () {
+      const phoneNumber = '(212)555-6789';
+      const expectedPhoneNumber = '2125556789';
+
+      final result = phoneNumber.normalizePhoneNumber();
+
+      expect(result, equals(expectedPhoneNumber));
+    });
+
+    test('should return phone number without any Spaces or Dashes', () {
+      const phoneNumber = '212 555-6789';
+      const expectedPhoneNumber = '2125556789';
+
+      final result = phoneNumber.normalizePhoneNumber();
+
+      expect(result, equals(expectedPhoneNumber));
+    });
+
+    test('should return phone number without any Plus Sign or Dots', () {
+      const phoneNumber = '+1.123.456.7890';
+      const expectedPhoneNumber = '11234567890';
+
+      final result = phoneNumber.normalizePhoneNumber();
+
+      expect(result, equals(expectedPhoneNumber));
+    });
+
+    test('should return phone number without any Country Code or Extension',
+        () {
+      const phoneNumber = '+1 (800)-555-1234 ext. 123';
+      const expectedPhoneNumber = '18005551234123';
+
+      final result = phoneNumber.normalizePhoneNumber();
+
+      expect(result, equals(expectedPhoneNumber));
+    });
+
+    test('should return phone number without any special characters', () {
+      const phoneNumber = '+1 (800)-555.1234 ext. 325';
+      const expectedPhoneNumber = '18005551234325';
+
+      final result = phoneNumber.normalizePhoneNumber();
+
+      expect(result, equals(expectedPhoneNumber));
+    });
+  });
+}


### PR DESCRIPTION
## Ticket
- #1153 
- Duplicated contacts:
![photo_1_2024-02-23_09-22-45](https://github.com/linagora/twake-on-matrix/assets/80142234/89f75385-eafc-47f0-b72c-7e111a8a169c)
![photo_2_2024-02-23_09-22-45](https://github.com/linagora/twake-on-matrix/assets/80142234/de0280c1-b095-471a-83d1-6aa10c2b91e0)
![photo_3_2024-02-23_09-22-45](https://github.com/linagora/twake-on-matrix/assets/80142234/52d9ce72-2738-48e6-bcb4-1fcb2344910e)
![photo_4_2024-02-23_09-22-45](https://github.com/linagora/twake-on-matrix/assets/80142234/449eca1e-50f7-4f6f-85fa-4a963f7f1f4f)
![photo_5_2024-02-23_09-22-45](https://github.com/linagora/twake-on-matrix/assets/80142234/c53477a2-d44c-4417-aa92-bc2411bcf2bb)
![photo_6_2024-02-23_09-22-45](https://github.com/linagora/twake-on-matrix/assets/80142234/34479755-cdfd-4d7f-aa8b-1788ce557060)
![photo_7_2024-02-23_09-22-45](https://github.com/linagora/twake-on-matrix/assets/80142234/90d3f61c-0f7a-4d6c-9039-439cdb99beb0)

## Root cause
- Because a contact in the device's address book can have multiple phone numbers that differ only in format (From user created, social media,...). Therefore when fetching contacts, it duplicated.

## Solution
- Filter contacts by normalize raw phone number (remove non-numeric digits) after fetching

## Resolved

https://github.com/linagora/twake-on-matrix/assets/80142234/70e3d424-122b-46e8-80c9-a82488184a2e

