### PR TITLE
TW-1613: Searching result should be empty when user remove keywords

### DIFF
--- a/lib/pages/search/server_search_controller.dart
+++ b/lib/pages/search/server_search_controller.dart
@@ -73,6 +73,14 @@ class ServerSearchController with SearchDebouncerMixin {
     searchResult.fold(
       (failure) => resetNextBatch(),
       (success) {
+        if (!searchTermIsNotEmpty) {
+          return;
+        }
+
+        if (success is ServerSearchInitial) {
+          searchResultsNotifier.value = PresentationServerSideInitial();
+        }
+
         if (success is ServerSearchChatSuccess) {
           updateNextBatch(success.nextBatch);
           if (success.results?.isEmpty == true) {


### PR DESCRIPTION
### Ticket

- #1613

### Resolved


https://github.com/linagora/twake-on-matrix/assets/99852347/2718d29f-60d4-4f42-99fb-5d5776aa60f1

https://github.com/linagora/twake-on-matrix/assets/99852347/577fe593-fad5-4693-8ef7-642d7b05ec81


https://github.com/linagora/twake-on-matrix/assets/99852347/405256e5-d9c4-4857-bcf5-327b965cf79c

