### PR TITLE
Hot fix: Wrong redirect to public public platform on web

### DIFF
--- a/lib/pages/connect/connect_page_mixin.dart
+++ b/lib/pages/connect/connect_page_mixin.dart
@@ -22,6 +22,8 @@ mixin ConnectPageMixin {
 
   static const windowNameValue = '_self';
 
+  static const redirectPublicPlatformOnWeb = 'post_login_redirect_url';
+
   bool supportsFlow({
     required BuildContext context,
     required String flowType,
@@ -64,7 +66,7 @@ mixin ConnectPageMixin {
     required String redirectUrl,
   }) {
     final redirectUrlEncode = Uri.encodeQueryComponent(redirectUrl);
-    return '${AppConfig.registrationUrl}?post_registered_redirect_url=$redirectUrlEncode';
+    return '${AppConfig.registrationUrl}?$redirectPublicPlatformOnWeb=$redirectUrlEncode';
   }
 
   String? _getLogoutUrl(


### PR DESCRIPTION
### Issue

<img width="1680" alt="Screenshot 2024-03-27 at 16 20 33" src="https://github.com/linagora/twake-on-matrix/assets/99852347/29999823-044d-447f-812e-aacfd76b93e2">


1. When click on start message on Twake web app 
2. Redirect to sign up tab on public platform side

### Resolved

Automatically  redirect to sign in tab in public platform side

https://github.com/linagora/twake-on-matrix/assets/99852347/32689c11-4e63-4711-b0a7-db4592534e2d



