### PR TITLE
hot-fix: logger is not show in mobile platform

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1624,7 +1624,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "00b6570f95556636499c845f475d2d9e9049e44d"
+      resolved-ref: a498051a8a7e41a35bde65f37c25add3f808b929
       url: "https://github.com/linagora/dart_matrix_api_lite.git"
     source: git
     version: "1.7.4"


### PR DESCRIPTION
### Need merge first:
https://github.com/linagora/dart_matrix_api_lite/pull/2


### Root cause:
The log only show in android, and not show in ios. And its because this `log` function from dart:developer is used specially for Flutter debug devtools not for `stdout` of terminal. So back to use `print` function. 

### Reference:
https://stackoverflow.com/questions/69689138/developer-log-does-not-print-log