### PR TITLE
[TW-1503] Format time for message

### DIFF
--- a/lib/utils/date_time_extension.dart
+++ b/lib/utils/date_time_extension.dart
@@ -41,11 +41,12 @@ extension DateTimeExtension on DateTime {
   /// Returns [localizedTimeOfDay()] if the ChatTime is today, the name of the week
   /// day if the ChatTime is this week and a date string else.
   String localizedTimeShort(BuildContext context, {DateTime? currentTime}) {
-    final now = currentTime ?? DateTime.now();
+    currentTime ??= DateTime.now();
 
-    final sameYear = now.year == year;
+    final sameYear = currentTime.year == year;
 
-    final sameDay = sameYear && now.month == month && now.day == day;
+    final sameDay =
+        sameYear && currentTime.month == month && currentTime.day == day;
 
     final sameWeek = isInCurrentWeek(currentTime: currentTime);
 
@@ -81,9 +82,10 @@ extension DateTimeExtension on DateTime {
   }
 
   bool isInCurrentWeek({DateTime? currentTime}) {
-    final now = currentTime ?? DateTime.now();
+    currentTime ??= DateTime.now();
 
-    final currentWeekStart = now.subtract(Duration(days: now.weekday - 1));
+    final currentWeekStart =
+        currentTime.subtract(Duration(days: currentTime.weekday - 1));
 
     final weekStart = subtract(Duration(days: weekday - 1));
 

--- a/lib/utils/date_time_extension.dart
+++ b/lib/utils/date_time_extension.dart
@@ -40,17 +40,14 @@ extension DateTimeExtension on DateTime {
 
   /// Returns [localizedTimeOfDay()] if the ChatTime is today, the name of the week
   /// day if the ChatTime is this week and a date string else.
-  String localizedTimeShort(BuildContext context) {
-    final now = DateTime.now();
+  String localizedTimeShort(BuildContext context, {DateTime? currentTime}) {
+    final now = currentTime ?? DateTime.now();
 
     final sameYear = now.year == year;
 
     final sameDay = sameYear && now.month == month && now.day == day;
 
-    final sameWeek = sameYear &&
-        !sameDay &&
-        now.millisecondsSinceEpoch - millisecondsSinceEpoch <
-            1000 * 60 * 60 * 24 * 7;
+    final sameWeek = isInCurrentWeek(currentTime: currentTime);
 
     if (sameDay) {
       return localizedTimeOfDay(context);
@@ -71,7 +68,7 @@ extension DateTimeExtension on DateTime {
         case 7:
           return L10n.of(context)!.sunday;
       }
-    } else if (year == DateTime.now().year) {
+    } else if (sameYear) {
       return DateFormat("MMM d").format(this);
     } else {
       return DateFormat("dd/MM/yy").format(this);
@@ -81,6 +78,18 @@ extension DateTimeExtension on DateTime {
       month.toString().padLeft(2, '0'),
       day.toString().padLeft(2, '0'),
     );
+  }
+
+  bool isInCurrentWeek({DateTime? currentTime}) {
+    final now = currentTime ?? DateTime.now();
+
+    final currentWeekStart = now.subtract(Duration(days: now.weekday - 1));
+
+    final weekStart = subtract(Duration(days: weekday - 1));
+
+    return currentWeekStart.year == weekStart.year &&
+        currentWeekStart.month == weekStart.month &&
+        currentWeekStart.day == weekStart.day;
   }
 
   /// If the DateTime is today, this returns [localizedTimeOfDay()], if not it also

--- a/test/utils/date_time_extension_test.dart
+++ b/test/utils/date_time_extension_test.dart
@@ -334,6 +334,172 @@ void main() {
     });
 
     testWidgets(
+        'GIVEN the current time is Sunday\n'
+        'AND the date time to display is Friday of current week\n'
+        'THEN should display Friday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Friday';
+      final currentTime = DateTime(2024, 3, 3);
+      final timeToTest = DateTime(2024, 3, 1, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the current time is Sunday\n'
+        'AND the date time to display is Saturday of current week\n'
+        'THEN should display Saturday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Saturday';
+      final currentTime = DateTime(2024, 3, 3);
+      final timeToTest = DateTime(2024, 3, 2, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN current time is Sunday\n'
+        'AND the date time to display is Monday of the next week\n'
+        'THEN should display the date in the format MMM d\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = 'Mar 4';
+      final currentTime = DateTime(2024, 3, 3);
+      final timeToTest = DateTime(2024, 3, 4, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN current time is Sunday\n'
+        'AND the date time to display is Tuesday of the next week\n'
+        'THEN should display the date in the format MMM d\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = 'Mar 5';
+      final currentTime = DateTime(2024, 3, 3);
+      final timeToTest = DateTime(2024, 3, 5, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
         'GIVEN the date time to display is not in the same week\n'
         'AND in the same year\n'
         'THEN should display the date in the format MMM d\n',

--- a/test/utils/date_time_extension_test.dart
+++ b/test/utils/date_time_extension_test.dart
@@ -1,0 +1,653 @@
+import 'package:fluffychat/utils/date_time_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(
+      '[localizedTimeShort TEST]\n'
+      'GIVEN a Text widget\n'
+      'USING localizedTimeShort\n', () {
+    const textWidgetKey = ValueKey('textWidget');
+
+    testWidgets(
+        'GIVEN the date time to display is today\n'
+        'THEN should display the time in the format HH:mm\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = '12:05';
+      final currentTime = DateTime(2022, 1, 1);
+      final timeToTest = DateTime(2022, 1, 1, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is Monday of current week\n'
+        'THEN should display the Monday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Monday';
+      final currentTime = DateTime(2022, 1, 1);
+      final timeToTest = DateTime(2021, 12, 27, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is Tuesday of current week\n'
+        'THEN should display Tuesday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Tuesday';
+      final currentTime = DateTime(2022, 1, 1);
+      final timeToTest = DateTime(2021, 12, 28, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is Wednesday of current week\n'
+        'THEN should display Wednesday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Wednesday';
+      final currentTime = DateTime(2022, 1, 1);
+      final timeToTest = DateTime(2021, 12, 29, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is Thursday of current week\n'
+        'THEN should display Thursday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Thursday';
+      final currentTime = DateTime(2022, 1, 1);
+      final timeToTest = DateTime(2021, 12, 30, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is Friday of current week\n'
+        'THEN should display Friday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Friday';
+      final currentTime = DateTime(2022, 1, 1);
+      final timeToTest = DateTime(2021, 12, 31, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is Saturday of current week\n'
+        'THEN should display Saturday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Saturday';
+      final currentTime = DateTime(2024, 2, 25);
+      final timeToTest = DateTime(2024, 2, 24, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is Sunday of current week\n'
+        'THEN should display Sunday\n', (WidgetTester tester) async {
+      const expectedDisplayText = 'Sunday';
+      final currentTime = DateTime(2022, 1, 1);
+      final timeToTest = DateTime(2022, 1, 2, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is not in the same week\n'
+        'AND in the same year\n'
+        'THEN should display the date in the format MMM d\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = 'Feb 22';
+      final currentTime = DateTime(2024, 2, 28);
+      final timeToTest = DateTime(2024, 2, 22, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is not in the same week\n'
+        'AND in the same year\n'
+        'THEN should display the date in the format MMM d\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = 'Feb 25';
+      final currentTime = DateTime(2024, 2, 28);
+      final timeToTest = DateTime(2024, 2, 25, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is not in the same week\n'
+        'AND in the same year\n'
+        'THEN should display the date in the format MMM d\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = 'Feb 24';
+      final currentTime = DateTime(2024, 2, 28);
+      final timeToTest = DateTime(2024, 2, 24, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is not in the same week\n'
+        'AND in the same year\n'
+        'THEN should display the date in the format MMM d\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = 'Feb 25';
+      final currentTime = DateTime(2024, 2, 26);
+      final timeToTest = DateTime(2024, 2, 25, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is not in the same week\n'
+        'AND in the same year\n'
+        'THEN should display the date in the format MMM d\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = 'Feb 24';
+      final currentTime = DateTime(2024, 2, 26);
+      final timeToTest = DateTime(2024, 2, 24, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is not in the same week\n'
+        'AND in the same year\n'
+        'THEN should display the date in the format MMM d\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = 'Feb 23';
+      final currentTime = DateTime(2024, 2, 26);
+      final timeToTest = DateTime(2024, 2, 23, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+
+    testWidgets(
+        'GIVEN the date time to display is not in the same week\n'
+        'AND not in the same year\n'
+        'THEN should display the date in the format dd/MM/yy\n',
+        (WidgetTester tester) async {
+      const expectedDisplayText = '22/02/23';
+      final currentTime = DateTime(2024, 2, 28);
+      final timeToTest = DateTime(2023, 2, 22, 12, 5);
+
+      final textWidgetBuilder = Builder(
+        builder: (BuildContext context) {
+          final displayText = timeToTest.localizedTimeShort(
+            context,
+            currentTime: currentTime,
+          );
+
+          return Text(
+            displayText,
+            key: textWidgetKey,
+          );
+        },
+      );
+
+      await tester.binding.setLocale('en', 'US');
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: const [L10n.delegate],
+          home: textWidgetBuilder,
+        ),
+      );
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals(expectedDisplayText));
+    });
+  });
+
+  group('[isInCurrentWeek TEST]', () {
+    final currentTime = DateTime(2022, 1, 1);
+    test(
+        'GIVEN time to check is in current week\n'
+        'THEN return true', () {
+      final timeToTest = DateTime(2021, 12, 27, 12, 5);
+
+      final result = timeToTest.isInCurrentWeek(currentTime: currentTime);
+
+      expect(result, isTrue);
+    });
+
+    test(
+        'GIVEN time to check is not in current week\n'
+        'THEN return false', () {
+      final timeToTest = DateTime(2021, 12, 20, 12, 5);
+
+      final result = timeToTest.isInCurrentWeek(currentTime: currentTime);
+
+      expect(result, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Ticket
- #1503 

## Root cause
- The condition to check if day is in current week is wrong

## Solution
* Update the condition:
   * Subtract now from `now.weekday - 1` to find the start day of the current week
   * Subtract the date to format from `date.weekday - 1` to find the start of the week in the date to format
   * Compare these 2 values

## Resolved

https://github.com/linagora/twake-on-matrix/assets/80142234/5c84cea2-421d-473f-ae4d-f2799e9fc984

