### PR TITLE
TW-1480: Fix filter message in chat

### DIFF
--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -37,7 +37,7 @@ class ChatEventList extends StatelessWidget {
       thisEventsKeyMap[events[i].eventId] = i;
     }
 
-    if (controller.isEmptyChat) {
+    if (controller.hasNoMessageEvents) {
       return Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [

--- a/lib/pages/chat/chat_view_body.dart
+++ b/lib/pages/chat/chat_view_body.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/pages/chat/events/message_content_mixin.dart';
 import 'package:fluffychat/pages/chat/chat_pinned_events/pinned_events_view.dart';
 import 'package:fluffychat/pages/chat/sticky_timestamp_widget.dart';
 import 'package:fluffychat/pages/chat/tombstone_display.dart';
+import 'package:fluffychat/presentation/model/chat/view_event_list_ui_state.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/widgets/connection_status_header.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -51,14 +52,21 @@ class ChatViewBody extends StatelessWidget with MessageContentMixin {
                     Expanded(
                       child: GestureDetector(
                         onTap: controller.clearSingleSelectedEvent,
-                        child: Builder(
-                          builder: (context) {
-                            if (controller.timeline == null) {
+                        child: ValueListenableBuilder(
+                          valueListenable:
+                              controller.openingChatViewStateNotifier,
+                          builder: (context, viewState, __) {
+                            if (viewState is ViewEventListLoading) {
                               return const ChatLoadingView();
                             }
-                            return ChatEventList(
-                              controller: controller,
-                            );
+
+                            if (viewState is ViewEventListSuccess) {
+                              return ChatEventList(
+                                controller: controller,
+                              );
+                            }
+
+                            return const SizedBox.shrink();
                           },
                         ),
                       ),

--- a/lib/presentation/model/chat/view_event_list_ui_state.dart
+++ b/lib/presentation/model/chat/view_event_list_ui_state.dart
@@ -1,0 +1,21 @@
+import 'package:equatable/equatable.dart';
+
+abstract class ViewEventListUIState with EquatableMixin {
+  @override
+  List<Object?> get props => [];
+}
+
+class ViewEventListInitial extends ViewEventListUIState {
+  @override
+  List<Object?> get props => [];
+}
+
+class ViewEventListLoading extends ViewEventListUIState {
+  @override
+  List<Object?> get props => [];
+}
+
+class ViewEventListSuccess extends ViewEventListUIState {
+  @override
+  List<Object?> get props => [];
+}


### PR DESCRIPTION
### Ticket

- #1480

### Resolved

- Set the default message that will be displayed is 30
- If events after apply filter < 30 ⇒ request history
- If all events are membership ⇒ Request history
- Update the condition `isEmptyChat` ⇒ `hasNoMessage`


https://github.com/linagora/twake-on-matrix/assets/99852347/7644f326-f152-4a0d-96c7-d671748681b8



