### PR TITLE
Hot-fix: Icon send button disappeard

### DIFF
--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -46,6 +46,10 @@ class ChatView extends StatelessWidget with MessageContentMixin {
               icon: !controller.isUnpinEvent(controller.selectedEvents.first)
                   ? Icons.push_pin_outlined
                   : null,
+              iconColor:
+                  controller.isUnpinEvent(controller.selectedEvents.first)
+                      ? Theme.of(context).colorScheme.onSurfaceVariant
+                      : null,
               imagePath:
                   controller.isUnpinEvent(controller.selectedEvents.first)
                       ? ImagePaths.icUnpin

--- a/lib/widgets/twake_components/twake_icon_button.dart
+++ b/lib/widgets/twake_components/twake_icon_button.dart
@@ -103,13 +103,12 @@ class TwakeIconButton extends StatelessWidget {
                             imagePath!,
                             height: imageSize,
                             width: imageSize,
-                            colorFilter: ColorFilter.mode(
-                              iconColor ??
-                                  Theme.of(context)
-                                      .colorScheme
-                                      .onSurfaceVariant,
-                              BlendMode.srcIn,
-                            ),
+                            colorFilter: iconColor != null
+                                ? ColorFilter.mode(
+                                    iconColor!,
+                                    BlendMode.srcIn,
+                                  )
+                                : null,
                           )
                         : null,
               ),


### PR DESCRIPTION
## Ticket
<img width="625" alt="Screenshot 2024-03-25 at 14 19 54" src="https://github.com/linagora/twake-on-matrix/assets/80142234/1139314b-926c-4a5d-b716-7b62166d7efa">


## Root cause
- `TwakeIconButton` has default `colorFilter`

## Resolved
- Web:

https://github.com/linagora/twake-on-matrix/assets/80142234/c4f47697-ac40-447b-aa39-577f1d720c90


- Android:

https://github.com/linagora/twake-on-matrix/assets/80142234/55d87b69-f903-4b51-bd76-2ccbfac1156c

