### PR TITLE
Hot-fix: Add unpin icon for chat app bar

### DIFF
--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -5,6 +5,7 @@ import 'package:fluffychat/pages/chat/chat_invitation_body.dart';
 import 'package:fluffychat/pages/chat/chat_view_body.dart';
 import 'package:fluffychat/pages/chat/chat_view_style.dart';
 import 'package:fluffychat/pages/chat/events/message_content_mixin.dart';
+import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
@@ -42,13 +43,22 @@ class ChatView extends StatelessWidget with MessageContentMixin {
           //   ),
           if (controller.selectedEvents.length == 1)
             TwakeIconButton(
-              icon: Icons.push_pin_outlined,
-              tooltip: L10n.of(context)!.pinChat,
+              icon: !controller.isUnpinEvent(controller.selectedEvents.first)
+                  ? Icons.push_pin_outlined
+                  : null,
+              imagePath:
+                  controller.isUnpinEvent(controller.selectedEvents.first)
+                      ? ImagePaths.icUnpin
+                      : null,
+              tooltip: !controller.isUnpinEvent(controller.selectedEvents.first)
+                  ? L10n.of(context)!.pinChat
+                  : L10n.of(context)!.unpin,
               onTap: () => controller.actionWithClearSelections(
                 () => controller.pinEventAction(
                   controller.selectedEvents.single,
                 ),
               ),
+              imageSize: ChatViewStyle.appBarIconSize,
             ),
           if (controller.selectedEvents.length == 1)
             PopupMenuButton<_EventContextAction>(

--- a/lib/pages/chat/chat_view_style.dart
+++ b/lib/pages/chat/chat_view_style.dart
@@ -9,6 +9,8 @@ class ChatViewStyle {
 
   static const double pinnedMessageHintHeight = 48;
 
+  static const double appBarIconSize = 24.0;
+
   static EdgeInsetsDirectional paddingLeading(BuildContext context) =>
       EdgeInsetsDirectional.only(
         start: responsive.isMobile(context) ? 0 : 16,

--- a/lib/widgets/twake_components/twake_icon_button.dart
+++ b/lib/widgets/twake_components/twake_icon_button.dart
@@ -103,6 +103,13 @@ class TwakeIconButton extends StatelessWidget {
                             imagePath!,
                             height: imageSize,
                             width: imageSize,
+                            colorFilter: ColorFilter.mode(
+                              iconColor ??
+                                  Theme.of(context)
+                                      .colorScheme
+                                      .onSurfaceVariant,
+                              BlendMode.srcIn,
+                            ),
                           )
                         : null,
               ),


### PR DESCRIPTION
## Ticket
- Pin icon in the chat app bar doesn't change to unpin when select a pinned message.

https://github.com/linagora/twake-on-matrix/assets/80142234/ffd69e05-9a58-45a1-a5ef-ab100ede5050



## Root cause
- We haven't provided icon for pinned message in the chat app bar yet.

## Resolved
- Web:

https://github.com/linagora/twake-on-matrix/assets/80142234/72bd3622-e4d5-4d51-97d5-acbb6da58ec2


- Android:

https://github.com/linagora/twake-on-matrix/assets/80142234/a72bad44-5de9-42fe-af1f-f67871b37f7f

