### PR TITLE
Hot-fix: Font size of unordered list text inside messages has been reduced.

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -958,7 +958,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "27e36218e126e9e1c382e45fde4a683b10e83f91"
+      resolved-ref: "9a1027b074c530f6deec4a5593a7a62f8fd70f45"
       url: "https://github.com/linagora/flutter_matrix_html.git"
     source: git
     version: "1.2.0"


### PR DESCRIPTION
## Ticket
- When device text's size is small, font size of text inside unordered list will be reduced.
- Web:
![issue web](https://github.com/linagora/twake-on-matrix/assets/80142234/e0286d94-73f9-48f2-8636-0974bc355875)
- Mobile:
![issue mobile](https://github.com/linagora/twake-on-matrix/assets/80142234/068e433e-d011-4c4f-8c4f-5a1006876ce0)


## Root cause
- When `HtmlMessage` widget has `bottomWidgetSpan` property, the text span that wrap `<li>` tag of html parser has `textScaleFactor=0.85` automatically.

## Solution
- Add `textScaleFactor=1.0` to keep the original size of text.

## Relevant
- https://github.com/linagora/flutter_matrix_html/pull/16

## Resolved
- Web:

https://github.com/linagora/twake-on-matrix/assets/80142234/e14d34c3-a2e7-44e8-9c3c-9cffd5d6bb07


- Mobile:

https://github.com/linagora/twake-on-matrix/assets/80142234/dadb8cbf-bd5c-44e6-b1ff-e60f963070af

