### PR TITLE
Hot-fix: Fix can't hover message in chat list

### DIFF
--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -188,6 +188,7 @@ class ChatEventList extends StatelessWidget {
                                 event.originServerTs,
                               );
                             },
+                            onLongPress: controller.onSelectMessage,
                           )
                         : const SizedBox(),
                   );


### PR DESCRIPTION
### Root case

- When we updated the support actions in the pin screen, we updated the hover action in the `message` widget and reuse it in Chat and Pin screen, but only updated the Pin screen and forgot to update the chat screen again. So hover actions in the chat screen, there is no activity.


https://github.com/linagora/twake-on-matrix/assets/99852347/6e410794-3942-4a87-a748-28a955c24d96


### Resolved

https://github.com/linagora/twake-on-matrix/assets/99852347/c2ba94f9-68b0-47cf-8c4a-9c94ee492793

https://github.com/linagora/twake-on-matrix/assets/99852347/843dc42c-a3aa-429d-af5b-7ff2992dd824


https://github.com/linagora/twake-on-matrix/assets/99852347/425ba8a6-93ff-4687-b09a-b9b58b62b96e

