### PR TITLE
TW-1675: status of user is not correct

### DIFF
--- a/docs/adr/0021-listen-to-presence-status.md
+++ b/docs/adr/0021-listen-to-presence-status.md
@@ -1,0 +1,67 @@
+# 21. Listen to presence status
+
+Date: 2024-04-08
+
+## Status
+
+Accepted
+
+## Context
+
+The status of presence of a user on a direct chat was not stable. By this we mean that it changes multiple times in a small timeline (few seconds).
+This was because the UI was listening to `onPresenceChanged`'s stream which is updated in a for loop where there can be multiple items. So if there was 6 items in this loop, the status was updated 6 times.
+
+```dart
+  /// Callback will be called on presence updates.
+  final CachedStreamController<CachedPresence> onPresenceChanged =
+      CachedStreamController();
+
+  for (final newPresence in sync.presence ?? []) {
+      final cachedPresence = CachedPresence.fromMatrixEvent(newPresence);
+      presences[newPresence.senderId] = cachedPresence;
+      // ignore: deprecated_member_use_from_same_package
+      onPresence.add(newPresence);
+      onPresenceChanged.add(cachedPresence);
+  }
+```
+
+## Decision
+
+To avoid this problem we created a new stream which purpose is to get the status of presence the closest of current time: `onlatestPresenceChanged` . That's the one who should be listened by the UI.
+
+Here `lowestLastActivePresence` is updated for each items in sync.presence list if it is `null` or if the current item's timestamp is before the one in `lowestLastActivePresence`. Then when the loop is over and we are sure to have the right value, we can update `onLatestPresenceChange` with the right value and this way update the UI.
+
+```dart
+  /// Callback will be called on presence updates.
+  final CachedStreamController<CachedPresence> onPresenceChanged =
+      CachedStreamController();
+
+  /// Callback will be called on presence update and return latest value.
+  final CachedStreamController<CachedPresence> onlatestPresenceChanged =
+      CachedStreamController();
+
+    CachedPresence? lowestLastActivePresence;
+
+
+    for (final newPresence in sync.presence ?? []) {
+      final cachedPresence = CachedPresence.fromMatrixEvent(newPresence);
+      presences[newPresence.senderId] = cachedPresence;
+      // ignore: deprecated_member_use_from_same_package
+      onPresence.add(newPresence);
+      onPresenceChanged.add(cachedPresence);
+
+
+      if (lowestLastActivePresence == null ||
+          (cachedPresence.lastActiveTimestamp != null &&
+              lowestLastActivePresence.lastActiveTimestamp != null &&
+              cachedPresence.lastActiveTimestamp!
+                  .isBefore(lowestLastActivePresence.lastActiveTimestamp!))) {
+        lowestLastActivePresence = cachedPresence;
+      }
+    }
+
+
+    if (lowestLastActivePresence != null) {
+      onlatestPresenceChanged.add(lowestLastActivePresence);
+    }
+```

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -170,7 +170,8 @@ class ChatView extends StatelessWidget with MessageContentMixin {
                             sendController: controller.sendController,
                             connectivityResultStream: controller
                                 .networkConnectionService
-                                .getStreamInstance(),
+                                .connectivity
+                                .onConnectivityChanged,
                             actions: _appBarActions(context),
                             onPushDetails: controller.onPushDetails,
                             roomName: controller.roomName,

--- a/lib/utils/room_status_extension.dart
+++ b/lib/utils/room_status_extension.dart
@@ -12,7 +12,7 @@ extension RoomStatusExtension on Room {
       client.presences[directChatMatrixID];
 
   Stream<CachedPresence> get directChatPresenceStream =>
-      client.onPresenceChanged.stream;
+      client.onlatestPresenceChanged.stream;
 
   String getLocalizedStatus(BuildContext context, {CachedPresence? presence}) {
     if (isDirectChat) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1598,8 +1598,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "twake-supported-0.22.6"
-      resolved-ref: "8f821c1cab2506d13c2266cc8759ffd2b2818770"
+      ref: TW-1675-incorrect-status-of-user
+      resolved-ref: "0faf92ee7f91db915ef6316092d2f9fed0996080"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1598,8 +1598,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: TW-1675-incorrect-status-of-user
-      resolved-ref: "0faf92ee7f91db915ef6316092d2f9fed0996080"
+      ref: "twake-supported-0.22.6"
+      resolved-ref: "699db764273c113e9d508a1f2d148067aabc8101"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   matrix:
     git:
       url: git@github.com:linagora/matrix-dart-sdk.git
-      ref: TW-1675-incorrect-status-of-user
+      ref: twake-supported-0.22.6
 
   receive_sharing_intent:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   matrix:
     git:
       url: git@github.com:linagora/matrix-dart-sdk.git
-      ref: twake-supported-0.22.6
+      ref: TW-1675-incorrect-status-of-user
 
   receive_sharing_intent:
     git:


### PR DESCRIPTION
### Issue: 
https://github.com/linagora/twake-on-matrix/issues/1675

### Root cause:

The root cause was in matrix-dart-sdk. Here is the copy paste of the explanation I made there:
 

> This was the previous code:
> https://github.com/linagora/matrix-dart-sdk/blob/e0b65295255b852532878a948662920d6963cc6f/lib/src/client.dart#L1793-L1799
> 
> The UI previously listened to `onPresenceChanged` which is a `CachedStreamController` . This instance had a new value added in the `for each` loop for every items in `sync.presence`list. This means if there's  different values in `sync.presence` , the UI will be updated 6 times.
> 
> To handle that I changed for this code:
> 
> https://github.com/linagora/matrix-dart-sdk/blob/b0c34117c60360d3f1241af9653ddaaa88aaead4/lib/src/client.dart#L1809-L1829
> 
> Here `lowestLastActivePresence` is updated for each items in `sync.presence` list if it is `null` or if the current item's timestamp is before the one in `lowestLastActivePresence`. Then when the loop is over and we are sure to have the right value, we can update onLatestPresenceChange with the right value and this way update the UI.


### Warning:

Merge https://github.com/linagora/matrix-dart-sdk/pull/54 before this one

### Demo:

[Capture vidéo du 04-04-2024 14:20:22.webm](https://github.com/linagora/twake-on-matrix/assets/31937920/2a85ea3b-e895-43e2-b637-9304a35811c7)

https://github.com/linagora/twake-on-matrix/assets/31937920/2ef61a81-6278-4771-aca5-3b938559ec4f

