### PR TITLE
Handle error recovery key lost

### DIFF
--- a/lib/pages/bootstrap/bootstrap_dialog.dart
+++ b/lib/pages/bootstrap/bootstrap_dialog.dart
@@ -4,6 +4,7 @@ import 'package:fluffychat/pages/bootstrap/tom_bootstrap_dialog.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/adaptive_flat_button.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -371,14 +372,20 @@ class BootstrapDialogState extends State<BootstrapDialog> {
                                     cancelLabel: L10n.of(context)!.cancel,
                                     isDestructiveAction: true,
                                   )) {
-                                await TomBootstrapDialog(
-                                  client: widget.client,
-                                ).show().then(
-                                      (value) => Navigator.of(
-                                        context,
-                                        rootNavigator: false,
-                                      ).pop<bool>(false),
-                                    );
+                                if (Matrix.of(context).twakeSupported) {
+                                  await TomBootstrapDialog(
+                                    client: widget.client,
+                                    wipe: true,
+                                    wipeRecovery: true,
+                                  ).show().then(
+                                        (value) => Navigator.of(
+                                          context,
+                                          rootNavigator: false,
+                                        ).pop<bool>(false),
+                                      );
+                                } else {
+                                  _createBootstrap(true);
+                                }
                               }
                             },
                     ),


### PR DESCRIPTION
### DoD:

- [x] Display toast when wipe upload recovery key failed on `homeserver` Twake supported.
- [x] Support user wipe recovery key on `homeserver` Twake not supported (`matrix`).


https://github.com/linagora/twake-on-matrix/assets/99852347/bed1f24b-001e-43a6-9d1e-52f18c92aeee


https://github.com/linagora/twake-on-matrix/assets/99852347/2676a739-e45f-4d00-b7b5-eff1c5bf090c


https://github.com/linagora/twake-on-matrix/assets/99852347/53a23f58-d8fb-499c-8684-2b9427d160e4

