### PR TITLE
TW-1523: Fix chat setting is not align with arrow

### DIFF
--- a/lib/pages/settings_dashboard/settings/settings_item_builder.dart
+++ b/lib/pages/settings_dashboard/settings/settings_item_builder.dart
@@ -48,6 +48,9 @@ class SettingsItemBuilder extends StatelessWidget {
               ),
               Expanded(
                 child: Row(
+                  crossAxisAlignment: subtitle.isEmpty
+                      ? CrossAxisAlignment.start
+                      : CrossAxisAlignment.center,
                   children: [
                     Expanded(
                       child: Column(


### PR DESCRIPTION
### Ticket

- #1523 

### Resovled

![Simulator Screenshot - iPhone 14 - 2024-04-03 at 17 28 39](https://github.com/linagora/twake-on-matrix/assets/99852347/3992845b-60eb-418f-9a2b-4c19e07ca1d9)
