### PR TITLE
TW-1656: Fix user can't mark as read / unread some chat conversation

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -276,16 +276,19 @@ class ChatListController extends State<ChatList>
   Future<void> toggleUnreadSelections() async {
     await TwakeDialog.showFutureLoadingDialogFullScreen(
       future: () async {
-        final markUnread = anySelectedRoomNotMarkedUnread;
+        final markUnreadAction = anySelectedRoomNotMarkedUnread;
         for (final conversation in conversationSelectionNotifier.value) {
           final room = activeClient.getRoomById(conversation.roomId)!;
-          if (room.markedUnread == markUnread) {
-            await room.setReadMarker(
-              room.lastEvent!.eventId,
-              mRead: room.lastEvent!.eventId,
-            );
+          if (room.markedUnread == markUnreadAction) {
+            if (room.isUnread) {
+              await room.setReadMarker(
+                room.lastEvent!.eventId,
+                mRead: room.lastEvent!.eventId,
+              );
+            }
           }
-          await room.markUnread(markUnread);
+
+          await room.markUnread(markUnreadAction);
         }
       },
     );


### PR DESCRIPTION
### Ticket

- #1656 

### Root cause

- When we enable select mode, click on read/unread actions can't be marked as read/unread because of wrong conditions.

### Resolved

- Mobile:

https://github.com/linagora/twake-on-matrix/assets/99852347/45a0c52a-d68e-491c-94b6-846fbd49f570

- Web


https://github.com/linagora/twake-on-matrix/assets/99852347/9a1e6aa7-36e4-40c6-af9d-5275028d376c

