### PR TITLE
TW-1269: can't play video in safari

### DIFF
--- a/lib/presentation/extensions/send_file_web_extension.dart
+++ b/lib/presentation/extensions/send_file_web_extension.dart
@@ -292,7 +292,7 @@ extension SendFileWebExtension on Room {
   ) async {
     if (originalFile.bytes == null) return null;
     try {
-      final url = originalFile.bytes?.toWebUrl();
+      final url = originalFile.bytes?.toWebUrl(mimeType: originalFile.mimeType);
       if (url == null) {
         throw Exception('Missing bytes in $originalFile');
       }
@@ -328,7 +328,7 @@ extension SendFileWebExtension on Room {
       return null;
     }
     try {
-      final url = originalFile.bytes?.toWebUrl();
+      final url = originalFile.bytes?.toWebUrl(mimeType: originalFile.mimeType);
       if (url == null) {
         throw Exception('$originalFile is empty');
       }

--- a/lib/presentation/mixins/handle_video_download_mixin.dart
+++ b/lib/presentation/mixins/handle_video_download_mixin.dart
@@ -22,7 +22,7 @@ mixin HandleVideoDownloadMixin {
     lastSelectedVideoEventId = event.eventId;
     if (PlatformInfos.isWeb) {
       final videoBytes = await event.downloadAndDecryptAttachment();
-      final url = videoBytes.bytes?.toWebUrl();
+      final url = videoBytes.bytes?.toWebUrl(mimeType: videoBytes.mimeType);
       if (url == null) {
         throw Exception('$videoBytes is null');
       }

--- a/lib/utils/extension/web_url_creation_extension.dart
+++ b/lib/utils/extension/web_url_creation_extension.dart
@@ -3,8 +3,8 @@ import 'dart:typed_data';
 import 'package:universal_html/html.dart' as html;
 
 extension WebUrlCreationExtension on Uint8List {
-  String toWebUrl() {
-    final blob = html.Blob([this]);
+  String toWebUrl({required String mimeType}) {
+    final blob = html.Blob([this], mimeType);
     return html.Url.createObjectUrlFromBlob(blob);
   }
 }


### PR DESCRIPTION
### issue:
#1269 

### Problem Explanation:
When using Flutter for web applications, Flutter team use the HTML `<video>` tag to implement video playback functionality. To play video in Twake, we create a Blob object that encapsulates video data fetched from a server. However, video can't be played with the Safari browser.

### Underlying Cause:
The problem is missing the MIME type of the Blob object.

### MIME Type Specification:
Browsers like Safari are particularly strict about security and content handling, and they rely on MIME types to optimize resource loading and enforce security policies. Without the correct MIME type, Safari might not attempt to play the video because it cannot confidently determine the video format and whether it supports that format.

### Docs: 
https://stackoverflow.com/questions/13231915/loading-audio-via-a-blob-url-fails-in-safari?rq=3
https://stackoverflow.com/questions/51485755/how-get-url-createobjecturlblob-to-work-in-safari


### Demo:
- Chrome:

https://github.com/linagora/twake-on-matrix/assets/43041967/edab370c-5f6d-4eb4-90f7-a919b981851c


- Safari:

https://github.com/linagora/twake-on-matrix/assets/43041967/768094d9-954a-4a99-98c1-ed369898a5fd


- Firefox: 

https://github.com/linagora/twake-on-matrix/assets/43041967/76514665-2531-435a-8a34-dde94902a03d

