### PR TITLE
TW-1587: Fix can't open chat when click on notification

### DIFF
--- a/lib/presentation/extensions/go_router_extensions.dart
+++ b/lib/presentation/extensions/go_router_extensions.dart
@@ -1,0 +1,14 @@
+import 'package:go_router/go_router.dart';
+
+extension GoRouterExtensions on GoRouter {
+  String? get activeRoomId {
+    try {
+      final path = routeInformationProvider.value.uri.path;
+      if (path.isEmpty) return null;
+      if (!path.startsWith('/rooms/')) return null;
+      return path.split('/')[2];
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -24,6 +24,7 @@ import 'dart:io';
 import 'package:fcm_shared_isolate/fcm_shared_isolate.dart';
 import 'package:fluffychat/domain/model/extensions/push/push_notification_extension.dart';
 import 'package:fluffychat/presentation/extensions/client_extension.dart';
+import 'package:fluffychat/presentation/extensions/go_router_extensions.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/client_stories_extension.dart';
 import 'package:fluffychat/utils/push_helper.dart';
 import 'package:fluffychat/widgets/twake_app.dart';
@@ -369,8 +370,8 @@ class BackgroundPush {
 
   Future<void> goToRoom(String? roomId) async {
     try {
-      _clearAllNavigatorAvailable();
       Logs().v('[Push] Attempting to go to room $roomId...');
+      _clearAllNavigatorAvailable(roomId: roomId);
       if (_matrixState == null || roomId == null) {
         return;
       }
@@ -609,8 +610,18 @@ class BackgroundPush {
     );
   }
 
-  void _clearAllNavigatorAvailable() {
-    final canPopNavigation = TwakeApp.router.canPop();
+  void _clearAllNavigatorAvailable({
+    String? roomId,
+  }) {
+    Logs().d(
+      "BackgroundPush:: - Current active room id  @2 ${TwakeApp.router.activeRoomId}",
+    );
+    if (roomId != null &&
+        TwakeApp.router.activeRoomId?.contains(roomId) == true) {
+      return;
+    }
+
+    final canPopNavigation = TwakeApp.router.routerDelegate.canPop();
     Logs().d("BackgroundPush:: - Can pop other Navigation  $canPopNavigation");
     if (canPopNavigation) {
       TwakeApp.router.routerDelegate.pop();


### PR DESCRIPTION
### Ticket

- #1587

- Reproduce:
  1. Open room A, received notifications and still stay in room A
  2. Click on notifications and go to room
  3. Back to chat list and can't open room A


- Root cause: 
  - When use `_clearAllNavigatorAvailable` missing the case still stays in the current room

- Side effect:
  - #915 

### Resolved
  - If click on notification, go to room same current room not use `_clearAllNavigatorAvailable`

- iOS

https://github.com/linagora/twake-on-matrix/assets/99852347/075a636e-898b-4048-830c-d6c68db3e41a

- Android

https://github.com/linagora/twake-on-matrix/assets/99852347/683e68eb-02ca-4b34-8ab3-d7628e2de1d7

https://github.com/linagora/twake-on-matrix/assets/99852347/f0b61b6a-b33f-40c9-954f-7165bc187aa7

- Web

https://github.com/linagora/twake-on-matrix/assets/99852347/090543ad-46bb-43c0-b814-65011bb9a1bd

