### PR TITLE
TW-1605: Fix display thumbnail when user sent a video

### DIFF
--- a/lib/domain/model/extensions/platform_file/platform_file_extension.dart
+++ b/lib/domain/model/extensions/platform_file/platform_file_extension.dart
@@ -2,13 +2,26 @@ import 'package:file_picker/file_picker.dart';
 import 'package:matrix/matrix.dart';
 
 extension PlatformFileListExtension on PlatformFile {
-  MatrixFile toMatrixFile() {
+  MatrixFile toMatrixFile({
+    required String temporaryDirectoryPath,
+  }) {
     return MatrixFile.fromMimeType(
       bytes: bytes,
       name: name,
-      filePath: '',
+      filePath: path ?? '$temporaryDirectoryPath/$name',
       readStream: readStream,
       sizeInBytes: size,
+    );
+  }
+
+  FileInfo toFileInfo({
+    required String temporaryDirectoryPath,
+  }) {
+    return FileInfo(
+      name,
+      path ?? '$temporaryDirectoryPath/$name',
+      size,
+      readStream: readStream,
     );
   }
 }

--- a/lib/pages/chat/events/sending_video_widget.dart
+++ b/lib/pages/chat/events/sending_video_widget.dart
@@ -1,7 +1,6 @@
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:fluffychat/presentation/mixins/play_video_action_mixin.dart';
 import 'package:fluffychat/presentation/model/file/display_image_info.dart';
-import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blurhash/flutter_blurhash.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
@@ -129,7 +128,7 @@ class VideoWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return matrixFile.bytes != null && event.isThumbnailGenerated()
+    return matrixFile.bytes != null && matrixFile.bytes!.isNotEmpty
         ? Image.memory(
             matrixFile.bytes!,
             width: imageWidth,

--- a/lib/pages/chat_draft/draft_chat.dart
+++ b/lib/pages/chat_draft/draft_chat.dart
@@ -32,6 +32,7 @@ import 'package:linagora_design_flutter/images_picker/asset_counter.dart';
 import 'package:linagora_design_flutter/images_picker/images_picker.dart'
     hide ImagePicker;
 import 'package:matrix/matrix.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 
 typedef OnRoomCreatedSuccess = FutureOr<void> Function(Room room)?;
@@ -328,8 +329,15 @@ class DraftChatController extends State<DraftChat>
     );
     if (result == null || result.files.isEmpty) return;
 
-    final matrixFilesList =
-        result.files.map((file) => file.toMatrixFile().detectFileType).toList();
+    final temporaryDirectory = await getTemporaryDirectory();
+
+    final matrixFilesList = result.files
+        .map(
+          (file) => file
+              .toMatrixFile(temporaryDirectoryPath: temporaryDirectory.path)
+              .detectFileType,
+        )
+        .toList();
 
     await sendImagesWithCaption(
       context: context,

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -470,12 +470,18 @@ extension SendFileExtension on Room {
     var width = fileInfo.width;
     var height = fileInfo.height;
     if (width == null || height == null) {
-      final imageDimension = await runBenchmarked(
-        '_calculateImageDimension',
-        () => _calculateImageBytesDimension(fileInfo.imagePlaceholderBytes),
-      );
-      width = imageDimension.width.toInt();
-      height = imageDimension.height.toInt();
+      try {
+        final imageDimension = await _calculateImageBytesDimension(
+          tempThumbnailFile.readAsBytesSync(),
+        );
+        width = imageDimension.width.toInt();
+        height = imageDimension.height.toInt();
+      } catch (e) {
+        Logs().e(
+          '_getThumbnailVideo():: Error while calculating image dimension',
+          e,
+        );
+      }
     }
     Logs().d('Video thumbnail generated', tempThumbnailFile.path);
     final newThumbnail = ImageFileInfo(

--- a/lib/presentation/mixins/send_files_mixin.dart
+++ b/lib/presentation/mixins/send_files_mixin.dart
@@ -42,13 +42,11 @@ mixin SendFilesMixin {
       withReadStream: true,
       allowMultiple: true,
     );
+    final temporaryDirectory = await getTemporaryDirectory();
     fileInfos ??= result?.files
         .map(
-          (xFile) => FileInfo(
-            xFile.name,
-            xFile.path ?? '${getTemporaryDirectory()}/${xFile.name}',
-            xFile.size,
-            readStream: xFile.readStream,
+          (xFile) => xFile.toFileInfo(
+            temporaryDirectoryPath: temporaryDirectory.path,
           ),
         )
         .toList();
@@ -65,7 +63,14 @@ mixin SendFilesMixin {
       withReadStream: true,
     );
     if (result == null || result.files.isEmpty) return [];
-    return result.files.map((file) => file.toMatrixFile()).toList();
+    final temporaryDirectory = await getTemporaryDirectory();
+    return result.files
+        .map(
+          (file) => file.toMatrixFile(
+            temporaryDirectoryPath: temporaryDirectory.path,
+          ),
+        )
+        .toList();
   }
 
   void onPickerTypeClick({

--- a/lib/presentation/mixins/send_files_mixin.dart
+++ b/lib/presentation/mixins/send_files_mixin.dart
@@ -45,8 +45,10 @@ mixin SendFilesMixin {
     final temporaryDirectory = await getTemporaryDirectory();
     fileInfos ??= result?.files
         .map(
-          (xFile) => xFile.toFileInfo(
-            temporaryDirectoryPath: temporaryDirectory.path,
+          (xFile) => FileInfo.fromMatrixFile(
+            xFile.toMatrixFile(
+              temporaryDirectoryPath: temporaryDirectory.path,
+            ),
           ),
         )
         .toList();

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -214,9 +214,4 @@ extension LocalizedBody on Event {
       hideReply: true,
     );
   }
-
-  bool isThumbnailGenerated() {
-    return fileSendingStatus == FileSendingStatus.encrypting ||
-        fileSendingStatus == FileSendingStatus.uploading;
-  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1598,8 +1598,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: update-duratation-for-file-info
-      resolved-ref: "93cbacde518ed75d73a0f6b76b213b041233689f"
+      ref: "twake-supported-0.22.6"
+      resolved-ref: "8f821c1cab2506d13c2266cc8759ffd2b2818770"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1598,8 +1598,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "twake-supported-0.22.6"
-      resolved-ref: "22311972c4d781133b893ae032dcb509b1351075"
+      ref: update-duratation-for-file-info
+      resolved-ref: "93cbacde518ed75d73a0f6b76b213b041233689f"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   matrix:
     git:
       url: git@github.com:linagora/matrix-dart-sdk.git
-      ref: update-duratation-for-file-info
+      ref: twake-supported-0.22.6
 
   receive_sharing_intent:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   matrix:
     git:
       url: git@github.com:linagora/matrix-dart-sdk.git
-      ref: twake-supported-0.22.6
+      ref: update-duratation-for-file-info
 
   receive_sharing_intent:
     git:


### PR DESCRIPTION
### Ticket

- #1605 

### Need to merge:

- https://github.com/linagora/matrix-dart-sdk/pull/53


### Root cause:

- While sending a video, the thumbnail display condition was wrong. This condition says that only when uploading and encrypting will the thumbnail be displayed.

```dart

bool isThumbnailGenerated() {
    return fileSendingStatus == FileSendingStatus.encrypting ||
        fileSendingStatus == FileSendingStatus.uploading;
  }

```

### Solution:

- Delete the false condition, update the new condition 

```dart
matrixFile.bytes != null && matrixFile.bytes!.isNotEmpty
```

### Resolved


https://github.com/linagora/twake-on-matrix/assets/99852347/244df7ae-0102-48af-94a7-8ff8a56ed9ba



