### PR TITLE
Renamed artifact to describe the OS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: matrix.os == 'android'
         with:
-          name: twake-release
+          name: twake-release-${{ matrix.os }}
           path: twake-${{ github.ref_name }}*
 
   package_desktop:


### PR DESCRIPTION
So the UI can display artifact name for each OSes: `twake-release-android`, `twake-release-windows`, `twake-release-linux`, `twake-release-macos`.

Currently it's missing `android`:

![image](https://github.com/linagora/twake-on-matrix/assets/39090621/6433a71e-568e-47e1-b306-3f651102faea)
