### PR TITLE
Hotfix: Can't get file on web

### DIFF
--- a/lib/domain/model/extensions/platform_file/platform_file_extension.dart
+++ b/lib/domain/model/extensions/platform_file/platform_file_extension.dart
@@ -2,13 +2,23 @@ import 'package:file_picker/file_picker.dart';
 import 'package:matrix/matrix.dart';
 
 extension PlatformFileListExtension on PlatformFile {
-  MatrixFile toMatrixFile({
+  MatrixFile toMatrixFileOnMobile({
     required String temporaryDirectoryPath,
   }) {
     return MatrixFile.fromMimeType(
       bytes: bytes,
       name: name,
       filePath: path ?? '$temporaryDirectoryPath/$name',
+      readStream: readStream,
+      sizeInBytes: size,
+    );
+  }
+
+  MatrixFile toMatrixFileOnWeb() {
+    return MatrixFile.fromMimeType(
+      bytes: bytes,
+      name: name,
+      filePath: '',
       readStream: readStream,
       sizeInBytes: size,
     );

--- a/lib/pages/chat_draft/draft_chat.dart
+++ b/lib/pages/chat_draft/draft_chat.dart
@@ -32,7 +32,6 @@ import 'package:linagora_design_flutter/images_picker/asset_counter.dart';
 import 'package:linagora_design_flutter/images_picker/images_picker.dart'
     hide ImagePicker;
 import 'package:matrix/matrix.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 
 typedef OnRoomCreatedSuccess = FutureOr<void> Function(Room room)?;
@@ -329,13 +328,9 @@ class DraftChatController extends State<DraftChat>
     );
     if (result == null || result.files.isEmpty) return;
 
-    final temporaryDirectory = await getTemporaryDirectory();
-
     final matrixFilesList = result.files
         .map(
-          (file) => file
-              .toMatrixFile(temporaryDirectoryPath: temporaryDirectory.path)
-              .detectFileType,
+          (file) => file.toMatrixFileOnWeb().detectFileType,
         )
         .toList();
 

--- a/lib/presentation/mixins/send_files_mixin.dart
+++ b/lib/presentation/mixins/send_files_mixin.dart
@@ -46,7 +46,7 @@ mixin SendFilesMixin {
     fileInfos ??= result?.files
         .map(
           (xFile) => FileInfo.fromMatrixFile(
-            xFile.toMatrixFile(
+            xFile.toMatrixFileOnMobile(
               temporaryDirectoryPath: temporaryDirectory.path,
             ),
           ),
@@ -65,14 +65,7 @@ mixin SendFilesMixin {
       withReadStream: true,
     );
     if (result == null || result.files.isEmpty) return [];
-    final temporaryDirectory = await getTemporaryDirectory();
-    return result.files
-        .map(
-          (file) => file.toMatrixFile(
-            temporaryDirectoryPath: temporaryDirectory.path,
-          ),
-        )
-        .toList();
+    return result.files.map((file) => file.toMatrixFileOnWeb()).toList();
   }
 
   void onPickerTypeClick({


### PR DESCRIPTION
### Root cause

- When get file from `file_picker`, convert to `MatrixFile`


```dart
MatrixFile toMatrixFileOnMobile({
    required String temporaryDirectoryPath,
  }) {
    return MatrixFile.fromMimeType(
      bytes: bytes,
      name: name,
      filePath: path ?? '$temporaryDirectoryPath/$name',
      readStream: readStream,
      sizeInBytes: size,
    );
  }

```

1. Failed because On web this is always `null`. You should access `bytes` property instead.

```dart
  /// The absolute path for a cached copy of this file. It can be used to create a
  /// file instance with a descriptor for the given path.
  /// ```
  /// final File myFile = File(platformFile.path);
  /// ```
  /// On web this is always `null`. You should access `bytes` property instead.
  /// Read more about it [here](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ)
  String? _path;

  String? get path {
    if (kIsWeb) {
      /// https://github.com/miguelpruivo/flutter_file_picker/issues/751
      throw '''
      On web `path` is always `null`,
      You should access `bytes` property instead,
      Read more about it [here](https://github.com/miguelpruivo/flutter_file_picker/wiki/FAQ)
      ''';
    }
    return _path;
  }
```

2. And using `getTemporaryDirectory` failed on the web

### Resolved


https://github.com/linagora/twake-on-matrix/assets/99852347/5de90a43-21c5-4adf-8362-d739abb051e5


https://github.com/linagora/twake-on-matrix/assets/99852347/70ad6f42-5644-4882-a632-6912b1cce6c9



