### PR TITLE
TW-1526: Fix Cannot unmute more than 2 chats at the same time

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -309,12 +309,13 @@ class ChatListController extends State<ChatList>
   Future<void> toggleMutedSelections() async {
     await TwakeDialog.showFutureLoadingDialogFullScreen(
       future: () async {
+        final newRuleState = pushRuleState;
         for (final conversation in conversationSelectionNotifier.value) {
           final room = activeClient.getRoomById(conversation.roomId)!;
-          if (room.pushRuleState == pushRuleState) continue;
+          if (room.pushRuleState == newRuleState) continue;
           await activeClient
               .getRoomById(conversation.roomId)!
-              .setPushRuleState(pushRuleState);
+              .setPushRuleState(newRuleState);
         }
       },
     );


### PR DESCRIPTION
### Ticket

- #1526 

### Root cause:

The `pushRuleState` is checked against the current `pushRuleState` of each room inside the loop. If they are the same, the loop continues to the next iteration without executing the following code. If they are different, the setPushRuleState(pushRuleState) method is called to update the `pushRuleState` of the room. 

### Resolved

The `pushRuleState` variable is defined outside the for loop, and its value is determined before the loop starts. This means that the `pushRuleState` value will be the same for all iterations of the loop.

- Mobile 
1. Mute/unmute

https://github.com/linagora/twake-on-matrix/assets/99852347/62b4b150-67d9-44d2-9007-8e9e9e12eee0

2. Read/unread

https://github.com/linagora/twake-on-matrix/assets/99852347/deb403c1-eb17-44a2-aa48-0ce23f0b0075

3. Pin/unpin

https://github.com/linagora/twake-on-matrix/assets/99852347/c7616291-7156-45a8-b4de-87e90a3e5b02


- Web

https://github.com/linagora/twake-on-matrix/assets/99852347/901651b0-d0da-4f17-b740-ad58ed2cc6e0


