### PR TITLE
TW-1812 Remove X from the search bar when it's empty

### DIFF
--- a/lib/pages/search/search_text_field.dart
+++ b/lib/pages/search/search_text_field.dart
@@ -42,16 +42,15 @@ class SearchTextField extends StatelessWidget {
           suffixIcon: ValueListenableBuilder(
             valueListenable: textEditingController,
             builder: (context, value, child) {
-              return textEditingController.text.isNotEmpty
-                  ? TwakeIconButton(
-                      tooltip: L10n.of(context)!.close,
-                      icon: Icons.close,
-                      onTap: () {
-                        textEditingController.clear();
-                      },
-                    )
-                  : const SizedBox.shrink();
+              return value.text.isNotEmpty ? child! : const SizedBox.shrink();
             },
+            child: TwakeIconButton(
+              tooltip: L10n.of(context)!.close,
+              icon: Icons.close,
+              onTap: () {
+                textEditingController.clear();
+              },
+            ),
           ),
         ),
       ),

--- a/lib/pages/search/search_text_field.dart
+++ b/lib/pages/search/search_text_field.dart
@@ -39,11 +39,18 @@ class SearchTextField extends StatelessWidget {
             size: SearchViewStyle.searchIconSize,
             color: Theme.of(context).colorScheme.onSurface,
           ),
-          suffixIcon: TwakeIconButton(
-            tooltip: L10n.of(context)!.close,
-            icon: Icons.close,
-            onTap: () {
-              textEditingController.clear();
+          suffixIcon: ValueListenableBuilder(
+            valueListenable: textEditingController,
+            builder: (context, value, child) {
+              return textEditingController.text.isNotEmpty
+                  ? TwakeIconButton(
+                      tooltip: L10n.of(context)!.close,
+                      icon: Icons.close,
+                      onTap: () {
+                        textEditingController.clear();
+                      },
+                    )
+                  : const SizedBox.shrink();
             },
           ),
         ),


### PR DESCRIPTION
## Issue :
 #1812 
## Solution:
wrapped the suffixIcon in   `ValueListenableBuilder`  to determine if the icon should be displayed or not 
## demo mobile :
[chat1.webm](https://github.com/linagora/twake-on-matrix/assets/160496984/e1729a3f-fbb6-4cd8-9294-46de515345e2)
## demo web :

https://github.com/linagora/twake-on-matrix/assets/160496984/fc9458a7-c848-469d-a888-82c01ab08e7b



