### PR TITLE
Hot-fix: Missing unpin icon

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1401,7 +1401,9 @@ class ChatController extends State<Chat>
         iconAction: action.getIconData(
           unpin: isUnpinEvent(event),
         ),
-        imagePath: action.getImagePath(),
+        imagePath: action.getImagePath(
+          unpin: isUnpinEvent(event),
+        ),
         onCallbackAction: () => _handleClickOnContextMenuItem(
           action,
           event,


### PR DESCRIPTION
## Root cause
- Missing unpin value when get image path.

## Resolved

https://github.com/linagora/twake-on-matrix/assets/80142234/bd9244b1-2a23-4686-9bd1-2847d1431c26

