### PR TITLE
Hot-fix: Fix loading forever when we open chat

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1599,7 +1599,9 @@ class ChatController extends State<Chat>
           Logs().d(
             'Chat::handleDisplayStickyTimestamp() CurrentDateTimeEvent - $_currentDateTimeEvent',
           );
-          stickyTimestampNotifier.value = dateTime;
+          _updateStickyTimestampNotifier(
+            dateTime: dateTime,
+          );
         }
       }
     });
@@ -1618,7 +1620,7 @@ class ChatController extends State<Chat>
 
   void _handleHideStickyTimestamp() {
     Logs().d('Chat::_handleHideStickyTimestamp() - Hide sticky timestamp');
-    stickyTimestampNotifier.value = null;
+    _updateStickyTimestampNotifier();
   }
 
   void handleScrollEndNotification() {
@@ -1656,12 +1658,20 @@ class ChatController extends State<Chat>
 
     if (allMembershipEvents || canRequestHistory) {
       try {
-        await requestHistory(historyCount: _defaultEventCountDisplay);
+        await requestHistory(historyCount: _defaultEventCountDisplay)
+            .then((response) {
+          Logs().d(
+            'Chat::_tryRequestHistory():: Try request history success',
+          );
+        });
       } catch (e) {
         Logs().e(
           'Chat::_tryRequestHistory():: Error - $e',
         );
+      } finally {
+        _updateOpeningChatViewStateNotifier(ViewEventListSuccess());
       }
+    } else {
       _updateOpeningChatViewStateNotifier(ViewEventListSuccess());
     }
   }
@@ -1744,6 +1754,18 @@ class ChatController extends State<Chat>
       isUnpin: isUnpin,
       eventId: eventId,
     );
+  }
+
+  void _updateStickyTimestampNotifier({
+    DateTime? dateTime,
+  }) {
+    try {
+      stickyTimestampNotifier.value = dateTime;
+    } on FlutterError catch (e) {
+      Logs().e(
+        'Chat::_updateStickyTimestampNotifier():: FlutterError - $e',
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
### Root case:

- Only update chat view when we try request history success in this case `allMembershipEvents` and `canRequestHistory`.

- Problem about scrolling in chat related to this case.

### Resolved

- If `allMembershipEvents` is false and `canRequestHistory` is false update chat view with timeline from `_tryLoadTimeline`

- Case `allMembershipEvents` and `canRequestHistory` is false

https://github.com/linagora/twake-on-matrix/assets/99852347/fdd48a49-812b-4d44-ab7e-dc40d80475c1

- Case `allMembershipEvents` and `canRequestHistory` is true, old chat


https://github.com/linagora/twake-on-matrix/assets/99852347/9acb5b7b-f78e-4b21-be61-d4f8f3838fe0

- Case jump to old message when search in Search screen and Chat search


https://github.com/linagora/twake-on-matrix/assets/99852347/a51bd9af-6a77-4a8f-bdf2-db93a487584d



