### PR TITLE
TW-1573: [MOBILE] [ANDROID ONLY] Part 1 - Save file to Downloads folder device

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3014,5 +3014,7 @@
   "showInChat": "Show in chat",
   "phone": "Phone",
   "viewProfile": "View profile",
-  "profileInfo": "Profile info"
+  "profileInfo": "Profile info",
+  "saveToDownloads": "Save to Downloads",
+  "saveToGallery": "Save to Gallery"
 }

--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3016,5 +3016,19 @@
   "viewProfile": "View profile",
   "profileInfo": "Profile info",
   "saveToDownloads": "Save to Downloads",
-  "saveToGallery": "Save to Gallery"
+  "saveToGallery": "Save to Gallery",
+  "fileSavedToDownloads": "File saved to Downloads",
+  "saveFileToDownloadsError": "Failed to save file to Downloads",
+  "explainPermissionToDownloadFiles": "To continue, please allow {appName} to access storage permission. This permission is essential for saving file to Downloads folder.",
+  "@explainPermissionToDownloadFiles": {
+    "placeholders": {
+      "appName": {
+        "type": "String",
+        "placeholders": {
+          "count": {}
+        }
+      }
+    }
+  },
+  "downloading": "Downloading"
 }

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:fluffychat/pages/chat/chat_actions.dart';
+import 'package:fluffychat/pages/chat/events/message_content_mixin.dart';
 import 'package:fluffychat/presentation/extensions/event_update_extension.dart';
 import 'package:fluffychat/presentation/mixins/handle_clipboard_action_mixin.dart';
 import 'package:fluffychat/presentation/mixins/paste_image_mixin.dart';
@@ -103,7 +104,8 @@ class ChatController extends State<Chat>
         GoToDraftChatMixin,
         PasteImageMixin,
         HandleClipboardActionMixin,
-        TwakeContextMenuMixin {
+        TwakeContextMenuMixin,
+        MessageContentMixin {
   final NetworkConnectionService networkConnectionService =
       getIt.get<NetworkConnectionService>();
 
@@ -1767,6 +1769,59 @@ class ChatController extends State<Chat>
       Logs().e(
         'Chat::_updateStickyTimestampNotifier():: FlutterError - $e',
       );
+    }
+  }
+
+  List<PopupMenuEntry<ChatAppBarActions>> appBarActionsBuilder() {
+    final listAction = [
+      if (PlatformInfos.isAndroid) ...[
+        ChatAppBarActions.saveToGallery,
+        ChatAppBarActions.saveToDownload,
+      ],
+      ChatAppBarActions.info,
+      ChatAppBarActions.report,
+    ];
+    return listAction
+        .map(
+          (action) => PopupMenuItem(
+            value: action,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  action.getIcon(),
+                  color: action.getColorIcon(context),
+                ),
+                Padding(
+                  padding: action.getPaddingTitle(),
+                  child: Text(action.getTitle(context)),
+                ),
+              ],
+            ),
+          ),
+        )
+        .toList();
+  }
+
+  void onSelectedAppBarActions(ChatAppBarActions action) {
+    switch (action) {
+      case ChatAppBarActions.saveToGallery:
+        break;
+      case ChatAppBarActions.saveToDownload:
+        break;
+      case ChatAppBarActions.info:
+        actionWithClearSelections(
+          () => showEventInfo(
+            context,
+            selectedEvents.single,
+          ),
+        );
+        break;
+      case ChatAppBarActions.report:
+        actionWithClearSelections(
+          reportEventAction,
+        );
+        break;
     }
   }
 

--- a/lib/pages/chat/chat_actions.dart
+++ b/lib/pages/chat/chat_actions.dart
@@ -1,22 +1,14 @@
 import 'package:fluffychat/pages/chat/chat_actions_style.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
 
-enum PickerType { gallery, documents, location, contact }
+enum PickerType {
+  gallery,
+  documents,
+  location,
+  contact;
 
-enum ChatScrollState {
-  scrolling,
-  startScroll,
-  endScroll;
-
-  bool get isScrolling => this == ChatScrollState.scrolling;
-
-  bool get isStartScroll => this == ChatScrollState.startScroll;
-
-  bool get isEndScroll => this == ChatScrollState.endScroll;
-}
-
-extension PickerTypeExtension on PickerType {
   String getTitle(BuildContext context) {
     switch (this) {
       case PickerType.gallery:
@@ -67,5 +59,65 @@ extension PickerTypeExtension on PickerType {
       case PickerType.contact:
         return ChatActionsStyle.colorBackgroundContactBottom;
     }
+  }
+}
+
+enum ChatScrollState {
+  scrolling,
+  startScroll,
+  endScroll;
+
+  bool get isScrolling => this == ChatScrollState.scrolling;
+
+  bool get isStartScroll => this == ChatScrollState.startScroll;
+
+  bool get isEndScroll => this == ChatScrollState.endScroll;
+}
+
+enum ChatAppBarActions {
+  info,
+  report,
+  saveToDownload,
+  saveToGallery;
+
+  String getTitle(BuildContext context) {
+    switch (this) {
+      case ChatAppBarActions.info:
+        return L10n.of(context)!.messageInfo;
+      case ChatAppBarActions.report:
+        return L10n.of(context)!.reportMessage;
+      case ChatAppBarActions.saveToDownload:
+        return L10n.of(context)!.saveToDownloads;
+      case ChatAppBarActions.saveToGallery:
+        return L10n.of(context)!.saveToGallery;
+    }
+  }
+
+  IconData getIcon() {
+    switch (this) {
+      case ChatAppBarActions.info:
+        return Icons.info_outlined;
+      case ChatAppBarActions.report:
+        return Icons.shield_outlined;
+      case ChatAppBarActions.saveToDownload:
+        return Icons.download_outlined;
+      case ChatAppBarActions.saveToGallery:
+        return Icons.save_outlined;
+    }
+  }
+
+  Color getColorIcon(BuildContext context) {
+    switch (this) {
+      case ChatAppBarActions.info:
+      case ChatAppBarActions.saveToDownload:
+      case ChatAppBarActions.saveToGallery:
+        return Theme.of(context).colorScheme.onSurface;
+      case ChatAppBarActions.report:
+        return LinagoraSysColors.material().errorDark;
+    }
+  }
+
+  EdgeInsets getPaddingTitle() {
+    return const EdgeInsets.only(left: 20);
   }
 }

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pages/chat/chat.dart';
+import 'package:fluffychat/pages/chat/chat_actions.dart';
 import 'package:fluffychat/pages/chat/chat_app_bar_title.dart';
 import 'package:fluffychat/pages/chat/chat_invitation_body.dart';
 import 'package:fluffychat/pages/chat/chat_view_body.dart';
@@ -14,8 +15,6 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:linagora_design_flutter/colors/linagora_state_layer.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
 import 'package:matrix/matrix.dart';
-
-enum _EventContextAction { info, report }
 
 class ChatView extends StatelessWidget with MessageContentMixin {
   final ChatController controller;
@@ -65,51 +64,9 @@ class ChatView extends StatelessWidget with MessageContentMixin {
               imageSize: ChatViewStyle.appBarIconSize,
             ),
           if (controller.selectedEvents.length == 1)
-            PopupMenuButton<_EventContextAction>(
-              onSelected: (action) {
-                switch (action) {
-                  case _EventContextAction.info:
-                    controller.actionWithClearSelections(
-                      () => showEventInfo(
-                        context,
-                        controller.selectedEvents.single,
-                      ),
-                    );
-                    break;
-                  case _EventContextAction.report:
-                    controller.actionWithClearSelections(
-                      controller.reportEventAction,
-                    );
-                    break;
-                }
-              },
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                  value: _EventContextAction.info,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Icon(Icons.info_outlined),
-                      const SizedBox(width: 12),
-                      Text(L10n.of(context)!.messageInfo),
-                    ],
-                  ),
-                ),
-                PopupMenuItem(
-                  value: _EventContextAction.report,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Icon(
-                        Icons.shield_outlined,
-                        color: Colors.red,
-                      ),
-                      const SizedBox(width: 12),
-                      Text(L10n.of(context)!.reportMessage),
-                    ],
-                  ),
-                ),
-              ],
+            PopupMenuButton<ChatAppBarActions>(
+              onSelected: controller.onSelectedAppBarActions,
+              itemBuilder: (context) => controller.appBarActionsBuilder(),
             ),
         ],
       );

--- a/lib/pages/chat/events/message_download_content.dart
+++ b/lib/pages/chat/events/message_download_content.dart
@@ -115,6 +115,18 @@ class _MessageDownloadContentState extends State<MessageDownloadContent>
     );
   }
 
+  void onDownloadFileTap() async {
+    await checkFileInDownloadsInApp();
+    if (downloadFileStateNotifier.value is DownloadedPresentationState) {
+      return;
+    }
+    downloadFileStateNotifier.value = const DownloadingPresentationState();
+    downloadManager.download(
+      event: widget.event,
+    );
+    _trySetupDownloadingStreamSubcription();
+  }
+
   @override
   void dispose() {
     streamSubscription?.cancel();
@@ -165,14 +177,7 @@ class _MessageDownloadContentState extends State<MessageDownloadContent>
         }
 
         return InkWell(
-          onTap: () {
-            downloadFileStateNotifier.value =
-                const DownloadingPresentationState();
-            downloadManager.download(
-              event: widget.event,
-            );
-            _trySetupDownloadingStreamSubcription();
-          },
+          onTap: onDownloadFileTap,
           child: DownloadFileTileWidget(
             mimeType: widget.event.mimeType,
             fileType: filetype,

--- a/lib/presentation/mixins/save_file_to_twake_downloads_folder_mixin.dart
+++ b/lib/presentation/mixins/save_file_to_twake_downloads_folder_mixin.dart
@@ -1,0 +1,175 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/app_state/success.dart';
+import 'package:fluffychat/utils/dialog/downloading_file_dialog.dart';
+import 'package:fluffychat/utils/exception/save_to_downloads_exception.dart';
+import 'package:fluffychat/utils/manager/download_manager/download_file_state.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
+import 'package:fluffychat/utils/storage_directory_utils.dart';
+import 'package:fluffychat/utils/twake_snackbar.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+
+mixin SaveFileToTwakeAndroidDownloadsFolderMixin {
+  void handleSaveToDownloadForDownloadingFile({
+    required BuildContext context,
+    required Stream<Either<Failure, Success>> downloadingStreamSubscription,
+    required Event event,
+  }) {
+    final downloadProgressNotifier = ValueNotifier<double?>(0);
+    StreamSubscription? streamSubscription;
+    streamSubscription = downloadingStreamSubscription.listen((downloadState) {
+      _onDownloadingFileStateChange(
+        event: event,
+        downloadState: downloadState,
+        context: context,
+        downloadProgressNotifier: downloadProgressNotifier,
+        streamSubscription: streamSubscription,
+      );
+    });
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => DownloadingFileDialog(
+        parentContext: context,
+        eventId: event.eventId,
+        downloadProgressNotifier: downloadProgressNotifier,
+      ),
+    );
+  }
+
+  Future<void> handleSaveToDownloadsForFileNotInDownloading(
+    Event event, {
+    required BuildContext context,
+  }) async {
+    final filePath =
+        await StorageDirectoryUtils.instance.getFilePathInAppDownloads(
+      eventId: event.eventId,
+      fileName: event.filename,
+    );
+    final file = File(filePath);
+    if (!await file.exists()) {
+      await _handleWhenFileHaveNotDownloaded(event, context);
+      return;
+    }
+    await handleSaveToDownloadsFolderWhenFileExisted(event, file, context);
+  }
+
+  Future<void> handleSaveToDownloadsFolderWhenFileExisted(
+    Event event,
+    File file,
+    BuildContext context,
+  ) async {
+    try {
+      final twakeFolder = await StorageDirectoryUtils.instance
+          .getTwakeDownloadsFolderInDevice();
+      if (twakeFolder?.isNotEmpty != true) {
+        throw SaveToDownloadsException(error: 'Twake folder is empty');
+      }
+      final twakeFilePath =
+          await StorageDirectoryUtils.instance.getAvailableFilePath(
+        '$twakeFolder/${event.filename}',
+      );
+
+      await File(twakeFilePath).create(recursive: true);
+      final copiedFile = await file.copy(twakeFilePath);
+      Logs().d(
+        'Chat::saveSelectedEventToDownloadAndroid():: Copied file - ${copiedFile.path}',
+      );
+      TwakeSnackBar.show(context, L10n.of(context)!.fileSavedToDownloads);
+    } catch (e) {
+      Logs().e(
+        'Chat::saveSelectedEventToDownloadAndroid():: Error - $e',
+      );
+      TwakeSnackBar.show(context, L10n.of(context)!.saveFileToDownloadsError);
+    }
+  }
+
+  Future<void> _handleWhenFileHaveNotDownloaded(
+    Event event,
+    BuildContext context,
+  ) async {
+    Logs().d(
+      'Chat::saveSelectedEventToDownloadAndroid():: File not exists',
+    );
+    final downloadStreamController =
+        StreamController<Either<Failure, Success>>();
+    final cancelDownloadToken = CancelToken();
+    StreamSubscription? streamSubcription;
+    final downloadProgressNotifier = ValueNotifier<double?>(0);
+    streamSubcription = downloadStreamController.stream.listen((downloadState) {
+      _onDownloadingFileStateChange(
+        event: event,
+        downloadState: downloadState,
+        context: context,
+        downloadProgressNotifier: downloadProgressNotifier,
+        streamSubscription: streamSubcription,
+      );
+    });
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (dialogContext) => DownloadingFileDialog(
+        parentContext: context,
+        eventId: event.eventId,
+        downloadProgressNotifier: downloadProgressNotifier,
+        cancelDownloadToken: cancelDownloadToken,
+      ),
+    );
+    await event.getFileInfo(
+      downloadStreamController: downloadStreamController,
+      cancelToken: cancelDownloadToken,
+    );
+  }
+
+  void _onDownloadingFileStateChange({
+    required Event event,
+    required Either<Failure, Success> downloadState,
+    required BuildContext context,
+    required ValueNotifier<double?> downloadProgressNotifier,
+    required StreamSubscription? streamSubscription,
+  }) {
+    downloadState.fold(
+      (left) {
+        Logs().e(
+          'Chat::saveSelectedEventToDownloadAndroid():: Downloading - $left',
+        );
+        _clear(
+          downloadProgressNotifier: downloadProgressNotifier,
+          streamSubscription: streamSubscription,
+        );
+      },
+      (right) async {
+        if (right is DownloadingFileState) {
+          if (right.total == 0) return null;
+          downloadProgressNotifier.value = right.receive / right.total;
+        } else if (right is DownloadNativeFileSuccessState) {
+          _clear(
+            downloadProgressNotifier: downloadProgressNotifier,
+            streamSubscription: streamSubscription,
+          );
+          Navigator.of(context, rootNavigator: true).pop();
+          await handleSaveToDownloadsForFileNotInDownloading(
+            event,
+            context: context,
+          );
+        }
+      },
+    );
+  }
+
+  void _clear({
+    ValueNotifier<double?>? downloadProgressNotifier,
+    StreamSubscription? streamSubscription,
+  }) {
+    downloadProgressNotifier?.dispose();
+    streamSubscription?.cancel();
+  }
+}

--- a/lib/utils/dialog/downloading_file_dialog.dart
+++ b/lib/utils/dialog/downloading_file_dialog.dart
@@ -1,0 +1,127 @@
+import 'package:dio/dio.dart';
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/utils/dialog/downloading_file_dialog_style.dart';
+import 'package:fluffychat/utils/manager/download_manager/download_manager.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+
+class DownloadingFileDialog extends StatelessWidget {
+  const DownloadingFileDialog({
+    super.key,
+    required this.parentContext,
+    required this.eventId,
+    required this.downloadProgressNotifier,
+    this.cancelDownloadToken,
+  });
+
+  final BuildContext parentContext;
+
+  final String eventId;
+
+  final ValueNotifier<double?> downloadProgressNotifier;
+
+  final CancelToken? cancelDownloadToken;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        backgroundColor: Colors.transparent,
+        body: Center(
+          child: Container(
+            width: DownloadingFileDialogStyle.dialogWidth,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: BorderRadius.circular(
+                DownloadingFileDialogStyle.borderRadiusDialog,
+              ),
+            ),
+            padding: DownloadingFileDialogStyle.paddingDialog,
+            child: IntrinsicHeight(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    L10n.of(parentContext)!.downloading,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurface,
+                          fontSize: DownloadingFileDialogStyle.titleFontSize,
+                        ),
+                  ),
+                  const SizedBox(height: 16.0),
+                  ValueListenableBuilder(
+                    valueListenable: downloadProgressNotifier,
+                    builder: (context, downloadProgress, child) {
+                      final downloadPercentage = (downloadProgress ?? 0) * 100;
+                      return Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(
+                              DownloadingFileDialogStyle.borderRadiusLoading,
+                            ),
+                            child: LinearProgressIndicator(
+                              backgroundColor: DownloadingFileDialogStyle
+                                  .backgroundColorLoading,
+                              value: downloadProgress,
+                            ),
+                          ),
+                          const SizedBox(height: 8.0),
+                          Text(
+                            '${downloadPercentage.toStringAsFixed(0)}%',
+                            style: TextStyle(
+                              color: Theme.of(context).colorScheme.onSurface,
+                              fontSize: DownloadingFileDialogStyle.fontSize,
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                  const SizedBox(
+                    height: 24,
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Material(
+                        color: Colors.transparent,
+                        child: InkWell(
+                          borderRadius: BorderRadius.circular(
+                            DownloadingFileDialogStyle.borderRadiusDialog,
+                          ),
+                          onTap: () => onCloseTap(context),
+                          child: Padding(
+                            padding: DownloadingFileDialogStyle.paddingButton,
+                            child: Text(
+                              L10n.of(parentContext)!.cancel,
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.primary,
+                                fontSize: DownloadingFileDialogStyle.fontSize,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void onCloseTap(BuildContext context) {
+    if (cancelDownloadToken != null) {
+      cancelDownloadToken!.cancel();
+    } else {
+      final downloadManager = getIt.get<DownloadManager>();
+      downloadManager.cancelDownload(eventId);
+    }
+    Navigator.of(context, rootNavigator: true).pop();
+  }
+}

--- a/lib/utils/dialog/downloading_file_dialog_style.dart
+++ b/lib/utils/dialog/downloading_file_dialog_style.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class DownloadingFileDialogStyle {
+  static const double dialogWidth = 300;
+
+  static const double dialogHeight = 220;
+
+  static const double borderRadiusDialog = 24.0;
+
+  static const double titleFontSize = 20;
+
+  static const double fontSize = 16.0;
+
+  static const double borderRadiusLoading = 8.0;
+
+  static const Color backgroundColorLoading = Colors.white;
+
+  static const EdgeInsetsGeometry paddingDialog = EdgeInsets.all(24.0);
+
+  static const EdgeInsetsGeometry paddingButton = EdgeInsets.all(8.0);
+}

--- a/lib/utils/exception/downloading_exception.dart
+++ b/lib/utils/exception/downloading_exception.dart
@@ -1,0 +1,17 @@
+class DownloadingException implements Exception {
+  final dynamic error;
+
+  DownloadingException({
+    this.error,
+  });
+
+  @override
+  String toString() => error;
+}
+
+class CancelDownloadingException extends DownloadingException {
+  CancelDownloadingException()
+      : super(
+          error: 'User cancel downloading file',
+        );
+}

--- a/lib/utils/exception/save_to_downloads_exception.dart
+++ b/lib/utils/exception/save_to_downloads_exception.dart
@@ -1,0 +1,10 @@
+class SaveToDownloadsException implements Exception {
+  final dynamic error;
+
+  SaveToDownloadsException({
+    this.error,
+  });
+
+  @override
+  String toString() => error;
+}

--- a/lib/utils/manager/download_manager/download_manager.dart
+++ b/lib/utils/manager/download_manager/download_manager.dart
@@ -5,6 +5,7 @@ import 'package:dio/dio.dart';
 import 'package:fluffychat/app_state/failure.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/utils/exception/downloading_exception.dart';
 import 'package:fluffychat/utils/manager/download_manager/download_file_info.dart';
 import 'package:fluffychat/utils/manager/download_manager/download_file_state.dart';
 import 'package:fluffychat/utils/manager/download_manager/downloading_worker_queue.dart';
@@ -32,8 +33,10 @@ class DownloadManager {
       try {
         cancelToken.cancel();
         _eventIdMapDownloadFileInfo[eventId]?.downloadStateStreamController.add(
-              const Right(
-                DownloadFileInitial(),
+              Left(
+                DownloadFileFailureState(
+                  exception: CancelDownloadingException(),
+                ),
               ),
             );
       } catch (e) {

--- a/lib/utils/permission_dialog.dart
+++ b/lib/utils/permission_dialog.dart
@@ -84,7 +84,9 @@ class _PermissionDialogState extends State<PermissionDialog>
                         if (widget.onAcceptButton != null) {
                           widget.onAcceptButton!.call();
                         } else {
-                          await widget.permission.request();
+                          await widget.permission.request().then(
+                                (value) => Navigator.of(context).pop(),
+                              );
                         }
                       },
                     ),

--- a/lib/utils/permission_service.dart
+++ b/lib/utils/permission_service.dart
@@ -127,6 +127,11 @@ class PermissionHandlerService {
     }
   }
 
+  Future<bool> isUserHaveToRequestStoragePermissionAndroid() async {
+    return await _getCurrentAndroidVersion() <= 29 &&
+        !(await Permission.storage.isGranted);
+  }
+
   void goToSettingsForPermissionActions() {
     openAppSettings();
   }

--- a/lib/utils/storage_directory_utils.dart
+++ b/lib/utils/storage_directory_utils.dart
@@ -1,4 +1,10 @@
+import 'dart:io';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/utils/exception/save_to_downloads_exception.dart';
+import 'package:matrix/matrix.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:external_path/external_path.dart';
 
 class StorageDirectoryUtils {
   StorageDirectoryUtils._();
@@ -33,5 +39,39 @@ class StorageDirectoryUtils {
     final downloadInAppFolder =
         await StorageDirectoryUtils.instance.getDownloadFolderInApp();
     return '$downloadInAppFolder/$eventId/$fileName';
+  }
+
+  Future<String?> getTwakeDownloadsFolderInDevice() async {
+    try {
+      final downloadPath = await ExternalPath.getExternalStoragePublicDirectory(
+        ExternalPath.DIRECTORY_DOWNLOADS,
+      );
+      if (downloadPath.isNotEmpty == true) {
+        return '$downloadPath/${AppConfig.applicationName}';
+      }
+      throw SaveToDownloadsException(error: 'Download path is empty');
+    } catch (e) {
+      Logs().e('StorageDirectoryUtils:: getDownloadFolderDevice: $e');
+    }
+    return null;
+  }
+
+  Future<String> getAvailableFilePath(String filePath) async {
+    String availableFilePath = filePath;
+    final positionOfDot = filePath.lastIndexOf('.');
+    String extension = '';
+    String fileName = '';
+    int counter = 1;
+    if (positionOfDot != -1) {
+      extension = filePath.substring(positionOfDot);
+      fileName = filePath.substring(0, positionOfDot);
+    } else {
+      fileName = filePath;
+    }
+    while (await File(availableFilePath).exists()) {
+      availableFilePath = '$fileName ($counter)$extension';
+      counter++;
+    }
+    return availableFilePath;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -562,6 +562,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  external_path:
+    dependency: "direct main"
+    description:
+      name: external_path
+      sha256: "2095c626fbbefe70d5a4afc9b1137172a68ee2c276e51c3c1283394485bea8f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -173,6 +173,7 @@ dependencies:
   flutter_slidable: ^3.0.1
   skeletonizer: 1.1.0
   flutter_portal: 1.1.4
+  external_path: 1.0.3
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/test/files/get_available_file_path_test.dart
+++ b/test/files/get_available_file_path_test.dart
@@ -1,0 +1,174 @@
+import 'dart:io';
+import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/utils/storage_directory_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Future<File> createMockFile(String filePath) async {
+  final file = File('$folderTestName/$filePath');
+  await file.create(recursive: true);
+  return file;
+}
+
+const folderTestName = 'generated';
+
+void main() async {
+  if (PlatformInfos.isWeb) {
+    return;
+  }
+  test("""WHEN exist only one file in the folder,
+          THEN the function should create another file with format fileName (1)
+      """, () async {
+    final file = await createMockFile('file1.pdf');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+    await file.delete();
+    expect(fileAvailable, '$folderTestName/file1 (1).pdf');
+  });
+
+  test("""WHEN exist only two files in the folder,
+          THEN the function should create another file with format fileName (2)
+      """, () async {
+    final file = await createMockFile('file1.pdf');
+    final file1 = await createMockFile('file1 (1).pdf');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+
+    await Future.wait([
+      file.delete(),
+      file1.delete(),
+    ]);
+    expect(fileAvailable, '$folderTestName/file1 (2).pdf');
+  });
+
+  test("""WHEN exist only two files in the folder,
+          THEN the function should create another file with format fileName (7)
+      """, () async {
+    final file = await createMockFile('file1.pdf');
+    final file1 = await createMockFile('file1 (1).pdf');
+    final file2 = await createMockFile('file1 (2).pdf');
+    final file3 = await createMockFile('file1 (3).pdf');
+    final file4 = await createMockFile('file1 (4).pdf');
+    final file5 = await createMockFile('file1 (5).pdf');
+    final file6 = await createMockFile('file1 (6).pdf');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+
+    await Future.wait([
+      file.delete(),
+      file1.delete(),
+      file2.delete(),
+      file3.delete(),
+      file4.delete(),
+      file5.delete(),
+      file6.delete(),
+    ]);
+    expect(fileAvailable, '$folderTestName/file1 (7).pdf');
+  });
+
+  test("""WHEN exist a file with name already have counter in the folder,
+          THEN the function should create another file with format fileName (6) (1)
+      """, () async {
+    final file = await createMockFile('file1 (6).pdf');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+
+    await Future.wait([
+      file.delete(),
+    ]);
+    expect(fileAvailable, '$folderTestName/file1 (6) (1).pdf');
+  });
+
+  test("""WHEN exist a file that contains dot,
+          THEN the function should create another file with format fileName (1)
+      """, () async {
+    final file = await createMockFile('my.document.v1.pdf');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+
+    await Future.wait([
+      file.delete(),
+    ]);
+    expect(fileAvailable, '$folderTestName/my.document.v1 (1).pdf');
+  });
+
+  test("""WHEN exist a file that contains no dot,
+          THEN the function should create another file with format fileName (1)
+      """, () async {
+    final file = await createMockFile('text');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+
+    await Future.wait([
+      file.delete(),
+    ]);
+    expect(fileAvailable, '$folderTestName/text (1)');
+  });
+
+  test("""WHEN exist a file that start with a dot,
+          THEN the function should create another file with format fileName (1)
+      """, () async {
+    final file = await createMockFile('.DS_Store');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+
+    await Future.wait([
+      file.delete(),
+    ]);
+    expect(fileAvailable, '$folderTestName/ (1).DS_Store');
+  });
+
+  test("""WHEN exist a file that have extension contains multiple dots,
+          THEN the function should create another file with format fileName (1)
+      """, () async {
+    final file = await createMockFile('filename.tar.gz');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+
+    await Future.wait([
+      file.delete(),
+    ]);
+    expect(fileAvailable, '$folderTestName/filename.tar (1).gz');
+  });
+
+  test(
+      """WHEN exist multiple files which have the same name and different counter,
+          AND file name exists in the folder are file, file (1) and file (3),
+          THEN the function should create another file with format fileName (2)
+      """, () async {
+    final file = await createMockFile('file.pdf');
+    final file1 = await createMockFile('file (1).pdf');
+    final file3 = await createMockFile('file (3).pdf');
+    final fileAvailable =
+        await StorageDirectoryUtils.instance.getAvailableFilePath(
+      file.path,
+    );
+
+    await Future.wait([
+      file.delete(),
+      file1.delete(),
+      file3.delete(),
+    ]);
+    expect(fileAvailable, '$folderTestName/file (2).pdf');
+  });
+
+  final testDirectory = Directory(folderTestName);
+  if (await testDirectory.exists()) {
+    await testDirectory.delete();
+  }
+}


### PR DESCRIPTION
### Ticket
- #1573 
### Some note: 
- external_path using API `Environment.getExternalStoragePublicDirectory`, so that they can get the path of Downloads folder in device [reference](https://gist.github.com/lopspower/76421751b21594c69eb2?permalink_comment_id=4131989)
- While path_provider use API `getExternalFilesDir` to get Downloads folder path [(compare with 2 APIs)](https://stackoverflow.com/questions/10123812/difference-between-getexternalfilesdir-and-getexternalstoragedirectory)
### Demo: 
### Android 12 - API 31, 32:
https://github.com/linagora/twake-on-matrix/assets/43041967/1d0e802b-9cce-4bce-9ebe-c93afd642037
### Android API 30:

https://github.com/linagora/twake-on-matrix/assets/43041967/9b0bed55-ee2a-45a2-9a8b-bb1e9cd012be
### Android API 33:

https://github.com/linagora/twake-on-matrix/assets/43041967/914e3f68-3565-4c81-8ae2-2cda6970e0ae

### demo case permission API 29:

https://github.com/linagora/twake-on-matrix/assets/43041967/b011341d-e55a-470b-9573-6c5523c5bcd2


