### PR TITLE
Tw 1773: Members chat group chat isnot updated correctly

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1733,7 +1733,8 @@ class ChatController extends State<Chat>
       Logs().d(
         'Chat::_listenRoomUpdateEvent():: Event Update Content ${eventUpdate.content}',
       );
-      if (eventUpdate.isPinnedEventsHasChanged) {
+      if (eventUpdate.isPinnedEventsHasChanged &&
+          room?.id == eventUpdate.roomID) {
         WidgetsBinding.instance.addPostFrameCallback((_) async {
           eventUpdate.updatePinnedMessage(
             onPinnedMessageUpdated: _handlePinnedMessageCallBack,

--- a/lib/pages/chat_details/chat_details_page_view/chat_details_members_page.dart
+++ b/lib/pages/chat_details/chat_details_page_view/chat_details_members_page.dart
@@ -50,7 +50,10 @@ class ChatDetailsMembersPage extends StatelessWidget {
                       onUpdatedMembers: onUpdatedMembers,
                     );
                   }
-
+                  final haveMoreMembers = actualMembersCount > members.length;
+                  if (!haveMoreMembers) {
+                    return const SizedBox.shrink();
+                  }
                   return ListTile(
                     title: Text(
                       L10n.of(context)!.loadCountMoreParticipants(

--- a/lib/presentation/extensions/event_update_extension.dart
+++ b/lib/presentation/extensions/event_update_extension.dart
@@ -20,6 +20,10 @@ extension EventUpdateExtension on EventUpdate {
     return content['type'] == EventTypes.RoomPinnedEvents;
   }
 
+  bool get isMemberChangedEvent {
+    return content['type'] == EventTypes.RoomMember;
+  }
+
   bool _isPinnedListChanged(
     Map<String, dynamic> content,
     Map<String, dynamic> prevContent,


### PR DESCRIPTION
### DESC:
# Root Cause Analysis:

When the `StreamBuilder` receives a new event update from the network, it rebuilds all widgets under it to ensure the UI is updated correctly. The algorithm for updating widgets relies on changes in their parameters.

In the case of members, the parameter is `memberNotifier`, which isn't updated when new changes come in. For the avatar, the parameter is `avatarUrl`, which updates correctly whenever `avatarUrl` changes.

To solve this issue, we need to have a listener, which will listen for member changed event, then we can updated correctly



### Demo: 

https://github.com/linagora/twake-on-matrix/assets/43041967/101f1d85-3dbe-49c2-b0a7-b31d66277fda




https://github.com/linagora/twake-on-matrix/assets/43041967/077657ad-0467-421e-af0b-663ac44331f1

https://github.com/linagora/twake-on-matrix/assets/43041967/7ca83b3c-123f-4616-b68b-290041283ca2


