### PR TITLE
TW-1787: Improve when leave chat

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1468,16 +1468,16 @@ class ChatController extends State<Chat>
       event,
     );
     _handleStateContextMenu();
-    final selectedAction = await showTwakeContextMenu(
+    final selectedActionIndex = await showTwakeContextMenu(
       offset: offset,
       context: context,
       listActions: listContextMenuActions,
       onClose: _handleStateContextMenu,
     );
 
-    if (selectedAction != null) {
+    if (selectedActionIndex != null && selectedActionIndex is int) {
       _handleClickOnContextMenuItem(
-        listPopupMenuActions[selectedAction],
+        listPopupMenuActions[selectedActionIndex],
         event,
       );
     }
@@ -1815,7 +1815,7 @@ class ChatController extends State<Chat>
       listActions: listContextMenuActions,
     );
 
-    if (selectedActionIndex != null) {
+    if (selectedActionIndex != null && selectedActionIndex is int) {
       final selectedAction = listAppBarActions[selectedActionIndex];
       onSelectedAppBarActions(selectedAction);
     }

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -12,6 +12,7 @@ import 'package:fluffychat/presentation/model/chat/view_event_list_ui_state.dart
 import 'package:fluffychat/utils/extension/basic_event_extension.dart';
 import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
+import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/mixins/popup_menu_widget_style.dart';
 import 'package:fluffychat/widgets/mixins/twake_context_menu_mixin.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
@@ -1394,10 +1395,7 @@ class ChatController extends State<Chat>
     }
   }
 
-  List<Widget> _popupMenuActionTile(
-    BuildContext context,
-    Event event,
-  ) {
+  List<ChatContextMenuActions> _getListPopupMenuActions(Event event) {
     final listAction = [
       ChatContextMenuActions.select,
       if (event.isCopyable) ChatContextMenuActions.copyMessage,
@@ -1406,24 +1404,25 @@ class ChatController extends State<Chat>
       if (PlatformInfos.isWeb && event.hasAttachment)
         ChatContextMenuActions.downloadFile,
     ];
-    return listAction.map((action) {
-      return popupItemByTwakeAppRouter(
-        context,
-        action.getTitle(
+    return listAction;
+  }
+
+  List<ContextMenuAction> _mapPopupMenuActionsToContextMenuActions(
+    List<ChatContextMenuActions> listActions,
+    Event event,
+  ) {
+    return listActions.map((action) {
+      return ContextMenuAction(
+        name: action.getTitle(
           context,
           unpin: isUnpinEvent(event),
           isSelected: isSelected(event),
         ),
-        iconAction: action.getIconData(
+        icon: action.getIconData(
           unpin: isUnpinEvent(event),
         ),
         imagePath: action.getImagePath(
           unpin: isUnpinEvent(event),
-        ),
-        isClearCurrentPage: false,
-        onCallbackAction: () => _handleClickOnContextMenuItem(
-          action,
-          event,
         ),
       );
     }).toList();
@@ -1461,15 +1460,27 @@ class ChatController extends State<Chat>
     BuildContext context,
     Event event,
     TapDownDetails tapDownDetails,
-  ) {
+  ) async {
     final offset = tapDownDetails.globalPosition;
+    final listPopupMenuActions = _getListPopupMenuActions(event);
+    final listContextMenuActions = _mapPopupMenuActionsToContextMenuActions(
+      listPopupMenuActions,
+      event,
+    );
     _handleStateContextMenu();
-    showTwakeContextMenu(
+    final selectedAction = await showTwakeContextMenu(
       offset: offset,
       context: context,
-      builder: (context) => _popupMenuActionTile(context, event),
+      listActions: listContextMenuActions,
       onClose: _handleStateContextMenu,
     );
+
+    if (selectedAction != null) {
+      _handleClickOnContextMenuItem(
+        listPopupMenuActions[selectedAction],
+        event,
+      );
+    }
   }
 
   void hideKeyboardChatScreen() {
@@ -1792,14 +1803,22 @@ class ChatController extends State<Chat>
   void handleAppbarMenuAction(
     BuildContext context,
     TapDownDetails tapDownDetails,
-  ) {
+  ) async {
     final offset = tapDownDetails.globalPosition;
-    showTwakeContextMenu(
+    final listAppBarActions = _getListActionAppBarMenu();
+    final listContextMenuActions =
+        _mapAppbarMenuActionToContextMenuAction(listAppBarActions);
+
+    final selectedActionIndex = await showTwakeContextMenu(
       offset: offset,
       context: context,
-      builder: (_) =>
-          _appbarMenuActionTile(context, _getListActionAppBarMenu()),
+      listActions: listContextMenuActions,
     );
+
+    if (selectedActionIndex != null) {
+      final selectedAction = listAppBarActions[selectedActionIndex];
+      onSelectedAppBarActions(selectedAction);
+    }
   }
 
   List<ChatAppBarActions> _getListActionAppBarMenu() {
@@ -1829,23 +1848,19 @@ class ChatController extends State<Chat>
     ];
   }
 
-  List<Widget> _appbarMenuActionTile(
-    BuildContext context,
+  List<ContextMenuAction> _mapAppbarMenuActionToContextMenuAction(
     List<ChatAppBarActions> listAction,
   ) {
     return listAction.map((action) {
-      return popupItemByTwakeAppRouter(
-        context,
-        action.getTitle(context),
-        iconAction: action.getIcon(),
+      return ContextMenuAction(
+        name: action.getTitle(context),
+        icon: action.getIcon(),
         colorIcon: action.getColorIcon(context),
         styleName: action == ChatAppBarActions.leaveGroup
             ? PopupMenuWidgetStyle.defaultItemTextStyle(context)?.copyWith(
                 color: action.getColorIcon(context),
               )
             : null,
-        isClearCurrentPage: false,
-        onCallbackAction: () => onSelectedAppBarActions(action),
       );
     }).toList();
   }

--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -4,6 +4,7 @@ import 'package:fluffychat/pages/chat/group_chat_empty_view.dart';
 import 'package:fluffychat/pages/chat_draft/draft_chat_empty_widget.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -189,6 +190,13 @@ class ChatEventList extends StatelessWidget {
                               );
                             },
                             onLongPress: controller.onSelectMessage,
+                            listAction: controller
+                                .listHorizontalActionMenuBuilder(event)
+                                .map((action) {
+                              return ContextMenuAction(
+                                name: action.action.name,
+                              );
+                            }).toList(),
                           )
                         : const SizedBox(),
                   );

--- a/lib/pages/chat/chat_pinned_events/pinned_messages_screen.dart
+++ b/lib/pages/chat/chat_pinned_events/pinned_messages_screen.dart
@@ -98,10 +98,19 @@ class PinnedMessagesScreen extends StatelessWidget {
                               selectMode: selectedEvents.isNotEmpty,
                               onSelect: controller.onSelectMessage,
                               selected: controller.isSelected(event),
-                              menuChildren: (context) => controller
-                                  .pinnedMessagesActionsList(context, event),
+                              menuChildren: (context) =>
+                                  controller.pinnedMessagesActionsList(
+                                context,
+                                controller.getPinnedMessagesActionsList(event),
+                                event,
+                              ),
                               onLongPress: (event) =>
                                   controller.onLongPressMessage(
+                                context,
+                                event,
+                              ),
+                              listAction: controller
+                                  .pinnedMessagesContextMenuActionsList(
                                 context,
                                 event,
                               ),

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -16,6 +16,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
+import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/swipeable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -61,6 +62,7 @@ class Message extends StatefulWidget {
   final FocusNode? focusNode;
   final void Function(Event)? timestampCallback;
   final void Function(Event)? onLongPress;
+  final List<ContextMenuAction> listAction;
 
   const Message(
     this.event, {
@@ -84,6 +86,7 @@ class Message extends StatefulWidget {
     this.focusNode,
     this.timestampCallback,
     this.onLongPress,
+    required this.listAction,
   });
 
   /// Indicates wheither the user may use a mouse instead
@@ -204,6 +207,7 @@ class _MessageState extends State<Message> {
               menuChildren: widget.menuChildren,
               focusNode: widget.focusNode,
               onLongPress: widget.onLongPress,
+              listActions: widget.listAction,
             ),
           ),
         ];

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action_item.dart';
 import 'package:fluffychat/widgets/context_menu/twake_context_menu_area.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
@@ -32,6 +33,7 @@ class MessageContentWithTimestampBuilder extends StatelessWidget {
   final bool selectMode;
   final ContextMenuBuilder? menuChildren;
   final FocusNode? focusNode;
+  final List<ContextMenuAction> listActions;
 
   static final responsiveUtils = getIt.get<ResponsiveUtils>();
 
@@ -50,6 +52,7 @@ class MessageContentWithTimestampBuilder extends StatelessWidget {
     this.onMenuAction,
     this.menuChildren,
     this.focusNode,
+    required this.listActions,
   });
 
   @override
@@ -78,6 +81,7 @@ class MessageContentWithTimestampBuilder extends StatelessWidget {
           builder: menuChildren != null
               ? (context) => menuChildren!.call(context)
               : null,
+          listActions: listActions,
           child: Container(
             alignment:
                 event.isOwnMessage ? Alignment.topRight : Alignment.topLeft,

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -555,7 +555,7 @@ class ChatListController extends State<ChatList>
       context: context,
       listActions: listContextActions,
     );
-    if (selectedActionIndex != null) {
+    if (selectedActionIndex != null && selectedActionIndex is int) {
       _handleClickOnContextMenuItem(
         listPopupActions[selectedActionIndex],
         room,

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -25,6 +25,7 @@ import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/utils/tor_stub.dart'
     if (dart.library.html) 'package:tor_detector_web/tor_detector_web.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
+import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/layouts/agruments/app_adaptive_scaffold_body_args.dart';
 import 'package:fluffychat/widgets/layouts/agruments/logged_in_other_account_body_args.dart';
 import 'package:fluffychat/widgets/mixins/popup_context_menu_action_mixin.dart';
@@ -541,19 +542,28 @@ class ChatListController extends State<ChatList>
     BuildContext context,
     Room room,
     TapDownDetails details,
-  ) {
+  ) async {
     final offset = details.globalPosition;
-    showTwakeContextMenu(
+    final listPopupActions = _popupMenuActions(room);
+    final listContextActions = _mapPopupMenuActionsToContextMenuActions(
+      context,
+      room,
+      listPopupActions,
+    );
+    final selectedActionIndex = await showTwakeContextMenu(
       offset: offset,
       context: context,
-      builder: (context) => _popupMenuActionTile(context, room),
+      listActions: listContextActions,
     );
+    if (selectedActionIndex != null) {
+      _handleClickOnContextMenuItem(
+        listPopupActions[selectedActionIndex],
+        room,
+      );
+    }
   }
 
-  List<Widget> _popupMenuActionTile(
-    BuildContext context,
-    Room room,
-  ) {
+  List<ChatListSelectionActions> _popupMenuActions(Room room) {
     final listAction = [
       if (!room.isInvitation) ...[
         ChatListSelectionActions.read,
@@ -561,15 +571,18 @@ class ChatListController extends State<ChatList>
       ],
       ChatListSelectionActions.mute,
     ];
-    return listAction.map((action) {
-      return popupItemByTwakeAppRouter(
-        context,
-        action.getTitleContextMenuSelection(context, room),
-        iconAction: action.getIconContextMenuSelection(room),
-        onCallbackAction: () => _handleClickOnContextMenuItem(
-          action,
-          room,
-        ),
+    return listAction;
+  }
+
+  List<ContextMenuAction> _mapPopupMenuActionsToContextMenuActions(
+    BuildContext context,
+    Room room,
+    List<ChatListSelectionActions> listActions,
+  ) {
+    return listActions.map((action) {
+      return ContextMenuAction(
+        name: action.getTitleContextMenuSelection(context, room),
+        icon: action.getIconContextMenuSelection(room),
       );
     }).toList();
   }

--- a/lib/widgets/context_menu/context_menu_action.dart
+++ b/lib/widgets/context_menu/context_menu_action.dart
@@ -1,15 +1,16 @@
+import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 
-class ContextMenuAction {
-  String name;
-  IconData? icon;
-  String? imagePath;
-  Color? colorIcon;
-  double? iconSize;
-  TextStyle? styleName;
-  EdgeInsets? padding;
+class ContextMenuAction extends Equatable {
+  final String name;
+  final IconData? icon;
+  final String? imagePath;
+  final Color? colorIcon;
+  final double? iconSize;
+  final TextStyle? styleName;
+  final EdgeInsets? padding;
 
-  ContextMenuAction({
+  const ContextMenuAction({
     required this.name,
     this.icon,
     this.imagePath,
@@ -18,4 +19,15 @@ class ContextMenuAction {
     this.styleName,
     this.padding,
   });
+
+  @override
+  List<Object?> get props => [
+        name,
+        icon,
+        imagePath,
+        colorIcon,
+        iconSize,
+        styleName,
+        padding,
+      ];
 }

--- a/lib/widgets/context_menu/context_menu_action.dart
+++ b/lib/widgets/context_menu/context_menu_action.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class ContextMenuAction {
+  String name;
+  IconData? icon;
+  String? imagePath;
+  Color? colorIcon;
+  double? iconSize;
+  TextStyle? styleName;
+  EdgeInsets? padding;
+
+  ContextMenuAction({
+    required this.name,
+    this.icon,
+    this.imagePath,
+    this.colorIcon,
+    this.iconSize,
+    this.styleName,
+    this.padding,
+  });
+}

--- a/lib/widgets/context_menu/context_menu_action_item_widget.dart
+++ b/lib/widgets/context_menu/context_menu_action_item_widget.dart
@@ -1,66 +1,33 @@
-import 'package:fluffychat/pages/chat/events/message/message_content_with_timestamp_builder.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
-import 'package:fluffychat/widgets/context_menu/twake_context_menu.dart';
 import 'package:fluffychat/widgets/mixins/twake_context_menu_style.dart';
-import 'package:fluffychat/widgets/twake_app.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
-/// Show a [TwakeContextMenu] on the given [BuildContext]. For other parameters, see [TwakeContextMenu].
-mixin TwakeContextMenuMixin {
-  Future<int?> showTwakeContextMenu({
-    required List<ContextMenuAction> listActions,
-    required Offset offset,
-    required BuildContext context,
-    double? verticalPadding,
-    VoidCallback? onClose,
-  }) async {
-    int? result;
-    await showDialog<int>(
-      context: context,
-      barrierColor: Colors.yellow,
-      barrierDismissible: false,
-      builder: (dialogContext) => TwakeContextMenu(
-        dialogContext: dialogContext,
-        listActions: listActions,
-        position: offset,
-        verticalPadding: verticalPadding,
-      ),
-    ).then((value) {
-      result = value;
-      onClose?.call();
-    });
-    return result;
-  }
+class ContextMenuActionItemWidget extends StatelessWidget {
+  final ContextMenuAction action;
+  final void Function()? closeMenuAction;
 
-  Widget contextMenuItem(
-    BuildContext context,
-    String nameAction, {
-    IconData? iconAction,
-    String? imagePath,
-    Color? colorIcon,
-    double? iconSize,
-    TextStyle? styleName,
-    EdgeInsets? padding,
-    void Function()? onCallbackAction,
-    bool isClearCurrentPage = true,
-  }) {
+  const ContextMenuActionItemWidget({
+    super.key,
+    required this.action,
+    this.closeMenuAction,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     return InkWell(
       onTap: () {
-        if (isClearCurrentPage) {
-          TwakeApp.router.routerDelegate.pop();
-        }
-        onCallbackAction!.call();
+        closeMenuAction?.call();
       },
       child: _itemBuilder(
         context,
-        nameAction,
-        iconAction: iconAction,
-        imagePath: imagePath,
-        colorIcon: colorIcon,
-        iconSize: iconSize,
-        styleName: styleName,
-        padding: padding,
+        action.name,
+        iconAction: action.icon,
+        imagePath: action.imagePath,
+        colorIcon: action.colorIcon,
+        iconSize: action.iconSize,
+        styleName: action.styleName,
+        padding: action.padding,
       ),
     );
   }

--- a/lib/widgets/context_menu/twake_context_menu.dart
+++ b/lib/widgets/context_menu/twake_context_menu.dart
@@ -17,14 +17,14 @@ const double _kMinTileHeight = 24;
 /// If you just want to use a normal [TwakeContextMenu], please use [TwakeContextMenuArea].
 
 class TwakeContextMenu extends StatefulWidget {
+  /// The [BuildContext] of the dialog/modal that will display the [TwakeContextMenu]. This is used to close the dialog/modal when the [TwakeContextMenu] is closed.
   final BuildContext dialogContext;
+
+  /// The list of items to be displayed in the [TwakeContextMenu]. This is used to build the UI of items
   final List<ContextMenuAction> listActions;
 
   /// The [Offset] from coordinate origin the [TwakeContextMenu] will be displayed at.
   final Offset position;
-
-  /// The builder for the items to be displayed. [ListTile] is very useful in most cases.
-  // final ContextMenuBuilder builder;
 
   /// The padding value at the top an bottom between the edge of the [TwakeContextMenu] and the first / last item
   final double? verticalPadding;
@@ -136,7 +136,7 @@ class TwakeContextMenuState extends State<TwakeContextMenu>
                                         child: action,
                                         closeMenuAction: () {
                                           closeContextMenu(
-                                            indexOfAction: widget.listActions
+                                            popResult: widget.listActions
                                                 .indexOf(action),
                                           );
                                         },
@@ -164,9 +164,9 @@ class TwakeContextMenuState extends State<TwakeContextMenu>
     );
   }
 
-  void closeContextMenu({int? indexOfAction}) {
+  void closeContextMenu({dynamic popResult}) {
     _animationController.reverse().whenComplete(() {
-      Navigator.of(widget.dialogContext).pop<int>(indexOfAction);
+      Navigator.of(widget.dialogContext).pop<dynamic>(popResult);
     });
   }
 

--- a/lib/widgets/context_menu/twake_context_menu_area.dart
+++ b/lib/widgets/context_menu/twake_context_menu_area.dart
@@ -14,7 +14,9 @@ typedef ContextMenuBuilder = List<Widget> Function(BuildContext context);
 /// with the corresponding location [Offset].
 
 class TwakeContextMenuArea extends StatelessWidget with TwakeContextMenuMixin {
+  /// The list of items to be displayed in the [TwakeContextMenu]. This is used to build the UI of items
   final List<ContextMenuAction> listActions;
+
   /// The widget displayed inside the [TwakeContextMenuArea]
   final Widget child;
 

--- a/lib/widgets/context_menu/twake_context_menu_area.dart
+++ b/lib/widgets/context_menu/twake_context_menu_area.dart
@@ -1,4 +1,5 @@
 // reference to: https://pub.dev/packages/contextmenu
+import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/mixins/twake_context_menu_mixin.dart';
 import 'package:fluffychat/widgets/mixins/twake_context_menu_style.dart';
 import 'package:flutter/material.dart';
@@ -13,6 +14,7 @@ typedef ContextMenuBuilder = List<Widget> Function(BuildContext context);
 /// with the corresponding location [Offset].
 
 class TwakeContextMenuArea extends StatelessWidget with TwakeContextMenuMixin {
+  final List<ContextMenuAction> listActions;
   /// The widget displayed inside the [TwakeContextMenuArea]
   final Widget child;
 
@@ -26,6 +28,7 @@ class TwakeContextMenuArea extends StatelessWidget with TwakeContextMenuMixin {
 
   const TwakeContextMenuArea({
     super.key,
+    required this.listActions,
     required this.child,
     this.builder,
     this.verticalPadding,
@@ -40,7 +43,7 @@ class TwakeContextMenuArea extends StatelessWidget with TwakeContextMenuMixin {
       onSecondaryTapDown: (details) => showTwakeContextMenu(
         offset: details.globalPosition,
         context: context,
-        builder: builder!,
+        listActions: listActions,
         verticalPadding:
             verticalPadding ?? TwakeContextMenuStyle.defaultVerticalPadding,
       ),

--- a/lib/widgets/mixins/twake_context_menu_mixin.dart
+++ b/lib/widgets/mixins/twake_context_menu_mixin.dart
@@ -1,24 +1,20 @@
-import 'package:fluffychat/pages/chat/events/message/message_content_with_timestamp_builder.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/context_menu/twake_context_menu.dart';
-import 'package:fluffychat/widgets/mixins/twake_context_menu_style.dart';
-import 'package:fluffychat/widgets/twake_app.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 
 /// Show a [TwakeContextMenu] on the given [BuildContext]. For other parameters, see [TwakeContextMenu].
 mixin TwakeContextMenuMixin {
-  Future<int?> showTwakeContextMenu({
+  Future<dynamic> showTwakeContextMenu({
     required List<ContextMenuAction> listActions,
     required Offset offset,
     required BuildContext context,
     double? verticalPadding,
     VoidCallback? onClose,
   }) async {
-    int? result;
-    await showDialog<int>(
+    dynamic result;
+    await showDialog(
       context: context,
-      barrierColor: Colors.yellow,
+      barrierColor: Colors.transparent,
       barrierDismissible: false,
       builder: (dialogContext) => TwakeContextMenu(
         dialogContext: dialogContext,
@@ -31,94 +27,5 @@ mixin TwakeContextMenuMixin {
       onClose?.call();
     });
     return result;
-  }
-
-  Widget contextMenuItem(
-    BuildContext context,
-    String nameAction, {
-    IconData? iconAction,
-    String? imagePath,
-    Color? colorIcon,
-    double? iconSize,
-    TextStyle? styleName,
-    EdgeInsets? padding,
-    void Function()? onCallbackAction,
-    bool isClearCurrentPage = true,
-  }) {
-    return InkWell(
-      onTap: () {
-        if (isClearCurrentPage) {
-          TwakeApp.router.routerDelegate.pop();
-        }
-        onCallbackAction!.call();
-      },
-      child: _itemBuilder(
-        context,
-        nameAction,
-        iconAction: iconAction,
-        imagePath: imagePath,
-        colorIcon: colorIcon,
-        iconSize: iconSize,
-        styleName: styleName,
-        padding: padding,
-      ),
-    );
-  }
-
-  Widget _itemBuilder(
-    BuildContext context,
-    String nameAction, {
-    IconData? iconAction,
-    String? imagePath,
-    Color? colorIcon,
-    double? iconSize,
-    TextStyle? styleName,
-    EdgeInsets? padding,
-  }) {
-    Widget buildIcon() {
-      // We try to get the SVG first and then the IconData
-      if (imagePath != null) {
-        return SvgPicture.asset(
-          imagePath,
-          width: iconSize ?? TwakeContextMenuStyle.defaultItemIconSize,
-          height: iconSize ?? TwakeContextMenuStyle.defaultItemIconSize,
-          fit: BoxFit.fill,
-          colorFilter: ColorFilter.mode(
-            colorIcon ?? TwakeContextMenuStyle.defaultItemColorIcon(context)!,
-            BlendMode.srcIn,
-          ),
-        );
-      }
-
-      if (iconAction != null) {
-        return Icon(
-          iconAction,
-          size: iconSize ?? TwakeContextMenuStyle.defaultItemIconSize,
-          color:
-              colorIcon ?? TwakeContextMenuStyle.defaultItemColorIcon(context),
-        );
-      }
-
-      return const SizedBox.shrink();
-    }
-
-    return Padding(
-      padding: padding ?? TwakeContextMenuStyle.defaultItemPadding,
-      child: SizedBox(
-        child: Row(
-          children: [
-            buildIcon(),
-            const SizedBox(width: TwakeContextMenuStyle.defaultItemElementsGap),
-            Expanded(
-              child: Text(
-                nameAction,
-                style: styleName ??
-                    TwakeContextMenuStyle.defaultItemTextStyle(context),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 }

--- a/lib/widgets/mixins/twake_context_menu_style.dart
+++ b/lib/widgets/mixins/twake_context_menu_style.dart
@@ -5,9 +5,22 @@ class TwakeContextMenuStyle {
     return Theme.of(context).colorScheme.surface;
   }
 
+  static Color? defaultItemColorIcon(BuildContext context) {
+    return Theme.of(context).colorScheme.onSurfaceVariant;
+  }
+
   static const double defaultVerticalPadding = 8.0;
   static const double menuElevation = 2.0;
   static const double menuBorderRadius = 4.0;
   static const double menuMinWidth = 196.0;
   static const double menuMaxWidth = 306.0;
+  static const double defaultItemIconSize = 24.0;
+  static const EdgeInsets defaultItemPadding = EdgeInsets.all(12.0);
+  static const double defaultItemElementsGap = 12.0;
+  static TextStyle? defaultItemTextStyle(BuildContext context) {
+    return Theme.of(context).textTheme.bodyLarge?.copyWith(
+          color: Theme.of(context).colorScheme.onSurface,
+          overflow: TextOverflow.ellipsis,
+        );
+  }
 }


### PR DESCRIPTION
## Ticket
- #1787 

## Root cause
- Right now, `close` context menu function and context menu `actions` function are called parallel -> for actions that show loading dialog, the expected behavior will not work

## Solution
- Move UI of `actions item` into context menu widget
- Call `actions` function after `close` function

## Resolved
- Web:

https://github.com/linagora/twake-on-matrix/assets/80142234/269b68b5-4667-4826-b3b1-d1c5657a0cb0


https://github.com/linagora/twake-on-matrix/assets/80142234/b324f911-5b02-461f-83c9-a2c29d045ddd


- Android:

https://github.com/linagora/twake-on-matrix/assets/80142234/eee65d22-020d-45e0-8a66-f6040e1d4778



https://github.com/linagora/twake-on-matrix/assets/80142234/48cecf8a-7fd0-4539-a6a9-3283862d2330

