### PR TITLE
TW-1589: Cannot search by link

### DIFF
--- a/lib/pages/search/server_search_controller.dart
+++ b/lib/pages/search/server_search_controller.dart
@@ -112,8 +112,8 @@ class ServerSearchController with SearchDebouncerMixin {
   void updateSearchCategories(String searchTerm) {
     resetNextBatch();
 
-    if (searchTerm.isContainsHttpProtocol()) {
-      searchTerm = searchTerm.removeHttpProtocol();
+    if (searchTerm.isContainsUrlSeparator()) {
+      searchTerm = searchTerm.removeUrlSeparatorAndPreceding();
     }
 
     _searchCategories = ServerSideSearchCategories(

--- a/lib/pages/search/server_search_controller.dart
+++ b/lib/pages/search/server_search_controller.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/domain/usecase/search/server_search_interactor.dart';
 import 'package:fluffychat/presentation/model/search/presentation_server_side_state.dart';
 import 'package:fluffychat/presentation/model/search/presentation_server_side_empty_search.dart';
 import 'package:fluffychat/presentation/model/search/presentation_server_side_search.dart';
+import 'package:fluffychat/utils/string_extension.dart';
 import 'package:flutter/material.dart';
 import 'package:fluffychat/domain/app_state/search/server_search_state.dart';
 import 'package:matrix/matrix.dart';
@@ -110,6 +111,11 @@ class ServerSearchController with SearchDebouncerMixin {
 
   void updateSearchCategories(String searchTerm) {
     resetNextBatch();
+
+    if (searchTerm.isContainsHttpProtocol()) {
+      searchTerm = searchTerm.removeHttpProtocol();
+    }
+
     _searchCategories = ServerSideSearchCategories(
       searchTerm: searchTerm,
       searchFilter: SearchFilter(

--- a/lib/utils/string_extension.dart
+++ b/lib/utils/string_extension.dart
@@ -341,4 +341,16 @@ extension StringCasingExtension on String {
   String normalizePhoneNumber() {
     return replaceAll(RegExp(r'\D'), '');
   }
+
+  bool isContainsHttpProtocol() {
+    final urlRegExp = RegExp(
+      r'(http://|https://)(www.)?([a-zA-Z0-9]+).[a-zA-Z0-9]*.[a-z]{2,}.?([a-z]+)?',
+    );
+    return urlRegExp.hasMatch(this);
+  }
+
+  String removeHttpProtocol() {
+    final httpProtocolRegExp = RegExp(r'(http://|https://)');
+    return replaceAll(httpProtocolRegExp, '');
+  }
 }

--- a/lib/utils/string_extension.dart
+++ b/lib/utils/string_extension.dart
@@ -342,15 +342,18 @@ extension StringCasingExtension on String {
     return replaceAll(RegExp(r'\D'), '');
   }
 
-  bool isContainsHttpProtocol() {
-    final urlRegExp = RegExp(
-      r'(http://|https://)(www.)?([a-zA-Z0-9]+).[a-zA-Z0-9]*.[a-z]{2,}.?([a-z]+)?',
-    );
-    return urlRegExp.hasMatch(this);
+  bool isContainsUrlSeparator() {
+    final separatorRegExp = RegExp(r'://');
+    return separatorRegExp.hasMatch(this);
   }
 
-  String removeHttpProtocol() {
-    final httpProtocolRegExp = RegExp(r'(http://|https://)');
-    return replaceAll(httpProtocolRegExp, '');
+  String removeUrlSeparatorAndPreceding() {
+    final separatorRegExp = RegExp(r'\b[^ ]*://');
+    final standAloneSeparatorRegExp = RegExp(r' *:// *');
+
+    var replacedText = replaceAll(separatorRegExp, '');
+    replacedText = replacedText.replaceAll(standAloneSeparatorRegExp, ' ');
+
+    return replacedText;
   }
 }

--- a/test/utils/string_extension_test.dart
+++ b/test/utils/string_extension_test.dart
@@ -49,4 +49,133 @@ void main() {
       expect(result, equals(expectedPhoneNumber));
     });
   });
+
+  group(
+      '[isContainsHttpProtocol] TEST\n'
+      'GIVEN a string\n'
+      'USING isContainsUrl function\n'
+      'IF the text contains a URL\n'
+      'THEN should return true\n'
+      'ELSE should return false\n', () {
+    final testMap = <String, bool>{
+      'https://www.example.com': true,
+      'https://www.example.com/': true,
+      'https://www.example.com/watch?v=ohg5sjyrha0': true,
+      'https://example.com/test/test-a-link/check/1608?test=1': true,
+      'https://www.example.com/watch?v=ohg5sjyrha0&feature=related': true,
+      'https://example.com/test/test-a-link/check/1608': true,
+      'http://www.example.com': true,
+      'http://www.example.com/': true,
+      'http://www.example.com/watch?v=ohg5sjyrha0': true,
+      'http://example.com/test/test-a-link/check/1608/': true,
+      'http://example.com/test/test-a-link/check/1608/?test=1': true,
+      'https://example': true,
+      'www.example.com': false,
+      'www.example.com/': false,
+      'www.example.com/watch?v=ohg5sjyrha0': false,
+      'example.com': false,
+      'example.com/test/test-a-link/check/1608': false,
+      'example.com/test/test-a-link/check/1608?test=1': false,
+      'example.com/test/test-a-link/check/1608/': false,
+      'example.com/test/test-a-link/check/1608/?test=1': false,
+      'https:/www.example.com': false,
+      'http//www.example.com': false,
+      'example.com/test test-a-link/check/1608': false,
+      'example.com/test/test-a-link/check/1608?test': false,
+      'example.com/test/test-a-link/check/1608/?test==1': false,
+      'example.com/test/test-a-link/check/1608/?test=1&': false,
+      'hello world': false,
+      'hello world.com': false,
+      'hello world.com/test': false,
+      'hello world.com/test/test-a-link': false,
+      'hello world.com/test/test-a-link/check': false,
+      'hello world.com/test/test-a-link/check/1608': false,
+      'hello world.com/test/test-a-link/check/1608?test': false,
+      'hello world.com/test/test-a-link/check/1608/?test==1': false,
+      'hello world.com/test/test-a-link/check/1608/?test=1&': false,
+      'this is a test string': false,
+    };
+
+    for (final entry in testMap.entries) {
+      test('Testing: ${entry.key} => Expected: ${entry.value}', () {
+        final result = entry.key.isContainsHttpProtocol();
+        expect(result, entry.value);
+      });
+    }
+  });
+
+  group(
+      '[removeHttpProtocol] TEST\n'
+      'GIVEN a string\n'
+      'USING removeHttpProtocol function\n'
+      'IF the URL starts with http:// or https://\n'
+      'THEN should return the URL without the protocol\n'
+      'ELSE should return the string unchanged\n', () {
+    final testMap = <String, String>{
+      'https://www.example.com': 'www.example.com',
+      'https://www.example.com/': 'www.example.com/',
+      'https://www.example.com/watch?v=ohg5sjyrha0':
+          'www.example.com/watch?v=ohg5sjyrha0',
+      'https://example.com/test/test-a-link/check/1608?test=1':
+          'example.com/test/test-a-link/check/1608?test=1',
+      'https://www.example.com/watch?v=ohg5sjyrha0&feature=related':
+          'www.example.com/watch?v=ohg5sjyrha0&feature=related',
+      'https://example.com/test/test-a-link/check/1608':
+          'example.com/test/test-a-link/check/1608',
+      'http://www.example.com': 'www.example.com',
+      'http://www.example.com/': 'www.example.com/',
+      'http://www.example.com/watch?v=ohg5sjyrha0':
+          'www.example.com/watch?v=ohg5sjyrha0',
+      'http://example.com/test/test-a-link/check/1608/':
+          'example.com/test/test-a-link/check/1608/',
+      'http://example.com/test/test-a-link/check/1608/?test=1':
+          'example.com/test/test-a-link/check/1608/?test=1',
+      'https://example': 'example',
+      'www.example.com': 'www.example.com',
+      'www.example.com/': 'www.example.com/',
+      'www.example.com/watch?v=ohg5sjyrha0':
+          'www.example.com/watch?v=ohg5sjyrha0',
+      'example.com': 'example.com',
+      'example.com/test/test-a-link/check/1608':
+          'example.com/test/test-a-link/check/1608',
+      'example.com/test/test-a-link/check/1608?test=1':
+          'example.com/test/test-a-link/check/1608?test=1',
+      'example.com/test/test-a-link/check/1608/':
+          'example.com/test/test-a-link/check/1608/',
+      'example.com/test/test-a-link/check/1608/?test=1':
+          'example.com/test/test-a-link/check/1608/?test=1',
+      'https:/www.example.com': 'https:/www.example.com',
+      'http//www.example.com': 'http//www.example.com',
+      'example.com/test test-a-link/check/1608':
+          'example.com/test test-a-link/check/1608',
+      'example.com/test/test-a-link/check/1608?test':
+          'example.com/test/test-a-link/check/1608?test',
+      'example.com/test/test-a-link/check/1608/?test==1':
+          'example.com/test/test-a-link/check/1608/?test==1',
+      'example.com/test/test-a-link/check/1608/?test=1&':
+          'example.com/test/test-a-link/check/1608/?test=1&',
+      'hello world': 'hello world',
+      'hello world.com': 'hello world.com',
+      'hello world.com/test': 'hello world.com/test',
+      'hello world.com/test/test-a-link': 'hello world.com/test/test-a-link',
+      'hello world.com/test/test-a-link/check':
+          'hello world.com/test/test-a-link/check',
+      'hello world.com/test/test-a-link/check/1608':
+          'hello world.com/test/test-a-link/check/1608',
+      'hello world.com/test/test-a-link/check/1608?test':
+          'hello world.com/test/test-a-link/check/1608?test',
+      'hello world.com/test/test-a-link/check/1608/?test==1':
+          'hello world.com/test/test-a-link/check/1608/?test==1',
+      'hello world.com/test/test-a-link/check/1608/?test=1&':
+          'hello world.com/test/test-a-link/check/1608/?test=1&',
+      'this is a test string': 'this is a test string',
+    };
+
+    for (final entry in testMap.entries) {
+      test('Testing: ${entry.key} => Expected: ${entry.value}', () {
+        final result = entry.key.removeHttpProtocol();
+        expect(result, entry.value);
+      });
+    }
+  });
 }

--- a/test/utils/string_extension_test.dart
+++ b/test/utils/string_extension_test.dart
@@ -54,16 +54,28 @@ void main() {
       '[isContainsHttpProtocol] TEST\n'
       'GIVEN a string\n'
       'USING isContainsUrl function\n'
-      'IF the text contains a URL\n'
+      'IF the string contains a URL\n'
       'THEN should return true\n'
       'ELSE should return false\n', () {
     final testMap = <String, bool>{
+      'https': false,
+      'https:': false,
+      'https:/': false,
+      'https/': false,
+      'https//': false,
+      'https://': true,
       'https://www.example.com': true,
       'https://www.example.com/': true,
       'https://www.example.com/watch?v=ohg5sjyrha0': true,
       'https://example.com/test/test-a-link/check/1608?test=1': true,
       'https://www.example.com/watch?v=ohg5sjyrha0&feature=related': true,
       'https://example.com/test/test-a-link/check/1608': true,
+      'http': false,
+      'http:': false,
+      'http:/': false,
+      'http/': false,
+      'http//': false,
+      'http://': true,
       'http://www.example.com': true,
       'http://www.example.com/': true,
       'http://www.example.com/watch?v=ohg5sjyrha0': true,
@@ -94,12 +106,49 @@ void main() {
       'hello world.com/test/test-a-link/check/1608/?test==1': false,
       'hello world.com/test/test-a-link/check/1608/?test=1&': false,
       'this is a test string': false,
+      'ftp': false,
+      'ftp:': false,
+      'ftp:/': false,
+      'ftp//': false,
+      'ftp://': true,
+      'ftp://www.example.com': true,
+      'ftp://www.example.com/': true,
+      'ftp://www.example.com/watch?v=ohg5sjyrha0': true,
+      'ftp://example.com/test/test-a-link/check/1608?test=1': true,
+      'ftp://www.example.com/watch?v=ohg5sjyrha0&feature=related': true,
+      'ftp://example.com/test/test-a-link/check/1608': true,
+      'sftp': false,
+      'sftp:': false,
+      'sftp:/': false,
+      'sftp//': false,
+      'sftp://': true,
+      'sftp://www.example.com': true,
+      'sftp://www.example.com/': true,
+      'sftp://www.example.com/watch?v=ohg5sjyrha0': true,
+      'sftp://example.com/test/test-a-link/check/1608?test=1': true,
+      'sftp://www.example.com/watch?v=ohg5sjyrha0&feature=related': true,
+      'sftp://example.com/test/test-a-link/check/1608': true,
+      'ssh': false,
+      'ssh:': false,
+      'ssh:/': false,
+      'ssh//': false,
+      'ssh://': true,
+      'ssh://www.example.com': true,
+      'ssh://www.example.com/': true,
+      'ssh://www.example.com/watch?v=ohg5sjyrha0': true,
+      'ssh://example.com/test/test-a-link/check/1608?test=1': true,
+      'ssh://www.example.com/watch?v=ohg5sjyrha0&feature=related': true,
+      'ssh://example.com/test/test-a-link/check/1608': true,
     };
 
     for (final entry in testMap.entries) {
       test('Testing: ${entry.key} => Expected: ${entry.value}', () {
-        final result = entry.key.isContainsHttpProtocol();
-        expect(result, entry.value);
+        final result = entry.key.isContainsUrlSeparator();
+        if (entry.value) {
+          expect(result, isTrue);
+        } else {
+          expect(result, isFalse);
+        }
       });
     }
   });
@@ -108,10 +157,15 @@ void main() {
       '[removeHttpProtocol] TEST\n'
       'GIVEN a string\n'
       'USING removeHttpProtocol function\n'
-      'IF the URL starts with http:// or https://\n'
+      'IF the string starts with http:// or https://\n'
       'THEN should return the URL without the protocol\n'
       'ELSE should return the string unchanged\n', () {
     final testMap = <String, String>{
+      'https': 'https',
+      'https:': 'https:',
+      'https:/': 'https:/',
+      'https//': 'https//',
+      'https://': '',
       'https://www.example.com': 'www.example.com',
       'https://www.example.com/': 'www.example.com/',
       'https://www.example.com/watch?v=ohg5sjyrha0':
@@ -122,6 +176,11 @@ void main() {
           'www.example.com/watch?v=ohg5sjyrha0&feature=related',
       'https://example.com/test/test-a-link/check/1608':
           'example.com/test/test-a-link/check/1608',
+      'http': 'http',
+      'http:': 'http:',
+      'http:/': 'http:/',
+      'http//': 'http//',
+      'http://': '',
       'http://www.example.com': 'www.example.com',
       'http://www.example.com/': 'www.example.com/',
       'http://www.example.com/watch?v=ohg5sjyrha0':
@@ -168,13 +227,67 @@ void main() {
           'hello world.com/test/test-a-link/check/1608/?test==1',
       'hello world.com/test/test-a-link/check/1608/?test=1&':
           'hello world.com/test/test-a-link/check/1608/?test=1&',
+      'hello 123://world.com/test/test-a-link/check/1608/?test=1&':
+          'hello world.com/test/test-a-link/check/1608/?test=1&',
+      'hello this is the://world.com/test/test-a-link/check/1608/?test=1& for the text contains :// inside it':
+          'hello this is world.com/test/test-a-link/check/1608/?test=1& for the text contains inside it',
       'this is a test string': 'this is a test string',
+      'ftp': 'ftp',
+      'ftp:': 'ftp:',
+      'ftp:/': 'ftp:/',
+      'ftp//': 'ftp//',
+      'ftp://': '',
+      'ftp://www.example.com': 'www.example.com',
+      'ftp://www.example.com/': 'www.example.com/',
+      'ftp://www.example.com/watch?v=ohg5sjyrha0':
+          'www.example.com/watch?v=ohg5sjyrha0',
+      'ftp://example.com/test/test-a-link/check/1608?test=1':
+          'example.com/test/test-a-link/check/1608?test=1',
+      'ftp://www.example.com/watch?v=ohg5sjyrha0&feature=related':
+          'www.example.com/watch?v=ohg5sjyrha0&feature=related',
+      'ftp://example.com/test/test-a-link/check/1608':
+          'example.com/test/test-a-link/check/1608',
+      'sftp': 'sftp',
+      'sftp:': 'sftp:',
+      'sftp:/': 'sftp:/',
+      'sftp//': 'sftp//',
+      'sftp://': '',
+      'sftp://www.example.com': 'www.example.com',
+      'sftp://www.example.com/': 'www.example.com/',
+      'sftp://www.example.com/watch?v=ohg5sjyrha0':
+          'www.example.com/watch?v=ohg5sjyrha0',
+      'sftp://example.com/test/test-a-link/check/1608?test=1':
+          'example.com/test/test-a-link/check/1608?test=1',
+      'sftp://www.example.com/watch?v=ohg5sjyrha0&feature=related':
+          'www.example.com/watch?v=ohg5sjyrha0&feature=related',
+      'sftp://example.com/test/test-a-link/check/1608':
+          'example.com/test/test-a-link/check/1608',
+      'ssh': 'ssh',
+      'ssh:': 'ssh:',
+      'ssh:/': 'ssh:/',
+      'ssh//': 'ssh//',
+      'ssh://': '',
+      'ssh://www.example.com': 'www.example.com',
+      'ssh://www.example.com/': 'www.example.com/',
+      'ssh://www.example.com/watch?v=ohg5sjyrha0':
+          'www.example.com/watch?v=ohg5sjyrha0',
+      'ssh://example.com/test/test-a-link/check/1608?test=1':
+          'example.com/test/test-a-link/check/1608?test=1',
+      'ssh://www.example.com/watch?v=ohg5sjyrha0&feature=related':
+          'www.example.com/watch?v=ohg5sjyrha0&feature=related',
+      'ssh://example.com/test/test-a-link/check/1608':
+          'example.com/test/test-a-link/check/1608',
     };
 
     for (final entry in testMap.entries) {
       test('Testing: ${entry.key} => Expected: ${entry.value}', () {
-        final result = entry.key.removeHttpProtocol();
-        expect(result, entry.value);
+        final result = entry.key.removeUrlSeparatorAndPreceding();
+        if (entry.value.isNotEmpty) {
+          expect(result, isNotEmpty);
+          expect(result, equals(entry.value));
+        } else {
+          expect(result, isEmpty);
+        }
       });
     }
   });


### PR DESCRIPTION
## Ticket
- #1589 

## Root cause
- Problem when querying URLs in PostgreSQL on the server side.

## Relevant
- https://github.com/matrix-org/synapse/issues/3024

## Solution
- Step 1: Check if search text is a link and contains http protocol.
- Step 2: Remove http protocol end pass the rest of text to search categories.

## Resolved

https://github.com/linagora/twake-on-matrix/assets/80142234/de665dbe-87e1-4b44-a132-170cf8620139

