### PR TITLE
Tw 1900: IOS is forced to log out many times

### DIFF
--- a/lib/domain/keychain_sharing/keychain_sharing_manager.dart
+++ b/lib/domain/keychain_sharing/keychain_sharing_manager.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/domain/keychain_sharing/keychain_sharing_restore_token.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:matrix/matrix.dart';
 
 class KeychainSharingManager {
   static FlutterSecureStorage get _secureStorage => const FlutterSecureStorage(
@@ -16,6 +17,21 @@ class KeychainSharingManager {
         key: token.session.userId,
         value: jsonEncode(token.toJson()),
       );
+
+  static Future<KeychainSharingRestoreToken?> read({
+    required String userId,
+  }) async {
+    try {
+      final token = await _secureStorage.read(key: userId);
+      if (token != null) {
+        return KeychainSharingRestoreToken.fromJson(jsonDecode(token));
+      }
+    } catch (e, s) {
+      Logs().e('Unable to read token from Secure storage: $e $s');
+      return null;
+    }
+    return null;
+  }
 
   static Future delete({required String? userId}) {
     if (userId != null) {

--- a/lib/domain/keychain_sharing/keychain_sharing_manager.dart
+++ b/lib/domain/keychain_sharing/keychain_sharing_manager.dart
@@ -10,6 +10,8 @@ class KeychainSharingManager {
         iOptions: IOSOptions(
           groupId: AppConfig.iOSKeychainSharingId,
           accountName: AppConfig.iOSKeychainSharingAccount,
+          synchronizable: true,
+          accessibility: KeychainAccessibility.first_unlock_this_device,
         ),
       );
 

--- a/lib/utils/matrix_sdk_extensions/flutter_hive_collections_database.dart
+++ b/lib/utils/matrix_sdk_extensions/flutter_hive_collections_database.dart
@@ -181,17 +181,12 @@ class FlutterHiveCollectionsDatabase extends HiveCollectionsDatabase {
     String? prevBatch,
     String? olmAccount,
   ) async {
-    if (PlatformInfos.isIOS) {
-      final restoreToken = KeychainSharingRestoreToken(
-        session: KeychainSharingSession(
-          accessToken: token,
-          userId: userId,
-          deviceId: deviceId ?? "",
-          homeserverUrl: homeserverUrl,
-        ),
-      );
-      await KeychainSharingManager.save(restoreToken);
-    }
+    await _updateIOSKeychainSharingRestoreToken(
+      homeserverUrl: homeserverUrl,
+      token: token,
+      userId: userId,
+      deviceId: deviceId,
+    );
     return super.updateClient(
       homeserverUrl,
       token,
@@ -201,6 +196,37 @@ class FlutterHiveCollectionsDatabase extends HiveCollectionsDatabase {
       prevBatch,
       olmAccount,
     );
+  }
+
+  Future<void> _updateIOSKeychainSharingRestoreToken({
+    required String homeserverUrl,
+    required String token,
+    required String userId,
+    required String? deviceId,
+  }) async {
+    if (!PlatformInfos.isIOS) {
+      return;
+    }
+    try {
+      final oldToken = await KeychainSharingManager.read(userId: userId);
+      if (oldToken?.session.accessToken != token ||
+          oldToken?.session.userId != userId ||
+          oldToken?.session.homeserverUrl != homeserverUrl ||
+          oldToken?.session.deviceId != deviceId) {
+        final restoreToken = KeychainSharingRestoreToken(
+          session: KeychainSharingSession(
+            accessToken: token,
+            userId: userId,
+            deviceId: deviceId ?? "",
+            homeserverUrl: homeserverUrl,
+          ),
+        );
+        await KeychainSharingManager.save(restoreToken);
+      }
+    } catch (e) {
+      Logs().w('insertClient::current token: $token');
+      Logs().w('insertClient::Unable to save restore token', e);
+    }
   }
 
   @override
@@ -214,17 +240,12 @@ class FlutterHiveCollectionsDatabase extends HiveCollectionsDatabase {
     String? prevBatch,
     String? olmAccount,
   ) async {
-    if (PlatformInfos.isIOS) {
-      final restoreToken = KeychainSharingRestoreToken(
-        session: KeychainSharingSession(
-          accessToken: token,
-          userId: userId,
-          deviceId: deviceId ?? "",
-          homeserverUrl: homeserverUrl,
-        ),
-      );
-      await KeychainSharingManager.save(restoreToken);
-    }
+    await _updateIOSKeychainSharingRestoreToken(
+      homeserverUrl: homeserverUrl,
+      token: token,
+      userId: userId,
+      deviceId: deviceId,
+    );
     return super.insertClient(
       name,
       homeserverUrl,


### PR DESCRIPTION
### Issue:
#1900

### How to reproduce:
- in your iphone, lock the iphone and make sure the Twake Chat is terminated. Wait for a notification from encrypted room to come, when the notification appear in the screen, wait for 5-10 second, then unlock the iphone, click the notification, the user will be redirect to /twakeWelcome page.

- Logs:
![image](https://github.com/linagora/twake-on-matrix/assets/43041967/e97d1c20-1324-4fe7-8d42-47b41bb8ff11)

### Root cause:
- When the device are locked, Twake chat can't access to the keychain storage, then because of the twake chat is terminated, the app need to run from main() again, in main method, it need to create client again. When creating a new client, the old logic need to write data to the Keychain -> this operation will throw an exception at runtime, and the client is null -> user is log out

### Solution:
add a try/catch in the write operation to keychain, so that if its failed, it still return the old client. Make the access to keychain storage to lowest (which is KeychainAccessibility.first_unlock_this_device), this will make sure we don't hvae this error anymore.

### Demo:

https://github.com/linagora/twake-on-matrix/assets/43041967/f761cf93-dae2-4a22-ac93-40ed970067ba

