### PR TITLE
TW-1791: Improve display contacts on multiple homeserver

### DIFF
--- a/lib/app_state/success.dart
+++ b/lib/app_state/success.dart
@@ -1,5 +1,6 @@
 import 'package:dartz/dartz.dart';
 import 'package:equatable/equatable.dart';
+import 'package:fluffychat/app_state/failure.dart';
 
 abstract class Success extends Equatable {
   const Success();
@@ -9,5 +10,10 @@ extension SuccessExtension on Either {
   T? getSuccessOrNull<T extends Success>({T? fallbackValue}) => fold(
         (failure) => fallbackValue,
         (success) => success is T ? success : fallbackValue,
+      );
+
+  T? getFailureOrNull<T extends Failure>({T? fallbackValue}) => fold(
+        (failure) => failure is T ? failure : fallbackValue,
+        (success) => fallbackValue,
       );
 }

--- a/lib/domain/contact_manager/contacts_manager.dart
+++ b/lib/domain/contact_manager/contacts_manager.dart
@@ -34,7 +34,7 @@ class ContactsManager {
   ValueNotifier<Either<Failure, Success>> getPhonebookContactsNotifier() =>
       _phonebookContactsNotifier;
 
-  bool get _isInitial =>
+  bool get _isSynchronizedTomContacts =>
       _contactsNotifier.value.getSuccessOrNull<ContactsInitial>() != null;
 
   bool get isDoNotShowWarningContactsBannerAgain =>
@@ -44,10 +44,14 @@ class ContactsManager {
     _doNotShowWarningContactsBannerAgain = value;
   }
 
+  Future<void> reSyncContacts() async {
+    _contactsNotifier.value = const Right(ContactsInitial());
+  }
+
   void initialSynchronizeContacts({
     bool isAvailableSupportPhonebookContacts = false,
   }) async {
-    if (!_isInitial) {
+    if (!_isSynchronizedTomContacts) {
       return;
     }
     _getAllContacts(
@@ -76,6 +80,7 @@ class ContactsManager {
     if (!isAvailableSupportPhonebookContacts) {
       return;
     }
+
     phonebookContactInteractor
         .execute(lookupChunkSize: _lookupChunkSize)
         .listen(

--- a/lib/domain/contact_manager/contacts_manager.dart
+++ b/lib/domain/contact_manager/contacts_manager.dart
@@ -6,7 +6,7 @@ import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/domain/app_state/contact/get_phonebook_contacts_state.dart';
 import 'package:fluffychat/domain/usecase/contacts/get_tom_contacts_interactor.dart';
 import 'package:fluffychat/domain/usecase/contacts/phonebook_contact_interactor.dart';
-import 'package:flutter/foundation.dart';
+import 'package:fluffychat/presentation/extensions/value_notifier_custom.dart';
 
 class ContactsManager {
   static const int _lookupChunkSize = 50;
@@ -17,22 +17,23 @@ class ContactsManager {
 
   bool _doNotShowWarningContactsBannerAgain = false;
 
-  final ValueNotifier<Either<Failure, Success>> _contactsNotifier =
-      ValueNotifier(const Right(ContactsInitial()));
+  final ValueNotifierCustom<Either<Failure, Success>> _contactsNotifier =
+      ValueNotifierCustom(const Right(ContactsInitial()));
 
-  final ValueNotifier<Either<Failure, Success>> _phonebookContactsNotifier =
-      ValueNotifier(const Right(GetPhonebookContactsInitial()));
+  final ValueNotifierCustom<Either<Failure, Success>>
+      _phonebookContactsNotifier =
+      ValueNotifierCustom(const Right(GetPhonebookContactsInitial()));
 
   ContactsManager({
     required this.getTomContactsInteractor,
     required this.phonebookContactInteractor,
   });
 
-  ValueNotifier<Either<Failure, Success>> getContactsNotifier() =>
+  ValueNotifierCustom<Either<Failure, Success>> getContactsNotifier() =>
       _contactsNotifier;
 
-  ValueNotifier<Either<Failure, Success>> getPhonebookContactsNotifier() =>
-      _phonebookContactsNotifier;
+  ValueNotifierCustom<Either<Failure, Success>>
+      getPhonebookContactsNotifier() => _phonebookContactsNotifier;
 
   bool get _isSynchronizedTomContacts =>
       _contactsNotifier.value.getSuccessOrNull<ContactsInitial>() != null;

--- a/lib/domain/contact_manager/contacts_manager.dart
+++ b/lib/domain/contact_manager/contacts_manager.dart
@@ -47,6 +47,8 @@ class ContactsManager {
 
   Future<void> reSyncContacts() async {
     _contactsNotifier.value = const Right(ContactsInitial());
+    _phonebookContactsNotifier.value =
+        const Right(GetPhonebookContactsInitial());
   }
 
   void initialSynchronizeContacts({

--- a/lib/pages/multiple_accounts/multiple_accounts_picker.dart
+++ b/lib/pages/multiple_accounts/multiple_accounts_picker.dart
@@ -91,6 +91,7 @@ class MultipleAccountsPickerController {
   Future<void> _setActiveClient(Client newClient) async {
     final result = await _matrixState.setActiveClient(newClient);
     if (result.isSuccess) {
+      _matrixState.reSyncContacts();
       context.go(
         '/rooms',
         extra: SwitchActiveAccountBodyArgs(

--- a/lib/presentation/extensions/value_notifier_custom.dart
+++ b/lib/presentation/extensions/value_notifier_custom.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+
+class ValueNotifierCustom<T> extends ValueNotifier<T> {
+  bool _isDisposed = false;
+
+  ValueNotifierCustom(super.value);
+
+  bool get isDisposed => _isDisposed;
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+}

--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -321,9 +321,6 @@ mixin class ContactsViewControllerMixin {
     textEditingController.clear();
     searchFocusNode.dispose();
     textEditingController.dispose();
-    presentationContactNotifier.dispose();
-    presentationPhonebookContactNotifier.dispose();
-    presentationRecentContactNotifier.dispose();
   }
 
   @visibleForTesting

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -599,7 +599,9 @@ class MatrixState extends State<Matrix>
     ToMServerInformation tomServer,
     IdentityServerInformation? identityServer,
   ) {
-    Logs().d('MatrixState::setUpToMServices: $tomServer, $identityServer');
+    Logs().d(
+      'MatrixState::setUpToMServices: $tomServer, ${identityServer?.baseUrl}',
+    );
     _setUpToMServer(tomServer);
     if (identityServer != null) {
       _setUpIdentityServer(identityServer);
@@ -711,22 +713,26 @@ class MatrixState extends State<Matrix>
       'Matrix::_checkHomeserverExists: Old twakeSupported - $twakeSupported',
     );
     if (client == null && client?.userID == null) return;
-    setUpAuthorization(client!);
     try {
-      final toMConfigurations = await getTomConfigurations(client.userID!);
+      final toMConfigurations = await getTomConfigurations(client!.userID!);
       Logs().d(
         'Matrix::_checkHomeserverExists: toMConfigurations - $toMConfigurations',
       );
       if (toMConfigurations == null) {
         _setUpToMServer(null);
         _setupAuthUrl();
+        setUpAuthorization(client);
       } else {
-        _setUpToMServer(toMConfigurations.tomServerInformation);
         _setupAuthUrl(url: toMConfigurations.authUrl);
+        setUpToMServices(
+          toMConfigurations.tomServerInformation,
+          toMConfigurations.identityServerInformation,
+        );
       }
     } catch (e) {
       _setUpToMServer(null);
       _setupAuthUrl();
+      setUpAuthorization(client!);
       Logs().e('Matrix::_checkHomeserverExists: error - $e');
     }
     Logs().d(

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'package:fluffychat/domain/contact_manager/contacts_manager.dart';
 import 'package:fluffychat/presentation/mixins/init_config_mixin.dart';
 import 'package:fluffychat/presentation/model/client_login_state_event.dart';
 import 'package:fluffychat/widgets/layouts/agruments/logout_body_args.dart';
@@ -75,6 +76,8 @@ class Matrix extends StatefulWidget {
 class MatrixState extends State<Matrix>
     with WidgetsBindingObserver, ReceiveSharingIntentMixin, InitConfigMixin {
   final tomConfigurationRepository = getIt.get<ToMConfigurationsRepository>();
+
+  final _contactsManager = getIt.get<ContactsManager>();
 
   int _activeClient = -1;
   String? activeBundle;
@@ -452,6 +455,7 @@ class MatrixState extends State<Matrix>
     waitForFirstSync = false;
     await setUpToMServicesInLogin(activeClient);
     final result = await setActiveClient(activeClient);
+    matrixState.reSyncContacts();
     if (result.isSuccess) {
       onClientLoginStateChanged.add(
         ClientLoginStateEvent(
@@ -808,6 +812,10 @@ class MatrixState extends State<Matrix>
       TwakeApp.router.go('/home', extra: true);
     }
     await _deleteAllTomConfigurations();
+  }
+
+  Future<void> reSyncContacts() async {
+    _contactsManager.reSyncContacts();
   }
 
   @override

--- a/test/mixin/contacts_view_controller_mixin_test.dart
+++ b/test/mixin/contacts_view_controller_mixin_test.dart
@@ -4,6 +4,7 @@ import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/domain/app_state/contact/get_phonebook_contacts_state.dart';
 import 'package:fluffychat/domain/model/contact/contact_status.dart';
+import 'package:fluffychat/presentation/extensions/value_notifier_custom.dart';
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
 import 'package:fluffychat/presentation/model/contact/get_presentation_contacts_success.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
@@ -141,18 +142,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -216,15 +217,17 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
-        ).thenReturn(ValueNotifier(const Left(GetContactsIsEmpty())));
+        ).thenReturn(ValueNotifierCustom(const Left(GetContactsIsEmpty())));
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
-        ).thenReturn(ValueNotifier(const Right(GetPhonebookContactsInitial())));
+        ).thenReturn(
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
+        );
 
         mockContactsViewControllerMixin.initialFetchContacts(
           client: mockClient,
@@ -287,17 +290,19 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(Right(GetContactsSuccess(contacts: tomContacts))),
+          ValueNotifierCustom(Right(GetContactsSuccess(contacts: tomContacts))),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
-        ).thenReturn(ValueNotifier(const Right(GetPhonebookContactsInitial())));
+        ).thenReturn(
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
+        );
 
         mockContactsViewControllerMixin.initialFetchContacts(
           client: mockClient,
@@ -374,19 +379,21 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             const Left(GetContactsFailure(keyword: '', exception: dynamic)),
           ),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
-        ).thenReturn(ValueNotifier(const Right(GetPhonebookContactsInitial())));
+        ).thenReturn(
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
+        );
 
         mockContactsViewControllerMixin.initialFetchContacts(
           client: mockClient,
@@ -471,18 +478,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -533,18 +540,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -641,18 +648,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -703,18 +710,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -811,18 +818,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(Right(GetContactsSuccess(contacts: tomContacts))),
+          ValueNotifierCustom(Right(GetContactsSuccess(contacts: tomContacts))),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -873,18 +880,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -981,18 +988,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(Right(GetContactsSuccess(contacts: tomContacts))),
+          ValueNotifierCustom(Right(GetContactsSuccess(contacts: tomContacts))),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -1043,12 +1050,12 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             Right(
               GetPresentationContactsSuccess(
                 contacts: tomContacts,
@@ -1061,7 +1068,7 @@ void main() {
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -1180,18 +1187,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(Right(GetContactsSuccess(contacts: tomContacts))),
+          ValueNotifierCustom(Right(GetContactsSuccess(contacts: tomContacts))),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -1242,12 +1249,12 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             Right(
               GetPresentationContactsSuccess(
                 contacts: tomContacts,
@@ -1260,7 +1267,7 @@ void main() {
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -1335,12 +1342,12 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             const Right(
               GetPresentationContactsSuccess(
                 contacts: [],
@@ -1353,7 +1360,7 @@ void main() {
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Right(GetPhonebookContactsInitial())),
+          ValueNotifierCustom(const Right(GetPhonebookContactsInitial())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -1447,18 +1454,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -1522,15 +1529,17 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
-        ).thenReturn(ValueNotifier(const Left(GetContactsIsEmpty())));
+        ).thenReturn(ValueNotifierCustom(const Left(GetContactsIsEmpty())));
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
-        ).thenReturn(ValueNotifier(const Left(GetPhonebookContactsIsEmpty())));
+        ).thenReturn(
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
+        );
 
         mockContactsViewControllerMixin.initialFetchContacts(
           client: mockClient,
@@ -1593,18 +1602,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(Right(GetContactsSuccess(contacts: tomContacts))),
+          ValueNotifierCustom(Right(GetContactsSuccess(contacts: tomContacts))),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             Right(GetPhonebookContactsSuccess(contacts: phonebookContacts)),
           ),
         );
@@ -1694,12 +1703,12 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             const Left(GetContactsFailure(keyword: '', exception: dynamic)),
           ),
         );
@@ -1707,7 +1716,7 @@ void main() {
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             const Left(GetPhonebookContactsFailure(exception: dynamic)),
           ),
         );
@@ -1795,18 +1804,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -1857,18 +1866,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -1965,18 +1974,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.initialFetchContacts(
@@ -2027,18 +2036,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -2135,18 +2144,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(Right(GetContactsSuccess(contacts: tomContacts))),
+          ValueNotifierCustom(Right(GetContactsSuccess(contacts: tomContacts))),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             Right(GetPhonebookContactsSuccess(contacts: phonebookContacts)),
           ),
         );
@@ -2199,18 +2208,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier([]));
+        ).thenReturn(ValueNotifierCustom([]));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetContactsIsEmpty())),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -2307,18 +2316,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(Right(GetContactsSuccess(contacts: tomContacts))),
+          ValueNotifierCustom(Right(GetContactsSuccess(contacts: tomContacts))),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             Right(GetPhonebookContactsSuccess(contacts: phonebookContacts)),
           ),
         );
@@ -2371,12 +2380,12 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             Right(
               GetPresentationContactsSuccess(
                 contacts: tomContacts,
@@ -2389,7 +2398,7 @@ void main() {
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -2508,18 +2517,18 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(Right(GetContactsSuccess(contacts: tomContacts))),
+          ValueNotifierCustom(Right(GetContactsSuccess(contacts: tomContacts))),
         );
 
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             Right(GetPhonebookContactsSuccess(contacts: phonebookContacts)),
           ),
         );
@@ -2572,12 +2581,12 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             Right(
               GetPresentationContactsSuccess(
                 contacts: tomContacts,
@@ -2590,7 +2599,7 @@ void main() {
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(
@@ -2665,12 +2674,12 @@ void main() {
 
         when(
           mockContactsViewControllerMixin.presentationRecentContactNotifier,
-        ).thenReturn(ValueNotifier(recentContacts));
+        ).thenReturn(ValueNotifierCustom(recentContacts));
 
         when(
           mockContactsViewControllerMixin.presentationContactNotifier,
         ).thenReturn(
-          ValueNotifier(
+          ValueNotifierCustom(
             const Right(
               GetPresentationContactsSuccess(
                 contacts: [],
@@ -2683,7 +2692,7 @@ void main() {
         when(
           mockContactsViewControllerMixin.presentationPhonebookContactNotifier,
         ).thenReturn(
-          ValueNotifier(const Left(GetPhonebookContactsIsEmpty())),
+          ValueNotifierCustom(const Left(GetPhonebookContactsIsEmpty())),
         );
 
         mockContactsViewControllerMixin.refreshAllContactsTest(


### PR DESCRIPTION
### Ticket:

- #1791 

### Resolved

- [x] Only display `ToM` contacts for homeserver is supported Twake
- [x] When we switch or add another account need to refresh all contacts (`ToM`, phone book, recent contacts)
- [x] For web only show `ToM` contacts is server supported and recent contacts

#### Mobile

https://github.com/linagora/twake-on-matrix/assets/99852347/c8b57a6e-8b56-4d77-ab5c-ce13ca7b6b05

#### Web

https://github.com/linagora/twake-on-matrix/assets/99852347/4f1e3451-9a53-4765-91d9-9dfdc3b289ec


https://github.com/linagora/twake-on-matrix/assets/99852347/38e95d45-262f-4d25-bdd0-6654cff9f6c1



