### PR TITLE
TW-1435: Big dot in message notification and chat list preview

### DIFF
--- a/lib/presentation/mixins/chat_list_item_mixin.dart
+++ b/lib/presentation/mixins/chat_list_item_mixin.dart
@@ -19,6 +19,7 @@ mixin ChatListItemMixin {
             hideEdit: true,
             plaintextBody: true,
             removeMarkdown: true,
+            removeBreakLine: true,
           ) ??
           Future.value(L10n.of(context)!.emptyChat),
       builder: (context, snapshot) {
@@ -108,6 +109,7 @@ mixin ChatListItemMixin {
               hideEdit: true,
               plaintextBody: true,
               removeMarkdown: true,
+              removeBreakLine: true,
             ) ??
             L10n.of(context)!.emptyChat;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1558,8 +1558,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "twake-supported-0.22.6"
-      resolved-ref: "40bab63ea8895015aed935bd3fb6c279c6fe294c"
+      ref: update-list-bullet-points
+      resolved-ref: "17fc0bddd86a54056feb71a24ff42b331cdb8740"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1558,8 +1558,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: update-list-bullet-points
-      resolved-ref: "17fc0bddd86a54056feb71a24ff42b331cdb8740"
+      ref: "twake-supported-0.22.6"
+      resolved-ref: "22311972c4d781133b893ae032dcb509b1351075"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   matrix:
     git:
       url: git@github.com:linagora/matrix-dart-sdk.git
-      ref: update-list-bullet-points
+      ref: twake-supported-0.22.6
 
   receive_sharing_intent:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   matrix:
     git:
       url: git@github.com:linagora/matrix-dart-sdk.git
-      ref: twake-supported-0.22.6
+      ref: update-list-bullet-points
 
   receive_sharing_intent:
     git:


### PR DESCRIPTION
## Ticket
- #1435  
- Add option for remove break line so the message preview can have more contents like Tele

## Relevant
- https://github.com/linagora/matrix-dart-sdk/pull/52

## Root cause
- `matrix-dart-sdk` library using list bullet points: `['●', '○', '■', '‣']`
## Solution
- Change list bullet points follow that using for message: `['-', '-', '-', '‣']`
- Also modify so that during `calcLocalizedBody`, new bullet points will not be removed.

## Resolved

https://github.com/linagora/twake-on-matrix/assets/80142234/2ea54ac5-f450-44eb-a87a-f9759cf0ae17


- Case user type big dot:

https://github.com/linagora/twake-on-matrix/assets/80142234/5a283b5d-e7dd-4e74-bf6a-927005636efd



https://github.com/linagora/twake-on-matrix/assets/80142234/cdd0e60a-ed15-40da-94d5-ec9c107d5054


- Android:

https://github.com/linagora/twake-on-matrix/assets/80142234/6279e42e-ed6c-49f9-a808-bc34caab6248

