### PR TITLE
Removed xcbeautify installation because it's preinstalled on runners

### DIFF
--- a/scripts/prepare-ios.sh
+++ b/scripts/prepare-ios.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs
-# Use alternate beautifier
-brew install xcbeautify
 cd ios
 pod install && pod update


### PR DESCRIPTION
We're using `macos-latest` runner, which corresponds to:

https://github.com/actions/runner-images/blob/870d08d9cbff9a9a2b0e805c7e41e5238c184bf0/images/macos/macos-14-arm64-Readme.md?plain=1#L75