### PR TITLE
TW-1920: hot-fix: wrong responsive when size of screen is small

### DIFF
--- a/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_builder.dart
+++ b/lib/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_builder.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat_adaptive_scaffold/chat_adaptive_scaffold_style.dart';
 import 'package:fluffychat/presentation/enum/chat/right_column_type_enum.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -71,7 +72,7 @@ class ChatAdaptiveScaffoldBuilderController
 
   @override
   Widget build(BuildContext context) {
-    final breakpoint = responsiveUtils.getMinDesktopWidth(context);
+    final breakpoint = getBreakpoint(context);
     return ValueListenableBuilder(
       valueListenable: rightColumnTypeNotifier,
       builder: (context, rightColumnType, body) {
@@ -144,5 +145,14 @@ class ChatAdaptiveScaffoldBuilderController
       },
       child: widget.bodyBuilder(this),
     );
+  }
+
+  double getBreakpoint(BuildContext context) {
+    var breakpoint = responsiveUtils.getMinDesktopWidth(context);
+    if (breakpoint < 0) {
+      breakpoint = ResponsiveUtils.minTabletWidth +
+          MessageStyle.messageBubbleDesktopMaxWidth;
+    }
+    return breakpoint;
   }
 }


### PR DESCRIPTION
## Ticket
**Related issue**
#1920

## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**
When the width of the screen is less than `bodyRadioWidth` (which is 472), the `getChatBodyRatio` will be large then 1, which will make the `getMinDesktopWidth` be negative. The negative number in breakpoint will make the responsive wrong when the width is less than 472.
## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**
The solution is when the width of screen is less than `bodyRadioWidth`, we will make the breakpoint for desktop to be constant like before. So that only when the screen is in tablet or desktop will apply the ratio calculated by new formular.
## Impact description
**If this is not a bug, please explain how the changes affect the project**

## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**
Change the width of the screen in web to see any problem about responsive.
## Pre-merge
**Does anything else need to be done before merging?**
No.
## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/linagora/twake-on-matrix/assets/43041967/c1a86fdb-55e5-468a-9bbc-315fc4044501



- Android:
- IOS: