### PR TITLE
TW-1499: video viewer actions

### DIFF
--- a/docs/adr/0018-show-in-chat-of-media-functionality.md
+++ b/docs/adr/0018-show-in-chat-of-media-functionality.md
@@ -1,0 +1,17 @@
+# 18. Show in chat of media functionality
+
+Date: 2024-03-07
+
+## Status
+
+Accepted
+
+## Context
+
+- We aim to support the `show in chat` feature for media (photos and videos), addressing navigation complexities across different devices and screen sizes. The feature operates smoothly within the chat screen, but challenges arise when implementing it for chat detail screens in group chats or profile info screens in direct chats. Specifically, navigating back to the chat screen varies: desktop screens require a single action, while tablet and mobile screens need two actions.
+
+## Consequences
+
+- To address the complexity of closing the right column (which displays chat details, profile info, or search pages) on the web platform, a direct use of the `pop()` method is ineffective. Instead, the closeRightColumn function must be employed. However, this introduces a cumbersome process where child widgets within the right column need to inherit and trigger this function from their parent widgets, leading to convoluted code patterns.
+
+To streamline this process, we propose a solution: when a child widget needs to close the right column, it should initiate a `pop` action with a specific result which are `MediaViewerPopupResultEnum.closeRightColumnFlag`. This action signals the parent widget, which is responsible for managing the navigation (via the `Navigator.push()` method), to handle the closure of the right column with the `closeRightColumn` function. This approach simplifies the interaction by removing the need for child widgets to directly manage or even be aware of the `closeRightColumn` method, effectively preventing "callback hell" and ensuring a more maintainable codebase.

--- a/lib/pages/chat/events/download_video_widget.dart
+++ b/lib/pages/chat/events/download_video_widget.dart
@@ -2,23 +2,25 @@ import 'package:dio/dio.dart';
 import 'package:fluffychat/pages/chat/events/download_video_state.dart';
 import 'package:fluffychat/pages/chat/events/event_video_player.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
+import 'package:fluffychat/pages/image_viewer/media_viewer_app_bar.dart';
 import 'package:fluffychat/presentation/mixins/handle_video_download_mixin.dart';
 import 'package:fluffychat/presentation/mixins/play_video_action_mixin.dart';
+import 'package:fluffychat/utils/extension/value_notifier_extension.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
-import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
-import 'package:fluffychat/widgets/video_viewer_style.dart';
 import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 import 'package:matrix/matrix.dart';
-import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 class DownloadVideoWidget extends StatefulWidget {
   final Event event;
 
-  const DownloadVideoWidget({super.key, required this.event});
+  const DownloadVideoWidget({
+    super.key,
+    required this.event,
+  });
 
   @override
   State<StatefulWidget> createState() => _DownloadVideoWidgetState();
@@ -30,6 +32,8 @@ class _DownloadVideoWidgetState extends State<DownloadVideoWidget>
   String? path;
   final downloadProgressNotifier = ValueNotifier(0.0);
   final cancelToken = CancelToken();
+
+  final ValueNotifier<bool> showAppbarPreview = ValueNotifier(true);
 
   @override
   void initState() {
@@ -44,6 +48,7 @@ class _DownloadVideoWidgetState extends State<DownloadVideoWidget>
     cancelToken.cancel();
     downloadProgressNotifier.dispose();
     _downloadStateNotifier.dispose();
+    showAppbarPreview.dispose();
     super.dispose();
   }
 
@@ -83,104 +88,102 @@ class _DownloadVideoWidgetState extends State<DownloadVideoWidget>
   Widget build(BuildContext context) {
     return Material(
       color: Colors.black,
-      child: Stack(
-        alignment: Alignment.topLeft,
-        children: [
-          Stack(
-            alignment: Alignment.center,
-            children: [
-              MxcImage(
-                event: widget.event,
-                fit: BoxFit.cover,
-              ),
-              ValueListenableBuilder<DownloadVideoState>(
-                valueListenable: _downloadStateNotifier,
-                builder: (context, downloadState, child) {
-                  switch (downloadState) {
-                    case DownloadVideoState.loading:
-                      return InkWell(
-                        onTap: downloadState == DownloadVideoState.loading
-                            ? null
-                            : _downloadAction,
-                        child: Center(
-                          child: Stack(
-                            children: [
-                              const CenterVideoButton(
-                                icon: Icons.play_arrow,
-                              ),
-                              SizedBox(
-                                width:
-                                    MessageContentStyle.videoCenterButtonSize,
-                                height:
-                                    MessageContentStyle.videoCenterButtonSize,
-                                child: ValueListenableBuilder(
-                                  valueListenable: downloadProgressNotifier,
-                                  builder: (context, progress, child) {
-                                    return CircularProgressIndicator(
-                                      strokeWidth: 2,
-                                      color: LinagoraRefColors.material()
-                                          .primary[100],
-                                      value:
-                                          PlatformInfos.isWeb ? null : progress,
-                                    );
-                                  },
+      child: GestureDetector(
+        onTap: () => showAppbarPreview.toggle(),
+        child: Stack(
+          alignment: Alignment.topLeft,
+          children: [
+            Stack(
+              alignment: Alignment.center,
+              children: [
+                MxcImage(
+                  event: widget.event,
+                  fit: BoxFit.cover,
+                ),
+                ValueListenableBuilder<DownloadVideoState>(
+                  valueListenable: _downloadStateNotifier,
+                  builder: (context, downloadState, child) {
+                    switch (downloadState) {
+                      case DownloadVideoState.loading:
+                        return InkWell(
+                          onTap: downloadState == DownloadVideoState.loading
+                              ? null
+                              : _downloadAction,
+                          child: Center(
+                            child: Stack(
+                              children: [
+                                const CenterVideoButton(
+                                  icon: Icons.play_arrow,
                                 ),
-                              ),
-                            ],
+                                SizedBox(
+                                  width:
+                                      MessageContentStyle.videoCenterButtonSize,
+                                  height:
+                                      MessageContentStyle.videoCenterButtonSize,
+                                  child: ValueListenableBuilder(
+                                    valueListenable: downloadProgressNotifier,
+                                    builder: (context, progress, child) {
+                                      return CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: LinagoraRefColors.material()
+                                            .primary[100],
+                                        value: PlatformInfos.isWeb
+                                            ? null
+                                            : progress,
+                                      );
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
-                        ),
-                      );
-                    case DownloadVideoState.initial:
-                      return InkWell(
-                        onTap: _downloadAction,
-                        child: const Center(
-                          child: CenterVideoButton(
-                            icon: Icons.play_arrow,
+                        );
+                      case DownloadVideoState.initial:
+                        return InkWell(
+                          onTap: _downloadAction,
+                          child: const Center(
+                            child: CenterVideoButton(
+                              icon: Icons.play_arrow,
+                            ),
                           ),
-                        ),
-                      );
-                    case DownloadVideoState.done:
-                      return InkWell(
-                        onTap: () {
-                          if (path != null) {
-                            playVideoAction(
-                              context,
-                              path!,
-                              event: widget.event,
-                            );
-                          }
-                        },
-                        child: const Center(
-                          child: CenterVideoButton(
-                            icon: Icons.play_arrow,
+                        );
+                      case DownloadVideoState.done:
+                        return InkWell(
+                          onTap: () {
+                            if (path != null) {
+                              playVideoAction(
+                                context,
+                                path!,
+                                event: widget.event,
+                              );
+                            }
+                          },
+                          child: const Center(
+                            child: CenterVideoButton(
+                              icon: Icons.play_arrow,
+                            ),
                           ),
-                        ),
-                      );
-                    case DownloadVideoState.failed:
-                      return InkWell(
-                        onTap: _downloadAction,
-                        child: const Center(
-                          child: CenterVideoButton(
-                            icon: Icons.error,
+                        );
+                      case DownloadVideoState.failed:
+                        return InkWell(
+                          onTap: _downloadAction,
+                          child: const Center(
+                            child: CenterVideoButton(
+                              icon: Icons.error,
+                            ),
                           ),
-                        ),
-                      );
-                  }
-                },
-              ),
-            ],
-          ),
-          TwakeIconButton(
-            margin: VideoViewerStyle.backButtonMargin(context),
-            tooltip: L10n.of(context)!.back,
-            icon: Icons.close,
-            onTap: () {
-              cancelToken.cancel();
-              Navigator.of(context).pop();
-            },
-            iconColor: Theme.of(context).colorScheme.surface,
-          ),
-        ],
+                        );
+                    }
+                  },
+                ),
+              ],
+            ),
+            MediaViewerAppBar(
+              showAppbarPreviewNotifier: showAppbarPreview,
+              event: widget.event,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/chat/events/event_video_player.dart
+++ b/lib/pages/chat/events/event_video_player.dart
@@ -36,6 +36,10 @@ class EventVideoPlayer extends StatelessWidget {
   /// Enable it if the thumbnail image is stretched, and you don't want to resize it
   final bool noResizeThumbnail;
 
+  final bool showPlayButton;
+
+  static final responsiveUtils = getIt.get<ResponsiveUtils>();
+
   const EventVideoPlayer(
     this.event, {
     Key? key,
@@ -46,6 +50,8 @@ class EventVideoPlayer extends StatelessWidget {
     this.thumbnailCacheMap,
     this.thumbnailCacheKey,
     this.noResizeThumbnail = false,
+    this.onCloseRightColumn,
+    this.showPlayButton = true,
   }) : super(key: key);
 
   @override
@@ -84,9 +90,10 @@ class EventVideoPlayer extends StatelessWidget {
                       thumbnailOnly: true,
                     ),
                   ),
-                const CenterVideoButton(
-                  icon: Icons.play_arrow,
-                ),
+                if (showPlayButton)
+                  const CenterVideoButton(
+                    icon: Icons.play_arrow,
+                  ),
                 if (showDuration)
                   Positioned(
                     bottom: ChatDetailsMediaStyle.durationPosition,

--- a/lib/pages/chat/events/event_video_player.dart
+++ b/lib/pages/chat/events/event_video_player.dart
@@ -1,10 +1,13 @@
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/events/download_video_widget.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_page_view/media/chat_details_media_style.dart';
+import 'package:fluffychat/presentation/enum/chat/media_viewer_popup_result_enum.dart';
 import 'package:fluffychat/utils/interactive_viewer_gallery.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/hero_page_route.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:flutter/material.dart';
@@ -38,6 +41,8 @@ class EventVideoPlayer extends StatelessWidget {
 
   final bool showPlayButton;
 
+  final VoidCallback? onPop;
+
   static final responsiveUtils = getIt.get<ResponsiveUtils>();
 
   const EventVideoPlayer(
@@ -50,8 +55,8 @@ class EventVideoPlayer extends StatelessWidget {
     this.thumbnailCacheMap,
     this.thumbnailCacheKey,
     this.noResizeThumbnail = false,
-    this.onCloseRightColumn,
     this.showPlayButton = true,
+    this.onPop,
   }) : super(key: key);
 
   @override
@@ -68,6 +73,7 @@ class EventVideoPlayer extends StatelessWidget {
       child: Material(
         color: Colors.black,
         child: InkWell(
+          mouseCursor: SystemMouseCursors.click,
           onTap: () => _onTapVideo(context),
           child: SizedBox(
             width: MessageContentStyle.imageBubbleWidth(imageWidth),
@@ -88,6 +94,7 @@ class EventVideoPlayer extends StatelessWidget {
                       thumbnailCacheMap: thumbnailCacheMap,
                       noResizeThumbnail: noResizeThumbnail,
                       thumbnailOnly: true,
+                      isPreview: false,
                     ),
                   ),
                 if (showPlayButton)
@@ -96,8 +103,8 @@ class EventVideoPlayer extends StatelessWidget {
                   ),
                 if (showDuration)
                   Positioned(
-                    bottom: ChatDetailsMediaStyle.durationPosition,
-                    right: ChatDetailsMediaStyle.durationPosition,
+                    bottom: ChatDetailsMediaStyle.durationPaddingAll(context),
+                    right: ChatDetailsMediaStyle.durationPaddingAll(context),
                     child: Container(
                       padding: ChatDetailsMediaStyle.durationPadding,
                       decoration: ChatDetailsMediaStyle.durationBoxDecoration(
@@ -118,18 +125,23 @@ class EventVideoPlayer extends StatelessWidget {
   }
 
   Future<void> _onTapVideo(BuildContext context) async {
-    await Navigator.of(
+    final result = await Navigator.of(
       context,
       rootNavigator: PlatformInfos.isWeb,
     ).push(
       HeroPageRoute(
         builder: (context) {
           return InteractiveViewerGallery(
-            itemBuilder: DownloadVideoWidget(event: event),
+            itemBuilder: DownloadVideoWidget(
+              event: event,
+            ),
           );
         },
       ),
     );
+    if (result == MediaViewerPopupResultEnum.closeRightColumnFlag) {
+      onPop?.call();
+    }
   }
 }
 

--- a/lib/pages/chat/events/image_bubble.dart
+++ b/lib/pages/chat/events/image_bubble.dart
@@ -19,6 +19,7 @@ class ImageBubble extends StatelessWidget {
   final bool rounded;
   final void Function()? onTapPreview;
   final void Function()? onTapSelectMode;
+  final bool isPreview;
   final Uint8List? imageData;
   final Duration animationDuration;
 
@@ -42,6 +43,7 @@ class ImageBubble extends StatelessWidget {
     this.thumbnailCacheKey,
     this.thumbnailCacheMap,
     this.noResizeThumbnail = false,
+    this.isPreview = true,
     Key? key,
   }) : super(key: key);
 
@@ -122,7 +124,7 @@ class ImageBubble extends StatelessWidget {
                 onTapPreview: onTapPreview,
                 onTapSelectMode: onTapSelectMode,
                 imageData: imageData,
-                isPreview: true,
+                isPreview: isPreview,
                 animationDuration: animationDuration,
                 cacheKey: thumbnailCacheKey,
                 cacheMap: thumbnailCacheMap,

--- a/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold.dart
+++ b/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold.dart
@@ -79,7 +79,7 @@ class _RightColumnNavigator extends StatelessWidget {
         );
       case RightColumnType.groupChatDetails:
         return ChatDetailsNavigator(
-          onCloseRightColumn: controller.hideRightColumn,
+          closeRightColumn: controller.hideRightColumn,
           roomId: roomId,
           isInStack: isInStack,
         );

--- a/lib/pages/chat_details/chat_details.dart
+++ b/lib/pages/chat_details/chat_details.dart
@@ -37,13 +37,13 @@ enum AliasActions { copy, delete, setCanonical }
 class ChatDetails extends StatefulWidget {
   final String roomId;
   final bool isInStack;
-  final VoidCallback? onCloseRightColumn;
+  final VoidCallback? closeRightColumn;
 
   const ChatDetails({
     super.key,
     required this.roomId,
     required this.isInStack,
-    this.onCloseRightColumn,
+    this.closeRightColumn,
   });
 
   @override
@@ -254,7 +254,7 @@ class ChatDetailsController extends State<ChatDetails>
                         controller: mediaListController!,
                         cacheMap: _mediaCacheMap,
                         handleDownloadVideoEvent: _handleDownloadAndPlayVideo,
-                        onCloseRightColumn: widget.onCloseRightColumn,
+                        closeRightColumn: widget.closeRightColumn,
                       ),
               );
             case ChatDetailsPage.links:

--- a/lib/pages/chat_details/chat_details_navigator.dart
+++ b/lib/pages/chat_details/chat_details_navigator.dart
@@ -11,14 +11,14 @@ class ChatDetailsRoutes {
 }
 
 class ChatDetailsNavigator extends StatelessWidget {
-  final VoidCallback? onCloseRightColumn;
+  final VoidCallback? closeRightColumn;
   final String? roomId;
   final PresentationContact? contact;
   final bool isInStack;
 
   const ChatDetailsNavigator({
     Key? key,
-    this.onCloseRightColumn,
+    this.closeRightColumn,
     this.roomId,
     this.contact,
     required this.isInStack,
@@ -29,7 +29,7 @@ class ChatDetailsNavigator extends StatelessWidget {
     if (PlatformInfos.isMobile) {
       return ChatDetails(
         roomId: roomId!,
-        onCloseRightColumn: onCloseRightColumn,
+        closeRightColumn: closeRightColumn,
         isInStack: isInStack,
       );
     }
@@ -41,7 +41,7 @@ class ChatDetailsNavigator extends StatelessWidget {
             case ChatDetailsRoutes.chatDetails:
               return ChatDetails(
                 roomId: roomId!,
-                onCloseRightColumn: onCloseRightColumn,
+                closeRightColumn: closeRightColumn,
                 isInStack: isInStack,
               );
             case ChatDetailsRoutes.chatDetailsEdit:
@@ -51,7 +51,7 @@ class ChatDetailsNavigator extends StatelessWidget {
             default:
               return ChatDetails(
                 roomId: roomId!,
-                onCloseRightColumn: onCloseRightColumn,
+                closeRightColumn: closeRightColumn,
                 isInStack: isInStack,
               );
           }

--- a/lib/pages/chat_details/chat_details_page_view/media/chat_details_media_page.dart
+++ b/lib/pages/chat_details/chat_details_page_view/media/chat_details_media_page.dart
@@ -1,11 +1,13 @@
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/room/timeline_search_event_state.dart';
 import 'package:fluffychat/pages/chat/events/event_video_player.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_page_view/media/chat_details_media_style.dart';
 import 'package:fluffychat/presentation/same_type_events_builder/same_type_events_builder.dart';
 import 'package:fluffychat/presentation/same_type_events_builder/same_type_events_controller.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
@@ -98,6 +100,8 @@ class _VideoItem extends StatelessWidget {
     this.thumbnailCacheMap,
   });
 
+  static final responsiveUtil = getIt.get<ResponsiveUtils>();
+
   @override
   Widget build(BuildContext context) {
     return EventVideoPlayer(
@@ -107,6 +111,8 @@ class _VideoItem extends StatelessWidget {
       thumbnailCacheKey: event.eventId,
       thumbnailCacheMap: thumbnailCacheMap,
       noResizeThumbnail: true,
+      onCloseRightColumn: onCloseRightColumn,
+      showPlayButton: !responsiveUtil.isDesktop(context),
     );
   }
 }

--- a/lib/pages/chat_details/chat_details_page_view/media/chat_details_media_page.dart
+++ b/lib/pages/chat_details/chat_details_page_view/media/chat_details_media_page.dart
@@ -17,14 +17,14 @@ class ChatDetailsMediaPage extends StatelessWidget {
   final SameTypeEventsBuilderController controller;
   final Map<EventId, ImageData>? cacheMap;
   final DownloadVideoEventCallback handleDownloadVideoEvent;
-  final VoidCallback? onCloseRightColumn;
+  final VoidCallback? closeRightColumn;
 
   const ChatDetailsMediaPage({
     Key? key,
     required this.controller,
     required this.handleDownloadVideoEvent,
     this.cacheMap,
-    this.onCloseRightColumn,
+    this.closeRightColumn,
   }) : super(key: key);
 
   @override
@@ -47,12 +47,13 @@ class ChatDetailsMediaPage extends StatelessWidget {
                   ? _ImageItem(
                       event: events[index],
                       cacheMap: cacheMap,
-                      onCloseRightColumn: onCloseRightColumn,
+                      closeRightColumn: closeRightColumn,
                     )
                   : _VideoItem(
                       event: events[index],
                       handleDownloadVideoEvent: handleDownloadVideoEvent,
                       thumbnailCacheMap: cacheMap,
+                      closeRightColumn: closeRightColumn,
                     ),
         );
       },
@@ -63,12 +64,12 @@ class ChatDetailsMediaPage extends StatelessWidget {
 class _ImageItem extends StatelessWidget {
   final Event event;
   final Map<EventId, ImageData>? cacheMap;
-  final VoidCallback? onCloseRightColumn;
+  final VoidCallback? closeRightColumn;
 
   const _ImageItem({
     required this.event,
     this.cacheMap,
-    this.onCloseRightColumn,
+    this.closeRightColumn,
   });
 
   @override
@@ -84,7 +85,7 @@ class _ImageItem extends StatelessWidget {
       ),
       cacheKey: event.eventId,
       cacheMap: cacheMap,
-      onCloseRightColumn: onCloseRightColumn,
+      closeRightColumn: closeRightColumn,
     );
   }
 }
@@ -93,11 +94,13 @@ class _VideoItem extends StatelessWidget {
   final Event event;
   final DownloadVideoEventCallback handleDownloadVideoEvent;
   final Map<EventId, ImageData>? thumbnailCacheMap;
+  final VoidCallback? closeRightColumn;
 
   const _VideoItem({
     required this.event,
     required this.handleDownloadVideoEvent,
     this.thumbnailCacheMap,
+    this.closeRightColumn,
   });
 
   static final responsiveUtil = getIt.get<ResponsiveUtils>();
@@ -111,7 +114,7 @@ class _VideoItem extends StatelessWidget {
       thumbnailCacheKey: event.eventId,
       thumbnailCacheMap: thumbnailCacheMap,
       noResizeThumbnail: true,
-      onCloseRightColumn: onCloseRightColumn,
+      onPop: closeRightColumn,
       showPlayButton: !responsiveUtil.isDesktop(context),
     );
   }

--- a/lib/pages/chat_details/chat_details_page_view/media/chat_details_media_style.dart
+++ b/lib/pages/chat_details/chat_details_page_view/media/chat_details_media_style.dart
@@ -29,5 +29,6 @@ class ChatDetailsMediaStyle {
             color: Theme.of(context).colorScheme.onPrimary,
           );
 
-  static const double durationPosition = 10;
+  static double durationPaddingAll(BuildContext context) =>
+      responsive.isDesktop(context) ? 4 : 10;
 }

--- a/lib/pages/chat_details/chat_details_view.dart
+++ b/lib/pages/chat_details/chat_details_view.dart
@@ -58,7 +58,7 @@ class ChatDetailsView extends StatelessWidget {
                       splashColor: Colors.transparent,
                       hoverColor: Colors.transparent,
                       highlightColor: Colors.transparent,
-                      onPressed: controller.widget.onCloseRightColumn,
+                      onPressed: controller.widget.closeRightColumn,
                       icon: controller.widget.isInStack
                           ? const Icon(Icons.arrow_back)
                           : const Icon(Icons.close),

--- a/lib/pages/chat_profile_info/chat_profile_info.dart
+++ b/lib/pages/chat_profile_info/chat_profile_info.dart
@@ -68,7 +68,7 @@ class ProfileInfoController extends State<ProfileInfo> {
         builder: (context) {
           return ProfileInfoShared(
             roomId: widget.roomId!,
-            onBack: widget.onBack,
+            closeRightColumn: widget.onBack,
           );
         },
       ),

--- a/lib/pages/chat_profile_info/chat_profile_info_shared/chat_profile_info_shared.dart
+++ b/lib/pages/chat_profile_info/chat_profile_info_shared/chat_profile_info_shared.dart
@@ -14,12 +14,12 @@ import 'package:matrix/matrix.dart';
 
 class ProfileInfoShared extends StatefulWidget {
   final String roomId;
-  final VoidCallback? onBack;
+  final VoidCallback? closeRightColumn;
 
   const ProfileInfoShared({
     super.key,
     required this.roomId,
-    this.onBack,
+    this.closeRightColumn,
   });
 
   @override
@@ -71,7 +71,7 @@ class ProfileInfoSharedController extends State<ProfileInfoShared>
                         ),
                         controller: mediaListController!,
                         handleDownloadVideoEvent: _handleDownloadAndPlayVideo,
-                        onCloseRightColumn: widget.onBack,
+                        closeRightColumn: widget.closeRightColumn,
                       ),
               );
             case ChatDetailsPage.links:

--- a/lib/pages/image_viewer/image_viewer.dart
+++ b/lib/pages/image_viewer/image_viewer.dart
@@ -12,14 +12,12 @@ class ImageViewer extends StatefulWidget {
   final Event? event;
   final Uint8List? imageData;
   final String? filePath;
-  final VoidCallback? onCloseRightColumn;
 
   const ImageViewer({
     Key? key,
     this.event,
     this.imageData,
     this.filePath,
-    this.onCloseRightColumn,
   }) : super(key: key);
 
   @override

--- a/lib/pages/image_viewer/image_viewer.dart
+++ b/lib/pages/image_viewer/image_viewer.dart
@@ -1,13 +1,9 @@
 import 'dart:typed_data';
 
-import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/forward/forward.dart';
 import 'package:fluffychat/pages/image_viewer/image_viewer_view.dart';
 import 'package:fluffychat/presentation/model/pop_result_from_forward.dart';
-import 'package:fluffychat/utils/extension/build_context_extension.dart';
-import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
-import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
@@ -40,10 +36,6 @@ class ImageViewerController extends State<ImageViewer> {
 
   final ValueNotifier<bool> showAppbarPreview = ValueNotifier(true);
 
-  final MenuController menuController = MenuController();
-
-  final responsiveUtils = getIt.get<ResponsiveUtils>();
-
   @override
   void initState() {
     super.initState();
@@ -69,62 +61,6 @@ class ImageViewerController extends State<ImageViewer> {
       Navigator.of(context).pop<PopResultFromForward>();
     }
   }
-
-  void toggleShowMoreActions() {
-    if (menuController.isOpen) {
-      menuController.close();
-    } else {
-      menuController.open();
-    }
-  }
-
-  void showInChat() {
-    if (!PlatformInfos.isMobile) {
-      handleShowInChatInWeb();
-    } else {
-      handleShowInChatInMobile();
-    }
-  }
-
-  void handleShowInChatInWeb() {
-    backToChatScreenInWeb();
-    scrollToEventInChat();
-    return;
-  }
-
-  void handleShowInChatInMobile() {
-    backToChatScreenInMobile();
-    scrollToEventInChat();
-  }
-
-  void backToChatScreenInWeb() {
-    Navigator.of(context).pop();
-    if (responsiveUtils.isTablet(context)) {
-      widget.onCloseRightColumn?.call();
-    }
-  }
-
-  void backToChatScreenInMobile() {
-    Navigator.of(context).popUntil(
-      (Route route) => route.settings.name == roomPathName,
-    );
-  }
-
-  void scrollToEventInChat() {
-    if (widget.event != null) {
-      context.goToRoomWithEvent(widget.event!.room.id, widget.event!.eventId);
-    }
-  }
-
-  void toggleAppbarPreview() {
-    showAppbarPreview.value = !showAppbarPreview.value;
-  }
-
-  void saveFileAction() => widget.event?.saveFile(context);
-
-  /// Save this file with a system call.
-  void shareFileAction(BuildContext context) =>
-      widget.event?.shareFile(context);
 
   static const maxScaleFactor = 1.5;
 

--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -80,7 +80,6 @@ class ImageViewerView extends StatelessWidget {
               MediaViewerAppBar(
                 showAppbarPreviewNotifier: controller.showAppbarPreview,
                 event: controller.widget.event,
-                onCloseRightColumn: controller.widget.onCloseRightColumn,
               ),
             ],
           ),

--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -1,15 +1,12 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:fluffychat/pages/image_viewer/context_menu_item_image_viewer.dart';
 import 'package:fluffychat/pages/image_viewer/image_viewer_style.dart';
-import 'package:fluffychat/resource/image_paths.dart';
+import 'package:fluffychat/pages/image_viewer/media_viewer_app_bar.dart';
+import 'package:fluffychat/utils/extension/value_notifier_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
-import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
 import 'package:matrix/matrix.dart';
 
 import 'image_viewer.dart';
@@ -72,7 +69,7 @@ class ImageViewerView extends StatelessWidget {
             if (PlatformInfos.isWeb) {
               Navigator.of(context).pop();
             } else {
-              controller.toggleAppbarPreview();
+              controller.showAppbarPreview.toggle();
             }
           },
           onDoubleTapDown: (details) => controller.onDoubleTapDown(details),
@@ -80,110 +77,14 @@ class ImageViewerView extends StatelessWidget {
           child: Stack(
             children: [
               interactiveViewer,
-              _buildAppBarPreview(),
+              MediaViewerAppBar(
+                showAppbarPreviewNotifier: controller.showAppbarPreview,
+                event: controller.widget.event,
+                onCloseRightColumn: controller.widget.onCloseRightColumn,
+              ),
             ],
           ),
         ),
-      ),
-    );
-  }
-
-  Widget _buildAppBarPreview() {
-    return Container(
-      padding: ImageViewerStyle.paddingTopAppBar,
-      height: ImageViewerStyle.appBarHeight,
-      color: LinagoraSysColors.material().onTertiaryContainer.withOpacity(0.5),
-      child: ValueListenableBuilder<bool>(
-        valueListenable: controller.showAppbarPreview,
-        builder: (context, showAppbar, _) {
-          if (showAppbar) {
-            return Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                IconButton(
-                  icon: Icon(
-                    controller.responsiveUtils.isMobile(context)
-                        ? Icons.arrow_back_rounded
-                        : Icons.close,
-                    color: LinagoraSysColors.material().onPrimary,
-                  ),
-                  onPressed: () {
-                    Navigator.of(context).pop();
-                  },
-                  color: LinagoraSysColors.material().onPrimary,
-                  tooltip: L10n.of(context)!.back,
-                ),
-                Row(
-                  children: [
-                    if (PlatformInfos.isMobile)
-                      Builder(
-                        builder: (context) => IconButton(
-                          onPressed: () => controller.shareFileAction(context),
-                          tooltip: L10n.of(context)!.share,
-                          color: LinagoraSysColors.material().onPrimary,
-                          icon: Icon(
-                            Icons.share,
-                            color: LinagoraSysColors.material().onPrimary,
-                          ),
-                        ),
-                      ),
-                    if (controller.widget.event != null)
-                      IconButton(
-                        icon: Icon(
-                          Icons.shortcut,
-                          color: LinagoraSysColors.material().onPrimary,
-                        ),
-                        onPressed: controller.forwardAction,
-                        color: LinagoraSysColors.material().onPrimary,
-                        tooltip: L10n.of(context)!.share,
-                      ),
-                    if (controller.widget.event != null)
-                      Padding(
-                        padding: const EdgeInsets.only(right: 8.0),
-                        child: Directionality(
-                          textDirection: TextDirection.rtl,
-                          child: MenuAnchor(
-                            controller: controller.menuController,
-                            style: const MenuStyle(
-                              alignment: Alignment.bottomRight,
-                            ),
-                            menuChildren: [
-                              ContextMenuItemImageViewer(
-                                icon: Icons.file_download_outlined,
-                                title: L10n.of(context)!.saveFile,
-                                onTap: () => controller.saveFileAction(),
-                              ),
-                              ContextMenuItemImageViewer(
-                                title: L10n.of(context)!.showInChat,
-                                imagePath: ImagePaths.icShowInChat,
-                                onTap: () => controller.showInChat(),
-                                haveDivider: false,
-                              ),
-                            ],
-                            child: InkWell(
-                              borderRadius: BorderRadius.circular(100),
-                              onTap: () => controller.toggleShowMoreActions(),
-                              child: Padding(
-                                padding: const EdgeInsets.all(8.0),
-                                child: TwakeIconButton(
-                                  paddingAll: 0.0,
-                                  icon: Icons.more_vert,
-                                  iconColor:
-                                      LinagoraSysColors.material().onPrimary,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                  ],
-                ),
-              ],
-            );
-          } else {
-            return const SizedBox.shrink();
-          }
-        },
       ),
     );
   }

--- a/lib/pages/image_viewer/media_viewer_app_bar.dart
+++ b/lib/pages/image_viewer/media_viewer_app_bar.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/forward/forward.dart';
 import 'package:fluffychat/pages/image_viewer/media_viewer_app_bar_view.dart';
+import 'package:fluffychat/presentation/enum/chat/media_viewer_popup_result_enum.dart';
 import 'package:fluffychat/presentation/model/pop_result_from_forward.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -13,14 +14,12 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 class MediaViewerAppBar extends StatefulWidget {
   const MediaViewerAppBar({
     Key? key,
-    required this.showAppbarPreviewNotifier,
-    this.onCloseRightColumn,
+    this.showAppbarPreviewNotifier,
     this.event,
   }) : super(key: key);
 
-  final ValueNotifier<bool> showAppbarPreviewNotifier;
+  final ValueNotifier<bool>? showAppbarPreviewNotifier;
   final Event? event;
-  final VoidCallback? onCloseRightColumn;
 
   static final responsiveUtils = getIt.get<ResponsiveUtils>();
 
@@ -31,14 +30,20 @@ class MediaViewerAppBar extends StatefulWidget {
 class MediaViewerAppBarController extends State<MediaViewerAppBar> {
   final MenuController menuController = MenuController();
 
+  ValueNotifier<bool>? showAppbarPreview;
+
   final responsiveUtils = getIt.get<ResponsiveUtils>();
 
-  final ValueNotifier<bool> showAppbarPreview = ValueNotifier(true);
+  @override
+  void initState() {
+    super.initState();
+    showAppbarPreview = widget.showAppbarPreviewNotifier;
+  }
 
   @override
   void dispose() {
     super.dispose();
-    showAppbarPreview.dispose();
+    showAppbarPreview?.dispose();
   }
 
   void toggleShowMoreActions() {
@@ -47,10 +52,6 @@ class MediaViewerAppBarController extends State<MediaViewerAppBar> {
     } else {
       menuController.open();
     }
-  }
-
-  void toggleAppbarPreview() {
-    showAppbarPreview.value = !showAppbarPreview.value;
   }
 
   /// Forward this image to another room.
@@ -106,6 +107,10 @@ class MediaViewerAppBarController extends State<MediaViewerAppBar> {
     Navigator.of(context).popUntil(
       (Route route) => route.settings.name == '/rooms/room',
     );
+  }
+
+  void onClose() {
+    Navigator.of(context).pop();
   }
 
   void saveFileAction() => widget.event?.saveFile(context);

--- a/lib/pages/image_viewer/media_viewer_app_bar.dart
+++ b/lib/pages/image_viewer/media_viewer_app_bar.dart
@@ -1,0 +1,118 @@
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/pages/forward/forward.dart';
+import 'package:fluffychat/pages/image_viewer/media_viewer_app_bar_view.dart';
+import 'package:fluffychat/presentation/model/pop_result_from_forward.dart';
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
+
+class MediaViewerAppBar extends StatefulWidget {
+  const MediaViewerAppBar({
+    Key? key,
+    required this.showAppbarPreviewNotifier,
+    this.onCloseRightColumn,
+    this.event,
+  }) : super(key: key);
+
+  final ValueNotifier<bool> showAppbarPreviewNotifier;
+  final Event? event;
+  final VoidCallback? onCloseRightColumn;
+
+  static final responsiveUtils = getIt.get<ResponsiveUtils>();
+
+  @override
+  State<MediaViewerAppBar> createState() => MediaViewerAppBarController();
+}
+
+class MediaViewerAppBarController extends State<MediaViewerAppBar> {
+  final MenuController menuController = MenuController();
+
+  final responsiveUtils = getIt.get<ResponsiveUtils>();
+
+  final ValueNotifier<bool> showAppbarPreview = ValueNotifier(true);
+
+  @override
+  void dispose() {
+    super.dispose();
+    showAppbarPreview.dispose();
+  }
+
+  void toggleShowMoreActions() {
+    if (menuController.isOpen) {
+      menuController.close();
+    } else {
+      menuController.open();
+    }
+  }
+
+  void toggleAppbarPreview() {
+    showAppbarPreview.value = !showAppbarPreview.value;
+  }
+
+  /// Forward this image to another room.
+  void forwardAction() async {
+    Matrix.of(context).shareContent = widget.event?.content;
+    final result = await showDialog(
+      context: context,
+      useSafeArea: false,
+      useRootNavigator: false,
+      builder: (c) => const Forward(),
+    );
+    if (result is PopResultFromForward) {
+      Navigator.of(context).pop<PopResultFromForward>();
+    }
+  }
+
+  void showInChat() {
+    if (!PlatformInfos.isMobile) {
+      handleShowInChatInWeb();
+    } else {
+      handleShowInChatInMobile();
+    }
+  }
+
+  void handleShowInChatInWeb() {
+    backToChatScreenInWeb();
+    scrollToEventInChat();
+    return;
+  }
+
+  void handleShowInChatInMobile() {
+    backToChatScreenInMobile();
+    scrollToEventInChat();
+  }
+
+  void backToChatScreenInWeb() {
+    Navigator.of(context).pop();
+    if (responsiveUtils.isTablet(context) ||
+        responsiveUtils.isMobile(context)) {
+      widget.onCloseRightColumn?.call();
+    }
+  }
+
+  void scrollToEventInChat() {
+    if (widget.event != null) {
+      context.goToRoomWithEvent(widget.event!.room.id, widget.event!.eventId);
+    }
+  }
+
+  void backToChatScreenInMobile() {
+    Navigator.of(context).popUntil(
+      (Route route) => route.settings.name == '/rooms/room',
+    );
+  }
+
+  void saveFileAction() => widget.event?.saveFile(context);
+
+  void shareFileAction(BuildContext context) =>
+      widget.event?.shareFile(context);
+
+  @override
+  Widget build(BuildContext context) {
+    return MediaViewerAppbarView(this);
+  }
+}

--- a/lib/pages/image_viewer/media_viewer_app_bar.dart
+++ b/lib/pages/image_viewer/media_viewer_app_bar.dart
@@ -87,10 +87,12 @@ class MediaViewerAppBarController extends State<MediaViewerAppBar> {
   }
 
   void backToChatScreenInWeb() {
-    Navigator.of(context).pop();
     if (responsiveUtils.isTablet(context) ||
         responsiveUtils.isMobile(context)) {
-      widget.onCloseRightColumn?.call();
+      Navigator.of(context)
+          .pop(MediaViewerPopupResultEnum.closeRightColumnFlag);
+    } else {
+      Navigator.of(context).pop();
     }
   }
 

--- a/lib/pages/image_viewer/media_viewer_app_bar_style.dart
+++ b/lib/pages/image_viewer/media_viewer_app_bar_style.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
+
+class MediaViewewAppbarStyle {
+  static const opacityAnimationDuration = Duration(milliseconds: 200);
+
+  static final appBarBackgroundColor =
+      LinagoraSysColors.material().onTertiaryContainer.withOpacity(0.5);
+
+  static EdgeInsets paddingRightMenu = const EdgeInsets.only(right: 8.0);
+
+  static BorderRadius showMoreIconSplashRadius = BorderRadius.circular(100);
+
+  static EdgeInsets marginAllShowMoreIcon = const EdgeInsets.all(8.0);
+
+  static double paddingAllShowMoreIcon = 0.0;
+}

--- a/lib/pages/image_viewer/media_viewer_app_bar_view.dart
+++ b/lib/pages/image_viewer/media_viewer_app_bar_view.dart
@@ -17,7 +17,7 @@ class MediaViewerAppbarView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: controller.widget.showAppbarPreviewNotifier,
+      valueListenable: controller.showAppbarPreview ?? ValueNotifier(true),
       builder: (context, showAppbarPreview, child) {
         return AnimatedOpacity(
           opacity: showAppbarPreview ? 1 : 0,
@@ -28,6 +28,7 @@ class MediaViewerAppbarView extends StatelessWidget {
                 ? ImageViewerStyle.paddingTopAppBar
                 : EdgeInsets.zero,
             height: ImageViewerStyle.appBarHeight,
+            width: MediaQuery.sizeOf(context).width,
             color: MediaViewewAppbarStyle.appBarBackgroundColor,
             child: showAppbarPreview
                 ? Row(
@@ -40,9 +41,7 @@ class MediaViewerAppbarView extends StatelessWidget {
                               : Icons.close,
                           color: LinagoraSysColors.material().onPrimary,
                         ),
-                        onPressed: () {
-                          Navigator.of(context).pop();
-                        },
+                        onPressed: controller.onClose,
                         color: LinagoraSysColors.material().onPrimary,
                         tooltip: L10n.of(context)!.back,
                       ),

--- a/lib/pages/image_viewer/media_viewer_app_bar_view.dart
+++ b/lib/pages/image_viewer/media_viewer_app_bar_view.dart
@@ -1,0 +1,126 @@
+import 'package:fluffychat/pages/image_viewer/image_viewer_style.dart';
+import 'package:fluffychat/pages/image_viewer/media_viewer_app_bar.dart';
+import 'package:fluffychat/pages/image_viewer/media_viewer_app_bar_style.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
+import 'package:fluffychat/resource/image_paths.dart';
+import 'package:fluffychat/pages/image_viewer/context_menu_item_image_viewer.dart';
+
+class MediaViewerAppbarView extends StatelessWidget {
+  final MediaViewerAppBarController controller;
+
+  const MediaViewerAppbarView(this.controller, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: controller.widget.showAppbarPreviewNotifier,
+      builder: (context, showAppbarPreview, child) {
+        return AnimatedOpacity(
+          opacity: showAppbarPreview ? 1 : 0,
+          duration: MediaViewewAppbarStyle.opacityAnimationDuration,
+          curve: Curves.easeIn,
+          child: Container(
+            padding: showAppbarPreview
+                ? ImageViewerStyle.paddingTopAppBar
+                : EdgeInsets.zero,
+            height: ImageViewerStyle.appBarHeight,
+            color: MediaViewewAppbarStyle.appBarBackgroundColor,
+            child: showAppbarPreview
+                ? Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      IconButton(
+                        icon: Icon(
+                          MediaViewerAppBar.responsiveUtils.isMobile(context)
+                              ? Icons.arrow_back_rounded
+                              : Icons.close,
+                          color: LinagoraSysColors.material().onPrimary,
+                        ),
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                        color: LinagoraSysColors.material().onPrimary,
+                        tooltip: L10n.of(context)!.back,
+                      ),
+                      Row(
+                        children: [
+                          if (PlatformInfos.isMobile)
+                            Builder(
+                              builder: (context) => IconButton(
+                                onPressed: () =>
+                                    controller.shareFileAction(context),
+                                tooltip: L10n.of(context)!.share,
+                                color: LinagoraSysColors.material().onPrimary,
+                                icon: Icon(
+                                  Icons.share,
+                                  color: LinagoraSysColors.material().onPrimary,
+                                ),
+                              ),
+                            ),
+                          if (controller.widget.event != null)
+                            IconButton(
+                              icon: Icon(
+                                Icons.shortcut,
+                                color: LinagoraSysColors.material().onPrimary,
+                              ),
+                              onPressed: controller.forwardAction,
+                              color: LinagoraSysColors.material().onPrimary,
+                              tooltip: L10n.of(context)!.share,
+                            ),
+                          if (controller.widget.event != null)
+                            Padding(
+                              padding: MediaViewewAppbarStyle.paddingRightMenu,
+                              child: Directionality(
+                                textDirection: TextDirection.rtl,
+                                child: MenuAnchor(
+                                  style: const MenuStyle(
+                                    alignment: Alignment.bottomRight,
+                                  ),
+                                  controller: controller.menuController,
+                                  menuChildren: [
+                                    ContextMenuItemImageViewer(
+                                      icon: Icons.file_download_outlined,
+                                      title: L10n.of(context)!.saveFile,
+                                      onTap: controller.saveFileAction,
+                                    ),
+                                    ContextMenuItemImageViewer(
+                                      title: L10n.of(context)!.showInChat,
+                                      imagePath: ImagePaths.icShowInChat,
+                                      onTap: controller.showInChat,
+                                      haveDivider: false,
+                                    ),
+                                  ],
+                                  child: InkWell(
+                                    borderRadius: MediaViewewAppbarStyle
+                                        .showMoreIconSplashRadius,
+                                    onTap: controller.toggleShowMoreActions,
+                                    child: Padding(
+                                      padding: MediaViewewAppbarStyle
+                                          .marginAllShowMoreIcon,
+                                      child: TwakeIconButton(
+                                        paddingAll: MediaViewewAppbarStyle
+                                            .paddingAllShowMoreIcon,
+                                        icon: Icons.more_vert,
+                                        iconColor: LinagoraSysColors.material()
+                                            .onPrimary,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
+                  )
+                : SizedBox(width: MediaQuery.sizeOf(context).width),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/enum/chat/media_viewer_popup_result_enum.dart
+++ b/lib/presentation/enum/chat/media_viewer_popup_result_enum.dart
@@ -1,0 +1,3 @@
+enum MediaViewerPopupResultEnum {
+  closeRightColumnFlag,
+}

--- a/lib/presentation/mixins/play_video_action_mixin.dart
+++ b/lib/presentation/mixins/play_video_action_mixin.dart
@@ -21,7 +21,10 @@ mixin PlayVideoActionMixin {
                   path: uriOrFilePath,
                   event: event,
                 )
-              : VideoViewerDesktopTheme(path: uriOrFilePath),
+              : VideoViewerDesktopTheme(
+                  path: uriOrFilePath,
+                  event: event,
+                ),
         );
       },
     );

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:fluffychat/pages/image_viewer/image_viewer.dart';
+import 'package:fluffychat/presentation/enum/chat/media_viewer_popup_result_enum.dart';
 import 'package:fluffychat/utils/interactive_viewer_gallery.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -40,7 +41,7 @@ class MxcImage extends StatefulWidget {
   /// Cache for screen locally, if null, use global cache
   final Map<EventId, ImageData>? cacheMap;
 
-  final VoidCallback? onCloseRightColumn;
+  final VoidCallback? closeRightColumn;
 
   const MxcImage({
     this.uri,
@@ -63,7 +64,7 @@ class MxcImage extends StatefulWidget {
     this.isPreview = false,
     this.cacheMap,
     this.noResize = false,
-    this.onCloseRightColumn,
+    this.closeRightColumn,
     Key? key,
   }) : super(key: key);
 
@@ -209,18 +210,21 @@ class _MxcImageState extends State<MxcImage>
   void _onTap(BuildContext context) async {
     if (widget.onTapPreview != null) {
       widget.onTapPreview!();
-      Navigator.of(context, rootNavigator: PlatformInfos.isWeb).push(
+      final result =
+          await Navigator.of(context, rootNavigator: PlatformInfos.isWeb).push(
         HeroPageRoute(
           builder: (context) {
             return InteractiveViewerGallery(
               itemBuilder: ImageViewer(
                 event: widget.event!,
-                onCloseRightColumn: widget.onCloseRightColumn,
               ),
             );
           },
         ),
       );
+      if (result == MediaViewerPopupResultEnum.closeRightColumnFlag) {
+        widget.closeRightColumn?.call();
+      }
     } else if (widget.onTapSelectMode != null) {
       widget.onTapSelectMode!();
       return;
@@ -261,6 +265,7 @@ class _MxcImageState extends State<MxcImage>
     if (widget.isPreview) {
       return Material(
         child: InkWell(
+          mouseCursor: SystemMouseCursors.click,
           borderRadius:
               widget.rounded ? BorderRadius.circular(12.0) : BorderRadius.zero,
           onTap: widget.onTapPreview != null || widget.onTapSelectMode != null

--- a/lib/widgets/video_player.dart
+++ b/lib/widgets/video_player.dart
@@ -1,4 +1,6 @@
+import 'package:fluffychat/pages/image_viewer/media_viewer_app_bar.dart';
 import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
@@ -6,9 +8,12 @@ class VideoPlayer extends StatefulWidget {
   const VideoPlayer({
     super.key,
     required this.path,
+    required this.event,
   });
 
   final String path;
+
+  final Event? event;
 
   @override
   State<VideoPlayer> createState() => _VideoPlayerState();
@@ -31,11 +36,20 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   @override
   Widget build(BuildContext context) {
-    return Video(
-      fill: Colors.transparent,
-      pauseUponEnteringBackgroundMode: true,
-      resumeUponEnteringForegroundMode: true,
-      controller: videoController,
+    return Scaffold(
+      body: Stack(
+        children: [
+          Video(
+            fill: Colors.black,
+            pauseUponEnteringBackgroundMode: true,
+            resumeUponEnteringForegroundMode: true,
+            controller: videoController,
+          ),
+          MediaViewerAppBar(
+            event: widget.event,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/video_viewer_desktop_theme.dart
+++ b/lib/widgets/video_viewer_desktop_theme.dart
@@ -1,35 +1,29 @@
-import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:fluffychat/widgets/video_player.dart';
 import 'package:fluffychat/widgets/video_viewer_style.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:matrix/matrix.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
 class VideoViewerDesktopTheme extends StatelessWidget {
   const VideoViewerDesktopTheme({
     super.key,
     required this.path,
+    this.event,
   });
 
   final String path;
+
+  final Event? event;
 
   @override
   Widget build(BuildContext context) {
     return MaterialDesktopVideoControlsTheme(
       normal: MaterialDesktopVideoControlsThemeData(
-        topButtonBar: [
-          TwakeIconButton(
-            tooltip: L10n.of(context)!.back,
-            icon: Icons.close,
-            onTap: () => context.pop(),
-            iconColor: Theme.of(context).colorScheme.surface,
-          ),
-        ],
         seekBarColor: Theme.of(context).colorScheme.onSurfaceVariant,
         seekBarPositionColor: Theme.of(context).colorScheme.primary,
         seekBarHeight: VideoViewerStyle.seekBarHeight,
         seekBarThumbColor: Theme.of(context).colorScheme.primary,
+        topButtonBarMargin: const EdgeInsets.all(0),
       ),
       fullscreen: MaterialDesktopVideoControlsThemeData(
         seekBarColor: Theme.of(context).colorScheme.onSurfaceVariant,
@@ -39,6 +33,7 @@ class VideoViewerDesktopTheme extends StatelessWidget {
       ),
       child: VideoPlayer(
         path: path,
+        event: event,
       ),
     );
   }

--- a/lib/widgets/video_viewer_mobile_theme.dart
+++ b/lib/widgets/video_viewer_mobile_theme.dart
@@ -1,9 +1,7 @@
 import 'package:fluffychat/widgets/mxc_image.dart';
-import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:fluffychat/widgets/video_player.dart';
 import 'package:fluffychat/widgets/video_viewer_style.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:matrix/matrix.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 
@@ -23,14 +21,6 @@ class VideoViewerMobileTheme extends StatelessWidget {
     return MaterialVideoControlsTheme(
       normal: MaterialVideoControlsThemeData(
         topButtonBarMargin: VideoViewerStyle.topButtonBarMargin(context),
-        topButtonBar: [
-          TwakeIconButton(
-            tooltip: L10n.of(context)!.back,
-            icon: Icons.close,
-            onTap: () => Navigator.of(context).pop(),
-            iconColor: Theme.of(context).colorScheme.surface,
-          ),
-        ],
         bottomButtonBar: const [
           MaterialPositionIndicator(),
           Spacer(),
@@ -50,10 +40,14 @@ class VideoViewerMobileTheme extends StatelessWidget {
                 MxcImage(event: event),
                 VideoPlayer(
                   path: path,
+                  event: event,
                 ),
               ],
             )
-          : VideoPlayer(path: path),
+          : VideoPlayer(
+              path: path,
+              event: event,
+            ),
     );
   }
 }


### PR DESCRIPTION
### Updated:
- Remove `onCloseRightColumn` -> use Navigator.pop with result instead
- Hide viewer action currently only work with `DownloadVideoWidget`, not `VideoPlayer`

### Issue:
#1499

### Demo mobile:

https://github.com/linagora/twake-on-matrix/assets/43041967/e2404f37-ddab-4cff-8e82-0b7c6a4e6d57

### Demo web:

https://github.com/linagora/twake-on-matrix/assets/43041967/bb47e9c5-1762-42fe-bb77-435b2a1a5e4c

### demo mobile android:

https://github.com/linagora/twake-on-matrix/assets/43041967/c2c48887-798f-4a24-8f1b-62e323acc9e9

