### PR TITLE
TW-1916: Improve search exact Matrix ID inside Contact tab

### DIFF
--- a/lib/pages/contacts_tab/contacts_tab.dart
+++ b/lib/pages/contacts_tab/contacts_tab.dart
@@ -12,6 +12,7 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:go_router/go_router.dart';
+import 'package:matrix/matrix.dart';
 
 class ContactsTab extends StatefulWidget {
   final Widget? bottomNavigationBar;
@@ -28,6 +29,8 @@ class ContactsTab extends StatefulWidget {
 class ContactsTabController extends State<ContactsTab>
     with ComparablePresentationContactMixin, ContactsViewControllerMixin {
   final responsive = getIt.get<ResponsiveUtils>();
+
+  Client get client => Matrix.of(context).client;
 
   @override
   void initState() {

--- a/lib/pages/contacts_tab/contacts_tab_body_view.dart
+++ b/lib/pages/contacts_tab/contacts_tab_body_view.dart
@@ -8,6 +8,7 @@ import 'package:fluffychat/pages/contacts_tab/empty_contacts_body.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/expansion_contact_list_tile.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/loading_contact_widget.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/no_contacts_found.dart';
+import 'package:fluffychat/pages/search/recent_item_widget.dart';
 import 'package:fluffychat/presentation/model/contact/get_presentation_contacts_empty.dart';
 import 'package:fluffychat/presentation/model/contact/get_presentation_contacts_failure.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
@@ -377,9 +378,22 @@ class _SliverRecentContacts extends StatelessWidget {
           return SliverExpandableList(
             title: L10n.of(context)!.recent,
             itemCount: recentContacts.length,
-            itemBuilder: (context, index) => _Contact(
-              contact: recentContacts[index].toPresentationContact(),
-              controller: controller,
+            itemBuilder: (context, index) => Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: ContactsTabViewStyle.padding,
+              ),
+              child: RecentItemWidget(
+                presentationSearch: recentContacts[index],
+                highlightKeyword: "",
+                client: controller.client,
+                key: Key('contact_recent_${recentContacts[index].id}'),
+                onTap: () => controller.onContactTap(
+                  contact: recentContacts[index].toPresentationContact(),
+                  context: context,
+                  path: 'rooms',
+                ),
+                avatarSize: ContactsTabViewStyle.avatarSize,
+              ),
             ),
           );
         },

--- a/lib/pages/contacts_tab/contacts_tab_view_style.dart
+++ b/lib/pages/contacts_tab/contacts_tab_view_style.dart
@@ -5,6 +5,7 @@ class ContactsTabViewStyle {
   static const double padding = 8.0;
   static const EdgeInsets loadingPadding = EdgeInsets.all(16);
   static const double loadingSpacer = 16;
+  static const double avatarSize = 48.0;
 
   static const searchItemsHoverRadius = BorderRadius.all(Radius.circular(12));
 }

--- a/lib/pages/search/recent_item_widget.dart
+++ b/lib/pages/search/recent_item_widget.dart
@@ -188,15 +188,12 @@ class _DirectChatInformation extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        SizedBox(
-          width: RecentItemStyle.avatarSize,
-          child: Avatar(
-            name: recentChatPresentationSearch.displayName,
-            mxContent: recentChatPresentationSearch.getAvatarUriByMatrixId(
-              client: client,
-            ),
-            size: avatarSize ?? RecentItemStyle.avatarSize,
+        Avatar(
+          name: recentChatPresentationSearch.displayName,
+          mxContent: recentChatPresentationSearch.getAvatarUriByMatrixId(
+            client: client,
           ),
+          size: avatarSize ?? RecentItemStyle.avatarSize,
         ),
         const SizedBox(width: 8),
         Flexible(

--- a/lib/pages/search/recent_item_widget.dart
+++ b/lib/pages/search/recent_item_widget.dart
@@ -17,6 +17,7 @@ class RecentItemWidget extends StatelessWidget {
   final String highlightKeyword;
   final Client client;
   final void Function()? onTap;
+  final double? avatarSize;
 
   const RecentItemWidget({
     required this.presentationSearch,
@@ -24,6 +25,7 @@ class RecentItemWidget extends StatelessWidget {
     this.onTap,
     super.key,
     required this.client,
+    this.avatarSize,
   });
 
   @override
@@ -53,6 +55,7 @@ class RecentItemWidget extends StatelessWidget {
         contactPresentationSearch:
             presentationSearch as ContactPresentationSearch,
         searchKeyword: highlightKeyword,
+        avatarSize: avatarSize,
       );
     } else {
       final recentChatPresentationSearch =
@@ -62,12 +65,14 @@ class RecentItemWidget extends StatelessWidget {
           client: client,
           recentChatPresentationSearch: recentChatPresentationSearch,
           searchKeyword: highlightKeyword,
+          avatarSize: avatarSize,
         );
       } else {
         return _DirectChatInformation(
           client: client,
           recentChatPresentationSearch: recentChatPresentationSearch,
           searchKeyword: highlightKeyword,
+          avatarSize: avatarSize,
         );
       }
     }
@@ -78,11 +83,13 @@ class _GroupChatInformation extends StatelessWidget {
   final RecentChatPresentationSearch recentChatPresentationSearch;
   final Client client;
   final String? searchKeyword;
+  final double? avatarSize;
 
   const _GroupChatInformation({
     required this.recentChatPresentationSearch,
     this.searchKeyword,
     required this.client,
+    this.avatarSize,
   });
 
   @override
@@ -99,7 +106,7 @@ class _GroupChatInformation extends StatelessWidget {
             mxContent: recentChatPresentationSearch.getAvatarUriByMatrixId(
               client: client,
             ),
-            size: RecentItemStyle.avatarSize,
+            size: avatarSize ?? RecentItemStyle.avatarSize,
           ),
         ),
         const SizedBox(width: 8),
@@ -167,11 +174,13 @@ class _DirectChatInformation extends StatelessWidget {
   final RecentChatPresentationSearch recentChatPresentationSearch;
   final Client client;
   final String? searchKeyword;
+  final double? avatarSize;
 
   const _DirectChatInformation({
     required this.recentChatPresentationSearch,
     this.searchKeyword,
     required this.client,
+    this.avatarSize,
   });
 
   @override
@@ -186,7 +195,7 @@ class _DirectChatInformation extends StatelessWidget {
             mxContent: recentChatPresentationSearch.getAvatarUriByMatrixId(
               client: client,
             ),
-            size: RecentItemStyle.avatarSize,
+            size: avatarSize ?? RecentItemStyle.avatarSize,
           ),
         ),
         const SizedBox(width: 8),
@@ -228,11 +237,13 @@ class _ContactInformation extends StatelessWidget {
   final ContactPresentationSearch contactPresentationSearch;
   final String? searchKeyword;
   final Client client;
+  final double? avatarSize;
 
   const _ContactInformation({
     required this.contactPresentationSearch,
     this.searchKeyword,
     required this.client,
+    this.avatarSize,
   });
 
   @override
@@ -246,7 +257,7 @@ class _ContactInformation extends StatelessWidget {
             return Avatar(
               mxContent: snapshot.data?.avatarUrl,
               name: contactPresentationSearch.displayName,
-              size: RecentItemStyle.avatarSize,
+              size: avatarSize ?? RecentItemStyle.avatarSize,
             );
           },
         ),

--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -124,29 +124,6 @@ mixin class ContactsViewControllerMixin {
     required MatrixLocalizations matrixLocalizations,
   }) {
     final keyword = _debouncer.value;
-    if (keyword.isValidMatrixId && keyword.startsWith("@")) {
-      if (presentationContactNotifier.isDisposed &&
-          presentationPhonebookContactNotifier.isDisposed) {
-        return;
-      }
-      presentationContactNotifier.value = Right(
-        PresentationExternalContactSuccess(
-          contact: PresentationContact(
-            matrixId: keyword,
-            displayName: keyword.substring(1),
-            type: ContactType.external,
-          ),
-        ),
-      );
-      presentationPhonebookContactNotifier.value =
-          const Right(GetPhonebookContactsInitial());
-      _refreshRecentContacts(
-        client: client,
-        keyword: keyword.isEmpty ? null : keyword,
-        matrixLocalizations: matrixLocalizations,
-      );
-      return;
-    }
     _refreshContacts(keyword);
     _refreshPhoneBookContacts(keyword);
     _refreshRecentContacts(
@@ -185,11 +162,23 @@ mixin class ContactsViewControllerMixin {
               .expand((contact) => contact.toPresentationContacts())
               .toList();
           if (filteredContacts.isEmpty) {
-            return Left(
-              GetPresentationContactsEmpty(
-                keyword: keyword,
-              ),
-            );
+            if (keyword.isValidMatrixId && keyword.startsWith("@")) {
+              return Right(
+                PresentationExternalContactSuccess(
+                  contact: PresentationContact(
+                    matrixId: keyword,
+                    displayName: keyword.substring(1),
+                    type: ContactType.external,
+                  ),
+                ),
+              );
+            } else {
+              return Left(
+                GetPresentationContactsEmpty(
+                  keyword: keyword,
+                ),
+              );
+            }
           } else {
             return Right(
               GetPresentationContactsSuccess(


### PR DESCRIPTION
## Ticket
- #1916 

## Root cause
- Right now, when search for exact Matrix ID, it will return contacts as an External contact.
- Right now, we use `Contact` widget for rendering recent contact. However, `Contact` widget will only fetch profile information if `status` is `active`. Because recent contact don't have `status` value, cannot fetch avatar.

## Solution
- Only return External contact if search for contact return `empty` and keyword is a Matrix ID
- Use `RecentItemWidget` instead.

## Pre-merge
- Need merge: #1911 
- Change base branch to `main`

## Resolved
- Web:

https://github.com/linagora/twake-on-matrix/assets/80142234/c1b81e02-cb79-44a2-b753-ffa2da4f25f7


- Android:

https://github.com/linagora/twake-on-matrix/assets/80142234/f5f28600-684b-48d6-8cbf-37465335b02c


- IOS: