### PR TITLE
hot-fix: fix the error l10n not found after build runner build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
 name: Build
 
 env:
-  FLUTTER_VERSION: 3.22.0
+  FLUTTER_VERSION: 3.22.1
   XCODE_VERSION: ^15.0.1
 
 jobs:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -2,7 +2,7 @@ on:
   pull_request:
 
 env:
-  FLUTTER_VERSION: 3.22.0
+  FLUTTER_VERSION: 3.22.1
   LIBOLM_VERSION: 3.2.16
 
 name: Deploying on GitHub Pages
@@ -57,7 +57,6 @@ jobs:
           flutter clean
           flutter pub get
           flutter pub run build_runner build --delete-conflicting-outputs
-          flutter pub get # In flutter 3.22, flutter gen-l10n is not working properly, so we need to run flutter pub get again
           flutter build web --release --verbose --source-maps --base-href="/${GITHUB_REPOSITORY##*/}/$FOLDER/"
           echo "$TWAKE_PREVIEW_CONFIG" | yq '.issue_id = strenv(FOLDER)' > ./build/web/config.json
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
       - "v*.*.*"
 
 env:
-  FLUTTER_VERSION: 3.22.0
+  FLUTTER_VERSION: 3.22.1
   XCODE_VERSION: ^15.0.1
 
 name: Release

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,7 +4,7 @@ on:
 name: Tests
 
 env:
-  FLUTTER_VERSION: 3.22.0
+  FLUTTER_VERSION: 3.22.1
 
 jobs:
   code_analyze:
@@ -57,7 +57,6 @@ jobs:
       - name: Run widget test
         run: |
           flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-          flutter pub get # In flutter 3.22, flutter gen-l10n is not working properly, so we need to run flutter pub get again
           flutter test
 
   # integration_test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 variables:
-  FLUTTER_VERSION: 3.22.0
+  FLUTTER_VERSION: 3.22.1
 
 image:
   name: cirrusci/flutter:${FLUTTER_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Specify versions
-ARG FLUTTER_VERSION=3.22.0
+ARG FLUTTER_VERSION=3.22.1
 ARG OLM_VERSION=3.2.15
 
 # Building libolm

--- a/scripts/build-android-apk.sh
+++ b/scripts/build-android-apk.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 flutter build apk --release
 mkdir -p build/android
 cp build/app/outputs/apk/release/app-release.apk build/android/

--- a/scripts/build-android-debug.sh
+++ b/scripts/build-android-debug.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 flutter build apk --debug

--- a/scripts/build-linux-debug.sh
+++ b/scripts/build-linux-debug.sh
@@ -9,5 +9,4 @@ sudo apt-get install -y clang cmake ninja-build \
 flutter config --enable-linux-desktop
 flutter clean
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 flutter build linux --profile -v

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -9,5 +9,4 @@ sudo apt-get install -y clang cmake ninja-build \
 flutter config --enable-linux-desktop
 flutter clean
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 flutter build linux --release -v

--- a/scripts/build-macos.sh
+++ b/scripts/build-macos.sh
@@ -2,7 +2,6 @@
 flutter config --enable-macos-desktop
 flutter clean
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 cd macos
 bundle exec fastlane sync_dev_id
 pod install --repo-update

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -3,6 +3,5 @@ flutter config --enable-web
 flutter clean
 flutter pub get
 flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 flutter build web --release --verbose --source-maps --base-href="/web/"
 cp config.sample.json ./build/web/config.json

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -3,7 +3,6 @@ echo "Building for Windows."
 flutter config --enable-windows-desktop
 flutter clean
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 flutter build windows --release -v
 
 # Building libolm

--- a/scripts/code_analyze.sh
+++ b/scripts/code_analyze.sh
@@ -1,5 +1,4 @@
 #!/bin/sh -ve
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
 dart format --set-exit-if-changed lib/ test/
-flutter pub get # In flutter 3.22, flutter gen-l10n is not working properly, so we need to run flutter pub get again
 flutter analyze

--- a/scripts/prepare-ios.sh
+++ b/scripts/prepare-ios.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 # Use alternate beautifier
 brew install xcbeautify
 cd ios

--- a/scripts/release-playstore-beta.sh
+++ b/scripts/release-playstore-beta.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-flutter pub get
 flutter build appbundle --release
 cd android
 bundle exec fastlane deploy_internal_test


### PR DESCRIPTION
### DESC:
in 3.22.1, flutter hot fix the bug related to build_runner that make us to rerun flutter pub get again.
### Reference:
https://github.com/flutter/flutter/blob/master/docs/releases/Hotfixes-to-the-Stable-Channel.md#3221-may-22-2024