### PR TITLE
TW-1841: Fix back screen when use `go_router` and `Navigator`

### DIFF
--- a/lib/pages/chat_details/participant_list_item/participant_list_item.dart
+++ b/lib/pages/chat_details/participant_list_item/participant_list_item.dart
@@ -9,7 +9,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_gen/gen_l10n/l10n.dart';
-import 'package:go_router/go_router.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
 import 'package:matrix/matrix.dart';
@@ -129,7 +128,7 @@ class ParticipantListItem extends StatelessWidget {
           userId: member.id,
           onUpdatedMembers: onUpdatedMembers,
           onNewChatOpen: () {
-            dialogContext.pop();
+            Navigator.of(dialogContext).pop();
           },
         );
       },
@@ -228,7 +227,7 @@ class ParticipantListItem extends StatelessWidget {
                       child: Padding(
                         padding: ParticipantListItemStyle.closeButtonPadding,
                         child: IconButton(
-                          onPressed: () => dialogContext.pop(),
+                          onPressed: () => Navigator.of(dialogContext).pop(),
                           icon: const Icon(Icons.close),
                         ),
                       ),
@@ -236,7 +235,7 @@ class ParticipantListItem extends StatelessWidget {
                     ProfileInfoBody(
                       user: member,
                       onNewChatOpen: () {
-                        dialogContext.pop();
+                        Navigator.of(dialogContext).pop();
                       },
                       onUpdatedMembers: onUpdatedMembers,
                     ),

--- a/lib/pages/invitation_selection/invitation_selection.dart
+++ b/lib/pages/invitation_selection/invitation_selection.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
-import 'package:go_router/go_router.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:matrix/matrix.dart';
@@ -94,7 +93,7 @@ class InvitationSelectionController
   }
 
   void inviteSuccessAction() {
-    context.pop();
+    Navigator.of(context).pop();
   }
 
   @override

--- a/lib/pages/new_group/contacts_selection_view.dart
+++ b/lib/pages/new_group/contacts_selection_view.dart
@@ -11,7 +11,6 @@ import 'package:fluffychat/widgets/twake_components/twake_fab.dart';
 import 'package:fluffychat/widgets/twake_components/twake_text_button.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 
 class ContactsSelectionView extends StatelessWidget {
@@ -140,7 +139,7 @@ class ContactsSelectionView extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
           TwakeTextButton(
-            onTap: () => context.pop(),
+            onTap: () => Navigator.of(context).pop(),
             message: L10n.of(context)!.cancel,
             borderHover: ContactsSelectionViewStyle.webActionsButtonBorder,
             margin: ContactsSelectionViewStyle.webActionsButtonMargin,

--- a/lib/pages/profile_info/profile_info_view.dart
+++ b/lib/pages/profile_info/profile_info_view.dart
@@ -2,7 +2,6 @@ import 'package:fluffychat/pages/profile_info/profile_info_page.dart';
 import 'package:fluffychat/pages/profile_info/profile_info_body/profile_info_body.dart';
 import 'package:fluffychat/pages/profile_info/profile_info_view_style.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:linagora_design_flutter/colors/linagora_state_layer.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
@@ -43,7 +42,7 @@ class ProfileInfoView extends StatelessWidget {
                   splashColor: Colors.transparent,
                   hoverColor: Colors.transparent,
                   highlightColor: Colors.transparent,
-                  onPressed: () => context.pop(),
+                  onPressed: () => Navigator.of(context).pop(),
                   icon: const Icon(Icons.arrow_back),
                 ),
               ),

--- a/lib/widgets/app_bars/searchable_app_bar.dart
+++ b/lib/widgets/app_bars/searchable_app_bar.dart
@@ -132,7 +132,7 @@ class SearchableAppBar extends StatelessWidget {
                 ] else ...[
                   if (displayBackButton)
                     TwakeIconButton(
-                      onTap: () => context.pop(),
+                      onTap: () => Navigator.of(context).pop(),
                       tooltip: L10n.of(context)!.close,
                       icon: Icons.close,
                       paddingAll: SearchableAppBarStyle.closeButtonPaddingAll,


### PR DESCRIPTION
### Ticket:

- #1841 

### Root cause:

- When we open a dialog on Web using `Navigator` however when we close a dialog → we use `go_router` (ex: context.pop() ...) →confusion when using `go_router` and `Navigator`

### Resolved


https://github.com/linagora/twake-on-matrix/assets/99852347/8c30b68b-e03a-40f6-a180-b9d6f8179803


https://github.com/linagora/twake-on-matrix/assets/99852347/0b30d55b-4153-4b79-abde-9227932cb669


