### PR TITLE
TW-1827: online status is not updated correctly

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -1376,6 +1376,7 @@
     "type": "text",
     "placeholders": {}
   },
+  "aWhileAgo": "A while ago",
   "ok": "Ok",
   "@ok": {
     "type": "text",

--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -1180,6 +1180,7 @@
     "type": "text",
     "placeholders": {}
   },
+  "loading": "Loading status...",
   "loadMore": "Load more…",
   "@loadMore": {
     "type": "text",
@@ -1376,7 +1377,11 @@
     "type": "text",
     "placeholders": {}
   },
-  "aWhileAgo": "A while ago",
+  "aWhileAgo": "a while ago",
+  "@aWhileAgo": {
+    "type": "text",
+    "placeholders": {}
+  },
   "ok": "Ok",
   "@ok": {
     "type": "text",
@@ -2565,6 +2570,12 @@
   "@onlineHourAgo": {
     "placeholders": {
       "hour": {}
+    }
+  },
+  "onlineDayAgo": "online {day} day ago",
+  "@onlineDayAgo": {
+    "placeholders": {
+      "day": {}
     }
   },
   "noMessageHereYet": "No message here yet...",

--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -2572,7 +2572,7 @@
       "hour": {}
     }
   },
-  "onlineDayAgo": "online {day} day ago",
+  "onlineDayAgo": "online {day}d ago",
   "@onlineDayAgo": {
     "placeholders": {
       "day": {}

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:fluffychat/pages/chat/chat_actions.dart';
 import 'package:fluffychat/pages/chat/events/message_content_mixin.dart';
 import 'package:fluffychat/presentation/extensions/event_update_extension.dart';
@@ -261,9 +260,6 @@ class ChatController extends State<Chat>
       SuggestionsController();
 
   ValueNotifier<CachedPresence?> cachedPresenceNotifier = ValueNotifier(null);
-
-  final StreamController<ConnectivityResult>
-      connectivityResultStreamController = StreamController.broadcast();
 
   StreamController<CachedPresence> cachedPresenceStreamController =
       StreamController.broadcast();
@@ -2008,6 +2004,7 @@ class ChatController extends State<Chat>
     InViewNotifierListCustom.of(context)?.dispose();
     replyEventNotifier.dispose();
     cachedPresenceStreamController.close();
+    cachedPresenceNotifier.dispose();
     super.dispose();
   }
 

--- a/lib/pages/chat/chat_app_bar_title.dart
+++ b/lib/pages/chat/chat_app_bar_title.dart
@@ -190,18 +190,18 @@ class _DirectChatAppBarStatusContent extends StatelessWidget {
                 );
                 if (connectivitySnapshot.hasData &&
                     connectivityResult == ConnectivityResult.none) {
-                  return _ChatAppBarTitleText(
+                  return ChatAppBarTitleText(
                     text: L10n.of(context)!.noConnection,
                   );
                 }
                 if (directChatPresence == null) {
-                  return _ChatAppBarTitleText(
+                  return ChatAppBarTitleText(
                     text: L10n.of(context)!.loading,
                   );
                 }
                 final typingText = room.getLocalizedTypingText(context);
                 if (typingText.isEmpty) {
-                  return _ChatAppBarTitleText(
+                  return ChatAppBarTitleText(
                     text: room
                         .getLocalizedStatus(
                           context,
@@ -241,11 +241,11 @@ class _GroupChatAppBarStatusContent extends StatelessWidget {
         );
 
         if (snapshot.hasData && connectivityResult == ConnectivityResult.none) {
-          return _ChatAppBarTitleText(text: L10n.of(context)!.noConnection);
+          return ChatAppBarTitleText(text: L10n.of(context)!.noConnection);
         }
         final typingText = room.getLocalizedTypingText(context);
         if (typingText.isEmpty) {
-          return _ChatAppBarTitleText(
+          return ChatAppBarTitleText(
             text: room.getLocalizedStatus(context).capitalize(context),
           );
         } else {
@@ -256,8 +256,9 @@ class _GroupChatAppBarStatusContent extends StatelessWidget {
   }
 }
 
-class _ChatAppBarTitleText extends StatelessWidget {
-  const _ChatAppBarTitleText({
+class ChatAppBarTitleText extends StatelessWidget {
+  const ChatAppBarTitleText({
+    super.key,
     required this.text,
   });
 

--- a/lib/pages/chat/chat_app_bar_title.dart
+++ b/lib/pages/chat/chat_app_bar_title.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:fluffychat/pages/chat/chat_app_bar_title_style.dart';
 import 'package:fluffychat/resource/image_paths.dart';
@@ -11,7 +13,6 @@ import 'package:lottie/lottie.dart';
 import 'package:matrix/matrix.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
-import 'package:rxdart/rxdart.dart';
 
 class ChatAppBarTitle extends StatelessWidget {
   final Widget? actions;
@@ -22,6 +23,8 @@ class ChatAppBarTitle extends StatelessWidget {
   final Stream<ConnectivityResult> connectivityResultStream;
   final VoidCallback onPushDetails;
   final String? roomName;
+  final ValueNotifier<CachedPresence?> cachedPresenceNotifier;
+  final StreamController<CachedPresence>? cachedPresenceStreamController;
 
   const ChatAppBarTitle({
     super.key,
@@ -33,6 +36,8 @@ class ChatAppBarTitle extends StatelessWidget {
     required this.sendController,
     required this.connectivityResultStream,
     required this.onPushDetails,
+    required this.cachedPresenceNotifier,
+    this.cachedPresenceStreamController,
   });
 
   @override
@@ -106,6 +111,9 @@ class ChatAppBarTitle extends StatelessWidget {
                 _ChatAppBarStatusContent(
                   connectivityResultStream: connectivityResultStream,
                   room: room!,
+                  cachedPresenceNotifier: cachedPresenceNotifier,
+                  cachedPresenceStreamController:
+                      cachedPresenceStreamController,
                 ),
               ],
             ),
@@ -120,10 +128,14 @@ class _ChatAppBarStatusContent extends StatelessWidget {
   const _ChatAppBarStatusContent({
     required this.connectivityResultStream,
     required this.room,
+    required this.cachedPresenceNotifier,
+    this.cachedPresenceStreamController,
   });
 
   final Stream<ConnectivityResult> connectivityResultStream;
   final Room room;
+  final ValueNotifier<CachedPresence?> cachedPresenceNotifier;
+  final StreamController<CachedPresence>? cachedPresenceStreamController;
 
   @override
   Widget build(BuildContext context) {
@@ -131,6 +143,8 @@ class _ChatAppBarStatusContent extends StatelessWidget {
       return _DirectChatAppBarStatusContent(
         connectivityResultStream: connectivityResultStream,
         room: room,
+        cachedPresenceNotifier: cachedPresenceNotifier,
+        cachedPresenceStreamController: cachedPresenceStreamController!,
       );
     }
 
@@ -145,50 +159,61 @@ class _DirectChatAppBarStatusContent extends StatelessWidget {
   const _DirectChatAppBarStatusContent({
     required this.connectivityResultStream,
     required this.room,
+    required this.cachedPresenceNotifier,
+    required this.cachedPresenceStreamController,
   });
 
   final Stream<ConnectivityResult> connectivityResultStream;
   final Room room;
+  final ValueNotifier<CachedPresence?> cachedPresenceNotifier;
+  final StreamController<CachedPresence> cachedPresenceStreamController;
 
   @override
   Widget build(BuildContext context) {
     CachedPresence? directChatPresence = room.directChatPresence;
-    return FutureBuilder<GetPresenceResponse>(
-      future: room.client.getPresence(room.directChatMatrixID!),
-      builder: (context, futureSnapshot) {
-        if (futureSnapshot.hasData) {
-          directChatPresence = CachedPresence.fromPresenceResponse(
-            futureSnapshot.data!,
-            room.directChatMatrixID!,
-          );
-        }
-        return StreamBuilder<List>(
-          stream: CombineLatestStream.list(
-            [connectivityResultStream, room.directChatPresenceStream],
-          ),
-          builder: (context, snapshot) {
-            final connectivityResult = tryCast<ConnectivityResult>(
-              snapshot.data?[0],
-              fallback: ConnectivityResult.none,
+    return ValueListenableBuilder(
+      valueListenable: cachedPresenceNotifier,
+      builder: (context, directChatCachedPresence, child) {
+        return StreamBuilder(
+          stream: connectivityResultStream,
+          builder: (context, connectivitySnapshot) {
+            return StreamBuilder(
+              stream: cachedPresenceStreamController.stream,
+              builder: (context, cachedPresenceSnapshot) {
+                final connectivityResult = tryCast<ConnectivityResult>(
+                  connectivitySnapshot.data,
+                  fallback: ConnectivityResult.none,
+                );
+                directChatPresence = tryCast<CachedPresence>(
+                  cachedPresenceSnapshot.data,
+                  fallback: directChatCachedPresence,
+                );
+                if (connectivitySnapshot.hasData &&
+                    connectivityResult == ConnectivityResult.none) {
+                  return _ChatAppBarTitleText(
+                    text: L10n.of(context)!.noConnection,
+                  );
+                }
+                if (directChatPresence == null) {
+                  return _ChatAppBarTitleText(
+                    text: L10n.of(context)!.loading,
+                  );
+                }
+                final typingText = room.getLocalizedTypingText(context);
+                if (typingText.isEmpty) {
+                  return _ChatAppBarTitleText(
+                    text: room
+                        .getLocalizedStatus(
+                          context,
+                          presence: directChatPresence,
+                        )
+                        .capitalize(context),
+                  );
+                } else {
+                  return _ChatAppBarTitleTyping(typingText: typingText);
+                }
+              },
             );
-            directChatPresence = tryCast<CachedPresence>(
-              snapshot.data?[1],
-              fallback: directChatPresence,
-            );
-            if (snapshot.hasData &&
-                connectivityResult == ConnectivityResult.none) {
-              return _ChatAppBarTitleText(text: L10n.of(context)!.noConnection);
-            }
-            final typingText = room.getLocalizedTypingText(context);
-            if (typingText.isEmpty) {
-              return _ChatAppBarTitleText(
-                text: room
-                    .getLocalizedStatus(context, presence: directChatPresence)
-                    .capitalize(context),
-              );
-            } else {
-              return _ChatAppBarTitleTyping(typingText: typingText);
-            }
           },
         );
       },

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -136,6 +136,10 @@ class ChatView extends StatelessWidget with MessageContentMixin {
                             actions: _appBarActions(context),
                             onPushDetails: controller.onPushDetails,
                             roomName: controller.roomName,
+                            cachedPresenceNotifier:
+                                controller.cachedPresenceNotifier,
+                            cachedPresenceStreamController:
+                                controller.cachedPresenceStreamController,
                           ),
                         ),
                       ],

--- a/lib/utils/date_time_extension.dart
+++ b/lib/utils/date_time_extension.dart
@@ -160,9 +160,14 @@ extension DateTimeExtension on DateTime {
     return other.difference(this) < const Duration(hours: 1);
   }
 
-  bool isLessThanTenHoursAgo({DateTime? other}) {
+  bool isLessThanADayAgo({DateTime? other}) {
     other ??= DateTime.now();
-    return other.difference(this) < const Duration(hours: 10);
+    return other.difference(this) < const Duration(hours: 24);
+  }
+
+  bool isLessThan30DaysAgo({DateTime? other}) {
+    other ??= DateTime.now();
+    return other.difference(this) < const Duration(days: 30);
   }
 
   String _formatDateWithLocale(BuildContext context, String pattern) {

--- a/lib/utils/room_status_extension.dart
+++ b/lib/utils/room_status_extension.dart
@@ -16,7 +16,7 @@ extension RoomStatusExtension on Room {
 
   String getLocalizedStatus(BuildContext context, {CachedPresence? presence}) {
     if (isDirectChat) {
-      return _getLocalizedStatusDirectChat(presence, context);
+      return getLocalizedStatusDirectChat(presence, context);
     }
 
     return _getLocalizedStatusGroupChat(context);
@@ -98,7 +98,7 @@ extension RoomStatusExtension on Room {
     return L10n.of(context)!.countMembers(totalMembers);
   }
 
-  String _getLocalizedStatusDirectChat(
+  String getLocalizedStatusDirectChat(
     CachedPresence? directChatPresence,
     BuildContext context,
   ) {

--- a/lib/utils/room_status_extension.dart
+++ b/lib/utils/room_status_extension.dart
@@ -115,10 +115,14 @@ extension RoomStatusExtension on Room {
           return L10n.of(context)!.onlineMinAgo(
             currentDateTime.difference(lastActiveDateTime).inMinutes,
           );
-        } else if (lastActiveDateTime.isLessThanTenHoursAgo()) {
+        } else if (lastActiveDateTime.isLessThanADayAgo()) {
           final timeOffline = currentDateTime.difference(lastActiveDateTime);
           return L10n.of(context)!.onlineHourAgo(
             (timeOffline.inMinutes / 60).round(),
+          );
+        } else if (lastActiveDateTime.isLessThan30DaysAgo()) {
+          return L10n.of(context)!.onlineDayAgo(
+            currentDateTime.difference(lastActiveDateTime).inDays,
           );
         } else {
           return L10n.of(context)!.aWhileAgo;

--- a/lib/utils/room_status_extension.dart
+++ b/lib/utils/room_status_extension.dart
@@ -120,6 +120,8 @@ extension RoomStatusExtension on Room {
           return L10n.of(context)!.onlineHourAgo(
             (timeOffline.inMinutes / 60).round(),
           );
+        } else {
+          return L10n.of(context)!.aWhileAgo;
         }
       }
     }

--- a/test/utils/get_localize_status_test.dart
+++ b/test/utils/get_localize_status_test.dart
@@ -1,0 +1,352 @@
+import 'package:fluffychat/utils/room_status_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:matrix/matrix.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:mockito/annotations.dart';
+
+import 'get_localize_status_test.mocks.dart';
+
+@GenerateMocks(
+  [
+    Logs,
+    Client,
+  ],
+)
+void main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  await initializeDateFormatting();
+
+  group("getLocalizedStatus function test", () {
+    const textWidgetKey = ValueKey('textWidget');
+
+    testWidgets(
+        'GIVEN the presenceType be online\n'
+        'THEN should display the status as active now\n',
+        (WidgetTester tester) async {
+      // Given
+      final presence = CachedPresence(
+        PresenceType.online,
+        0,
+        "",
+        true,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      //EXPECT
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('Active now'));
+    });
+
+    testWidgets(
+        'GIVEN the presence time to be one minute from present with currently active be false\n'
+        'THEN should display the status as active now\n',
+        (WidgetTester tester) async {
+      // Given
+      final lessThanOneMinuteAgo = const Duration(seconds: 30).inMilliseconds;
+      final presence = CachedPresence(
+        PresenceType.offline,
+        lessThanOneMinuteAgo,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('Active now'));
+    });
+
+    testWidgets(
+        'GIVEN the presence time to be 10 minute from present with currently active be false\n'
+        'THEN should display the status as online 10 minutes ago\n',
+        (WidgetTester tester) async {
+      // Given
+      final lessThan10MinutesAgo = (const Duration(minutes: 10)).inMilliseconds;
+      final presence = CachedPresence(
+        PresenceType.offline,
+        lessThan10MinutesAgo,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('online 10m ago'));
+    });
+
+    testWidgets(
+        'GIVEN the presence time to be 10 minute from present with currently active be false\n'
+        'THEN should display the status as online 10 minutes ago\n',
+        (WidgetTester tester) async {
+      // Given
+      final lessThan10MinutesAgo = (const Duration(minutes: 10)).inMilliseconds;
+      final presence = CachedPresence(
+        PresenceType.offline,
+        lessThan10MinutesAgo,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('online 10m ago'));
+    });
+
+    testWidgets(
+        'GIVEN the presence time to be 10 minute from present with currently active be false\n'
+        'THEN should display the status as online 10 minutes ago\n',
+        (WidgetTester tester) async {
+      // Given
+      final lessThan20hoursAgo = (const Duration(hours: 20)).inMilliseconds;
+      final presence = CachedPresence(
+        PresenceType.offline,
+        lessThan20hoursAgo,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('online 20h ago'));
+    });
+
+    testWidgets(
+        'GIVEN the presence time to be 5 days ago from present with currently active be false\n'
+        'THEN should display the status as online 5d ago\n',
+        (WidgetTester tester) async {
+      // Given
+      final lessThan5daysAgo = (const Duration(days: 5)).inMilliseconds;
+      final presence = CachedPresence(
+        PresenceType.offline,
+        lessThan5daysAgo,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('online 5d ago'));
+    });
+
+    testWidgets(
+        'GIVEN the presence time to be more than 30d ago from present with currently active be false\n'
+        'THEN should display the status as a while ago\n',
+        (WidgetTester tester) async {
+      // Given
+      final lessThan60daysAgo = (const Duration(days: 60)).inMilliseconds;
+      final presence = CachedPresence(
+        PresenceType.offline,
+        lessThan60daysAgo,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('a while ago'));
+    });
+
+    testWidgets(
+        'GIVEN the presence time to be more than 30d ago from present with currently active be false\n'
+        'THEN should display the status as a while ago\n',
+        (WidgetTester tester) async {
+      // Given
+      final lessThan60daysAgo = (const Duration(days: 60)).inMilliseconds;
+      final presence = CachedPresence(
+        PresenceType.offline,
+        lessThan60daysAgo,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('a while ago'));
+    });
+
+    testWidgets(
+        'GIVEN the presence to be unavailable \n'
+        'THEN should display the status as offline\n',
+        (WidgetTester tester) async {
+      // Given
+      final presence = CachedPresence(
+        PresenceType.unavailable,
+        null,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('Offline'));
+    });
+
+    testWidgets(
+        'GIVEN the presence to be unavailable \n'
+        'THEN should display the status as offline\n',
+        (WidgetTester tester) async {
+      // Given
+      final presence = CachedPresence(
+        PresenceType.unavailable,
+        null,
+        "",
+        false,
+        "testuserid",
+      );
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('Offline'));
+    });
+
+    testWidgets(
+        'GIVEN the presence to be null \n'
+        'THEN should display the status as offline\n',
+        (WidgetTester tester) async {
+      // Given
+      const presence = null;
+
+      // WHEN
+      await prepareTextWidget(presence, textWidgetKey, tester);
+
+      final textWidgetFinder = find.byKey(textWidgetKey);
+
+      expect(textWidgetFinder, findsOneWidget);
+
+      final Text textWidget = tester.widget(textWidgetFinder) as Text;
+
+      expect(textWidget.data, isNotNull);
+
+      expect(textWidget.data, equals('Offline'));
+    });
+  });
+}
+
+Future<void> prepareTextWidget(
+  CachedPresence? presence,
+  ValueKey<String> textWidgetKey,
+  WidgetTester tester,
+) async {
+  final client = MockClient();
+  final room = Room(id: 'testid', client: client);
+
+  // WHEN
+  final textWidgetBuilder = Builder(
+    builder: (BuildContext context) {
+      final displayText = room.getLocalizedStatusDirectChat(presence, context);
+      return Text(
+        key: textWidgetKey,
+        displayText,
+      );
+    },
+  );
+
+  await tester.pumpWidget(
+    MaterialApp(
+      locale: const Locale('en'),
+      localizationsDelegates: L10n.localizationsDelegates,
+      supportedLocales: L10n.supportedLocales,
+      home: textWidgetBuilder,
+    ),
+  );
+}


### PR DESCRIPTION
### Updated:
- for chat we don't have `lastActiveTimestamp`, keep `offine` status (in this case, it means user never online before or in the case of can't get presence of user)
- for people that offline longer than 10 hours, we display `aWhile ago` instead of `offline`

### android:

https://github.com/linagora/twake-on-matrix/assets/43041967/12bc31cc-babd-4fb2-a860-bcd8297ddc32


### ios:

https://github.com/linagora/twake-on-matrix/assets/43041967/6e10b9f4-b82f-4bda-b9f4-935748262cc6
