### PR TITLE
TW-1406: can not go back in chat search screen in android

### DIFF
--- a/lib/pages/chat_search/chat_search_view.dart
+++ b/lib/pages/chat_search/chat_search_view.dart
@@ -15,7 +15,6 @@ import 'package:fluffychat/presentation/same_type_events_builder/same_type_event
 import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/result_extension.dart';
-import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/string_extension.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
 import 'package:fluffychat/widgets/highlight_text.dart';
@@ -38,32 +37,24 @@ class ChatSearchView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: false,
-      onPopInvoked: (isPop) async {
-        if (PlatformInfos.isAndroid) {
-          controller.onBack();
-        }
-      },
-      child: Scaffold(
+    return Scaffold(
+      backgroundColor: LinagoraSysColors.material().onPrimary,
+      appBar: AppBar(
+        toolbarHeight: AppConfig.toolbarHeight(context),
         backgroundColor: LinagoraSysColors.material().onPrimary,
-        appBar: AppBar(
-          toolbarHeight: AppConfig.toolbarHeight(context),
-          backgroundColor: LinagoraSysColors.material().onPrimary,
-          automaticallyImplyLeading: false,
-          title: _ChatSearchAppBar(controller),
-        ),
-        body: controller.sameTypeEventsBuilderController != null
-            ? _TimelineSearchView(
-                controller: controller,
-                sameTypeEventsBuilderController:
-                    controller.sameTypeEventsBuilderController!,
-              )
-            : _ServerSearchView(
-                controller: controller,
-                serverSearchController: controller.serverSearchController,
-              ),
+        automaticallyImplyLeading: false,
+        title: _ChatSearchAppBar(controller),
       ),
+      body: controller.sameTypeEventsBuilderController != null
+          ? _TimelineSearchView(
+              controller: controller,
+              sameTypeEventsBuilderController:
+                  controller.sameTypeEventsBuilderController!,
+            )
+          : _ServerSearchView(
+              controller: controller,
+              serverSearchController: controller.serverSearchController,
+            ),
     );
   }
 }


### PR DESCRIPTION
### Reason:
- The `pop()` inside PopScope is redundancy, and no need to have in Android device (even with device support [predictive back gesture](https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture))
<img width="712" alt="image" src="https://github.com/linagora/twake-on-matrix/assets/43041967/3fa3d823-7440-43dd-82f4-f9a814843383">

### Demo android:

https://github.com/linagora/twake-on-matrix/assets/43041967/e751d825-105e-40d6-a79c-890ade7659ed

