### PR TITLE
TW-1693: delele the encrypted file after downloading it

### DIFF
--- a/lib/utils/matrix_sdk_extensions/download_file_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/download_file_extension.dart
@@ -193,6 +193,26 @@ extension DownloadFileExtension on Event {
           DownloadFileFailureState(exception: e),
         ),
       );
+    } finally {
+      await _clearEncryptedFile(
+        eventId: eventId,
+        filename: filename,
+      );
+    }
+  }
+
+  Future<void> _clearEncryptedFile({
+    required String eventId,
+    required String filename,
+  }) async {
+    try {
+      final encryptedFilePath = await StorageDirectoryManager.instance
+          .getFilePathInAppDownloads(eventId: eventId, fileName: filename);
+      await File(encryptedFilePath).delete();
+    } catch (e) {
+      Logs().e(
+        '_clearEncryptedFile(): $e',
+      );
     }
   }
 


### PR DESCRIPTION
### Demo mobile image + video + encrypted chat / normal chat:
https://drive.google.com/file/d/1UDY0YDVBhkMwULUPO8IaQGh3gg6Tli7T/view?usp=sharing

### Demo mobile file when downloading file in encrypted/normal chat:

https://github.com/linagora/twake-on-matrix/assets/43041967/cc4d0cf3-d726-4195-bec3-47faf91608c1

### Demo mobile file when sending a file in encrypted/normal chat:

