### PR TITLE
TW-1400: allow user to change avatar, group name, pin message, invite people in chat

### DIFF
--- a/lib/config/default_power_level_member.dart
+++ b/lib/config/default_power_level_member.dart
@@ -1,0 +1,18 @@
+enum DefaultPowerLevelMember {
+  user,
+  moderator,
+  admin;
+
+  int get powerLevel {
+    switch (this) {
+      case DefaultPowerLevelMember.user:
+        return 0;
+      case DefaultPowerLevelMember.moderator:
+        return 50;
+      case DefaultPowerLevelMember.admin:
+        return 100;
+      default:
+        return 0;
+    }
+  }
+}

--- a/lib/di/global/get_it_initializer.dart
+++ b/lib/di/global/get_it_initializer.dart
@@ -79,6 +79,7 @@ import 'package:fluffychat/domain/usecase/settings/update_profile_interactor.dar
 import 'package:fluffychat/event/twake_event_dispatcher.dart';
 import 'package:fluffychat/pages/chat/chat_pinned_events/pinned_events_controller.dart';
 import 'package:fluffychat/utils/famedlysdk_store.dart';
+import 'package:fluffychat/utils/power_level_manager.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:get_it/get_it.dart';
 
@@ -110,6 +111,7 @@ class GetItInitializer {
     HiveDI().bind();
     NetworkConnectivityDI().bind();
     getIt.registerSingleton(ResponsiveUtils());
+    getIt.registerSingleton(PowerLevelManager());
     getIt.registerSingleton(TwakeEventDispatcher());
     getIt.registerSingleton(Store());
     getIt.registerFactory<LanguageCacheManager>(() => LanguageCacheManager());

--- a/lib/domain/model/room/create_new_group_chat_request.dart
+++ b/lib/domain/model/room/create_new_group_chat_request.dart
@@ -7,6 +7,7 @@ class CreateNewGroupChatRequest extends Equatable {
   final bool? enableEncryption;
   final CreateRoomPreset createRoomPreset;
   final String? urlAvatar;
+  final Map<String, dynamic>? powerLevelContentOverride;
 
   const CreateNewGroupChatRequest({
     this.groupName,
@@ -14,6 +15,7 @@ class CreateNewGroupChatRequest extends Equatable {
     this.enableEncryption,
     this.createRoomPreset = CreateRoomPreset.privateChat,
     this.urlAvatar,
+    this.powerLevelContentOverride,
   });
 
   @override
@@ -23,5 +25,6 @@ class CreateNewGroupChatRequest extends Equatable {
         enableEncryption,
         createRoomPreset,
         urlAvatar,
+        powerLevelContentOverride,
       ];
 }

--- a/lib/domain/usecase/room/create_new_group_chat_interactor.dart
+++ b/lib/domain/usecase/room/create_new_group_chat_interactor.dart
@@ -37,6 +37,8 @@ class CreateNewGroupChatInteractor {
         enableEncryption: createNewGroupChatRequest.enableEncryption,
         preset: createNewGroupChatRequest.createRoomPreset,
         initialState: [addAvatarStateEvent, historyVisibilityStateEvent],
+        powerLevelContentOverride:
+            createNewGroupChatRequest.powerLevelContentOverride,
       );
 
       if (roomId.isNotEmpty) {

--- a/lib/pages/new_group/new_group_chat_info.dart
+++ b/lib/pages/new_group/new_group_chat_info.dart
@@ -116,6 +116,7 @@ class NewGroupChatInfoController extends State<NewGroupChatInfo>
       EventTypes.RoomName: getPowerLevelUserInChat(),
       EventTypes.RoomAvatar: getPowerLevelUserInChat(),
       EventTypes.RoomMember: getPowerLevelUserInChat(),
+      EventTypes.RoomTopic: getPowerLevelUserInChat(),
     };
   }
 

--- a/lib/pages/new_group/new_group_chat_info.dart
+++ b/lib/pages/new_group/new_group_chat_info.dart
@@ -114,6 +114,7 @@ class NewGroupChatInfoController extends State<NewGroupChatInfo>
     return {
       EventTypes.RoomPinnedEvents: getPowerLevelUserInChat(),
       EventTypes.RoomName: getPowerLevelUserInChat(),
+      EventTypes.RoomAvatar: getPowerLevelUserInChat(),
     };
   }
 

--- a/lib/pages/new_group/new_group_chat_info.dart
+++ b/lib/pages/new_group/new_group_chat_info.dart
@@ -115,6 +115,7 @@ class NewGroupChatInfoController extends State<NewGroupChatInfo>
       EventTypes.RoomPinnedEvents: getPowerLevelUserInChat(),
       EventTypes.RoomName: getPowerLevelUserInChat(),
       EventTypes.RoomAvatar: getPowerLevelUserInChat(),
+      EventTypes.RoomMember: getPowerLevelUserInChat(),
     };
   }
 

--- a/lib/pages/new_group/new_group_chat_info.dart
+++ b/lib/pages/new_group/new_group_chat_info.dart
@@ -113,6 +113,7 @@ class NewGroupChatInfoController extends State<NewGroupChatInfo>
   Map<String, dynamic> _getOverridePowerLevelEventForMember() {
     return {
       EventTypes.RoomPinnedEvents: getPowerLevelUserInChat(),
+      EventTypes.RoomName: getPowerLevelUserInChat(),
     };
   }
 

--- a/lib/pages/new_group/new_group_chat_info.dart
+++ b/lib/pages/new_group/new_group_chat_info.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
 import 'package:fluffychat/app_state/success.dart';
-import 'package:fluffychat/config/power_level_member_in_chat.dart';
 import 'package:fluffychat/domain/app_state/room/create_new_group_chat_state.dart';
 import 'package:fluffychat/domain/app_state/room/upload_content_state.dart';
 import 'package:fluffychat/pages/new_group/new_group_chat_info_view.dart';
@@ -12,6 +11,7 @@ import 'package:fluffychat/presentation/mixins/common_media_picker_mixin.dart';
 import 'package:fluffychat/presentation/mixins/single_image_picker_mixin.dart';
 import 'package:fluffychat/presentation/model/presentation_contact.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
+import 'package:fluffychat/utils/power_level_manager.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
@@ -93,6 +93,7 @@ class NewGroupChatInfoController extends State<NewGroupChatInfo>
 
   void createNewGroup({String? urlAvatar}) {
     final client = Matrix.of(context).client;
+    final powerLevelManager = getIt.get<PowerLevelManager>();
     createNewGroupChatAction(
       matrixClient: client,
       createNewGroupChatRequest: CreateNewGroupChatRequest(
@@ -104,24 +105,10 @@ class NewGroupChatInfoController extends State<NewGroupChatInfo>
         enableEncryption: enableEncryptionNotifier.value,
         urlAvatar: urlAvatar,
         powerLevelContentOverride: {
-          'events': _getOverridePowerLevelEventForMember(),
+          'events': powerLevelManager.getDefaultPowerLevelEventForMember(),
         },
       ),
     );
-  }
-
-  Map<String, dynamic> _getOverridePowerLevelEventForMember() {
-    return {
-      EventTypes.RoomPinnedEvents: getPowerLevelUserInChat(),
-      EventTypes.RoomName: getPowerLevelUserInChat(),
-      EventTypes.RoomAvatar: getPowerLevelUserInChat(),
-      EventTypes.RoomMember: getPowerLevelUserInChat(),
-      EventTypes.RoomTopic: getPowerLevelUserInChat(),
-    };
-  }
-
-  int getPowerLevelUserInChat() {
-    return DefaultPowerLevelMemberInChat.user;
   }
 
   void _handleUploadAvatarNewGroupChatOnData(

--- a/lib/pages/new_group/new_group_chat_info.dart
+++ b/lib/pages/new_group/new_group_chat_info.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
 import 'package:fluffychat/app_state/success.dart';
+import 'package:fluffychat/config/power_level_member_in_chat.dart';
 import 'package:fluffychat/domain/app_state/room/create_new_group_chat_state.dart';
 import 'package:fluffychat/domain/app_state/room/upload_content_state.dart';
 import 'package:fluffychat/pages/new_group/new_group_chat_info_view.dart';
@@ -102,8 +103,21 @@ class NewGroupChatInfoController extends State<NewGroupChatInfo>
             .toList(),
         enableEncryption: enableEncryptionNotifier.value,
         urlAvatar: urlAvatar,
+        powerLevelContentOverride: {
+          'events': _getOverridePowerLevelEventForMember(),
+        },
       ),
     );
+  }
+
+  Map<String, dynamic> _getOverridePowerLevelEventForMember() {
+    return {
+      EventTypes.RoomPinnedEvents: getPowerLevelUserInChat(),
+    };
+  }
+
+  int getPowerLevelUserInChat() {
+    return DefaultPowerLevelMemberInChat.user;
   }
 
   void _handleUploadAvatarNewGroupChatOnData(

--- a/lib/utils/power_level_manager.dart
+++ b/lib/utils/power_level_manager.dart
@@ -1,0 +1,26 @@
+import 'package:fluffychat/config/default_power_level_member.dart';
+import 'package:matrix/matrix.dart';
+
+class PowerLevelManager {
+  static final PowerLevelManager _instance = PowerLevelManager._internal();
+
+  PowerLevelManager._internal();
+
+  factory PowerLevelManager() {
+    return _instance;
+  }
+
+  int getUserPowerLevel() {
+    return DefaultPowerLevelMember.user.powerLevel;
+  }
+
+  Map<String, dynamic> getDefaultPowerLevelEventForMember() {
+    return {
+      EventTypes.RoomPinnedEvents: getUserPowerLevel(),
+      EventTypes.RoomName: getUserPowerLevel(),
+      EventTypes.RoomAvatar: getUserPowerLevel(),
+      EventTypes.RoomMember: getUserPowerLevel(),
+      EventTypes.RoomTopic: getUserPowerLevel(),
+    };
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1551,7 +1551,7 @@ packages:
     description:
       path: "."
       ref: "twake-supported-0.22.6"
-      resolved-ref: "8e69a2315c6bcd1dc2d89ee3d9601d6740b18304"
+      resolved-ref: "599c37af897625f936bdab98d56d3deef789c171"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"


### PR DESCRIPTION
### Ticket:
#1400 

### Blocker:
https://github.com/linagora/matrix-dart-sdk/pull/49
### Problem:
Before that, the power level of pin message default to be 100 (means that only admin can pin the message), but when create a room, we have an option to override the default power level of the members in the room. So that, we only need to set the power level of pin/unpin event to equals the power level of user in the room

### Demo:

https://github.com/linagora/twake-on-matrix/assets/43041967/0a19c5c1-d86b-40c7-9bb1-3034ff8f9b69

