### PR TITLE
TW-1733: Fix context menu overflow on mobile

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1399,6 +1399,7 @@ class ChatController extends State<Chat>
         imagePath: action.getImagePath(
           unpin: isUnpinEvent(event),
         ),
+        isClearCurrentPage: false,
         onCallbackAction: () => _handleClickOnContextMenuItem(
           action,
           event,
@@ -1820,6 +1821,7 @@ class ChatController extends State<Chat>
                 color: action.getColorIcon(context),
               )
             : null,
+        isClearCurrentPage: false,
         onCallbackAction: () => onSelectedAppBarActions(action),
       );
     }).toList();

--- a/lib/widgets/context_menu/twake_context_menu.dart
+++ b/lib/widgets/context_menu/twake_context_menu.dart
@@ -82,7 +82,8 @@ class TwakeContextMenuState extends State<TwakeContextMenu>
               Positioned(
                 left: contextMenuPosition.left,
                 top: contextMenuPosition.top,
-                bottom: contextMenuPosition.bottom,
+                bottom:
+                    !PlatformInfos.isMobile ? contextMenuPosition.bottom : null,
                 right: contextMenuPosition.right,
                 child: AnimatedBuilder(
                   animation: _animationController,


### PR DESCRIPTION
### Ticket

- #1733

- Root cause:

- Context menu overflow on mobile
   - Incorrect calculation of bottom position when opening context menu on mobile

- Chat room screen disappear when clicking on context menu actions 
  - When using the context menu in the chat screen, it was popped up twice at `popupItemByTwakeAppRouter` and `TwakeContextMenu`

### Resolved

- [x] Fix context menu overflow on mobile
- [x] Fix chat room screen disappear when clicking on context menu actions 


https://github.com/linagora/twake-on-matrix/assets/99852347/ac9518c9-07d9-4b42-9eed-0a2cd63efe7e


https://github.com/linagora/twake-on-matrix/assets/99852347/96d132ec-0708-4462-8cea-6b6f93255b82



