### PR TITLE
TW-1834: profile image is not updated in multiple account

### DIFF
--- a/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
@@ -472,12 +472,10 @@ class SettingsProfileController extends State<SettingsProfile>
           'SettingsProfile::_handleUploadProfileOnData() - success: $success',
         );
         if (success is UpdateProfileSuccess) {
-          _clearImageInLocal();
           final newProfile = Profile(
             userId: client.userID!,
             displayName: success.displayName ?? displayName,
-            avatarUrl:
-                success.avatar == null ? currentProfile?.avatarUrl : null,
+            avatarUrl: success.avatar ?? currentProfile?.avatarUrl,
           );
           _sendAccountDataEvent(profile: newProfile);
           if (!success.isDeleteAvatar) {
@@ -675,6 +673,7 @@ class SettingsProfileController extends State<SettingsProfile>
 
   @override
   void dispose() {
+    _clearImageInLocal();
     displayNameEditingController.dispose();
     matrixIdEditingController.dispose();
     displayNameFocusNode.dispose();

--- a/lib/widgets/mixins/on_account_data_listen_mixin.dart
+++ b/lib/widgets/mixins/on_account_data_listen_mixin.dart
@@ -1,0 +1,27 @@
+import 'dart:async';
+
+import 'package:fluffychat/event/twake_inapp_event_types.dart';
+import 'package:matrix/matrix.dart';
+
+mixin OnProfileChangeMixin {
+  StreamSubscription? onAccountDataSubscription;
+
+  void listenOnProfileChangeStream({
+    required Client client,
+    Profile? currentProfile,
+    void Function(Profile newProfile)? onProfileChanged,
+  }) {
+    onAccountDataSubscription = client.onAccountData.stream.listen((event) {
+      if (event.type == TwakeInappEventTypes.uploadAvatarEvent) {
+        final newProfile = Profile.fromJson(event.content);
+        Logs().d(
+          'TwakeHeader::_handleOnAccountDataSubscription() - newProfileAvatar: ${newProfile.avatarUrl}, newProfileDisplayName: ${newProfile.displayName}',
+        );
+        if (newProfile.avatarUrl != currentProfile?.avatarUrl ||
+            newProfile.displayName != currentProfile?.displayName) {
+          onProfileChanged?.call(newProfile);
+        }
+      }
+    });
+  }
+}


### PR DESCRIPTION
### Issue:
#1834 

### Root cause:
- The avatar in the chat list screen have not listen for uploading new avatar, so only when you terminate the app, the avatar will be updated correctly
### Solution:
- We can listen for uploading new avatar using onAccountData stream from matrix client. We also need to put it in the `didUpdateWidget` method, because when switch account, we need to listen to the right client
- The other change is for improve the UX a bit when uploading new avatar

### Demo android:

https://github.com/linagora/twake-on-matrix/assets/43041967/41452fd2-a0f9-4e86-ac9f-3789d3386aa5

### demo ios:

https://github.com/linagora/twake-on-matrix/assets/43041967/30a1f25e-f751-461d-bd54-05d0f38319b6