### PR TITLE
TW-1785: Improve logout for multiple homeserver

### DIFF
--- a/lib/data/datasource/tom_configurations_datasource.dart
+++ b/lib/data/datasource/tom_configurations_datasource.dart
@@ -7,4 +7,6 @@ abstract class ToMConfigurationsDatasource {
     String userId,
     ToMConfigurations toMConfigurations,
   );
+
+  Future<void> deleteTomConfigurations(String userId);
 }

--- a/lib/data/datasource_impl/tom_configurations_datasource_impl.dart
+++ b/lib/data/datasource_impl/tom_configurations_datasource_impl.dart
@@ -46,4 +46,10 @@ class HiveToMConfigurationDatasource implements ToMConfigurationsDatasource {
           .toJson(),
     );
   }
+
+  @override
+  Future<void> deleteTomConfigurations(String userId) {
+    final hiveCollectionToMDatabase = getIt.get<HiveCollectionToMDatabase>();
+    return hiveCollectionToMDatabase.tomConfigurationsBox.delete(userId);
+  }
 }

--- a/lib/data/repository/tom_configurations_repository_impl.dart
+++ b/lib/data/repository/tom_configurations_repository_impl.dart
@@ -22,4 +22,9 @@ class ToMConfigurationsRepositoryImpl implements ToMConfigurationsRepository {
       toMConfigurations,
     );
   }
+
+  @override
+  Future<void> deleteTomConfigurations(String userId) {
+    return tomConfigurationsDatasource.deleteTomConfigurations(userId);
+  }
 }

--- a/lib/domain/repository/tom_configurations_repository.dart
+++ b/lib/domain/repository/tom_configurations_repository.dart
@@ -7,4 +7,6 @@ abstract class ToMConfigurationsRepository {
     String userId,
     ToMConfigurations toMConfigurations,
   );
+
+  Future<void> deleteTomConfigurations(String userId);
 }

--- a/lib/pages/settings_dashboard/settings/settings.dart
+++ b/lib/pages/settings_dashboard/settings/settings.dart
@@ -108,7 +108,7 @@ class SettingsController extends State<Settings> with ConnectPageMixin {
           if (matrix.backgroundPush != null) {
             await matrix.backgroundPush!.removeCurrentPusher();
           }
-          Future.wait([
+          await Future.wait([
             matrix.client.logout(),
             _deleteTomConfigurations(matrix.client),
           ]);
@@ -126,7 +126,7 @@ class SettingsController extends State<Settings> with ConnectPageMixin {
           if (matrix.backgroundPush != null) {
             await matrix.backgroundPush!.removeCurrentPusher();
           }
-          Future.wait([
+          await Future.wait([
             matrix.client.logout(),
             _deleteTomConfigurations(matrix.client),
           ]);

--- a/lib/presentation/mixins/connect_page_mixin.dart
+++ b/lib/presentation/mixins/connect_page_mixin.dart
@@ -177,6 +177,7 @@ mixin ConnectPageMixin {
       Logs().d('tryLogoutSso::result: $result');
     } catch (e) {
       Logs().d('tryLogoutSso::error: $e');
+      rethrow;
     }
   }
 

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -764,14 +764,14 @@ class MatrixState extends State<Matrix>
   Future<void> _setupAuthUrl({
     String? url,
   }) async {
-    final newAuthUrl = loginHomeserverSummary?.discoveryInformation
-        ?.additionalProperties["m.authentication"]?["issuer"];
     if (url != null) {
       Logs().e(
         'Matrix::_setupAuthUrl: newAuthUrl - $url',
       );
       _authUrl = url;
     } else {
+      final newAuthUrl = loginHomeserverSummary?.discoveryInformation
+          ?.additionalProperties["m.authentication"]?["issuer"];
       Logs().e(
         'Matrix::_setupAuthUrl: newAuthUrl - $newAuthUrl',
       );

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -377,13 +377,8 @@ class MatrixState extends State<Matrix>
         Logs().v('[MATRIX]:_listenLoginStateChanged:: First Log in successful');
         _handleFirstLoggedIn(client);
       } else {
-        Logs().v('[MATRIX]:_listenLoginStateChanged:: Log out successful');
-        if (PlatformInfos.isMobile) {
-          await _deletePersistActiveAccount();
-          TwakeApp.router.go('/home/twakeWelcome');
-        } else {
-          TwakeApp.router.go('/home', extra: true);
-        }
+        Logs().v('[MATRIX]:_listenLoginStateChanged:: Last Log out successful');
+        await _handleLastLogout();
       }
     }
   }
@@ -457,10 +452,7 @@ class MatrixState extends State<Matrix>
   Future<void> _deletePersistActiveAccount() async {
     try {
       final multipleAccountRepository = getIt.get<MultipleAccountRepository>();
-      await Future.wait([
-        multipleAccountRepository.deletePersistActiveAccount(),
-        _deleteAllTomConfigurations(),
-      ]);
+      await multipleAccountRepository.deletePersistActiveAccount();
       Logs().d(
         'MatrixState::_handleLogoutWithMultipleAccount: Delete persist active account success',
       );
@@ -785,6 +777,16 @@ class MatrixState extends State<Matrix>
     Logs().d(
       'MatrixState::_deleteAllTomConfigurations: Delete ToM database success',
     );
+  }
+
+  Future<void> _handleLastLogout() async {
+    if (PlatformInfos.isMobile) {
+      await _deletePersistActiveAccount();
+      TwakeApp.router.go('/home/twakeWelcome');
+    } else {
+      TwakeApp.router.go('/home', extra: true);
+    }
+    await _deleteAllTomConfigurations();
   }
 
   @override


### PR DESCRIPTION
### Ticket 

- #1785 

### Root cause:

- When login success, only set value for `authUrl` however when set active to another account we can't set it again

- When logout an account on multi account, the condition for deleting ToM database is wrong

### Resolved

- [x] : Set value for `authUrl` when we login success and set active to another account
- [x] : Update the condition for deleting ToM database when logout 
   - please prevent delete all tom-db when client logout, only do it when no client available.
   - delete specific client in tom-db when this client logout.

https://github.com/linagora/twake-on-matrix/assets/99852347/a79042b9-1e35-453e-a371-4e45e00ec702


https://github.com/linagora/twake-on-matrix/assets/99852347/aefe4150-08cc-4710-9e20-519191731f91



