### PR TITLE
TW-1766: fix 500,404 error in POST request when login

### DIFF
--- a/lib/pages/bootstrap/bootstrap_dialog.dart
+++ b/lib/pages/bootstrap/bootstrap_dialog.dart
@@ -15,8 +15,6 @@ import 'package:matrix/encryption/utils/bootstrap.dart';
 import 'package:matrix/matrix.dart';
 import 'package:share_plus/share_plus.dart';
 
-import '../key_verification/key_verification_dialog.dart';
-
 class BootstrapDialog extends StatefulWidget {
   final bool wipe;
   final Client client;
@@ -333,25 +331,26 @@ class BootstrapDialogState extends State<BootstrapDialog> {
                         const Expanded(child: Divider()),
                       ],
                     ),
-                    const SizedBox(height: 16),
-                    ElevatedButton.icon(
-                      icon: const Icon(Icons.cast_connected_outlined),
-                      label: Text(L10n.of(context)!.transferFromAnotherDevice),
-                      onPressed: _recoveryKeyInputLoading
-                          ? null
-                          : () async {
-                              final req = await TwakeDialog
-                                  .showFutureLoadingDialogFullScreen(
-                                future: () => widget.client
-                                    .userDeviceKeys[widget.client.userID!]!
-                                    .startVerification(),
-                              );
-                              if (req.error != null) return;
-                              await KeyVerificationDialog(request: req.result!)
-                                  .show(context);
-                              Navigator.of(context, rootNavigator: false).pop();
-                            },
-                    ),
+                    // TODO: TW-1766: temporary disable right now, because not supported yet
+                    // const SizedBox(height: 16),
+                    // ElevatedButton.icon(
+                    //   icon: const Icon(Icons.cast_connected_outlined),
+                    //   label: Text(L10n.of(context)!.transferFromAnotherDevice),
+                    //   onPressed: _recoveryKeyInputLoading
+                    //       ? null
+                    //       : () async {
+                    //           final req = await TwakeDialog
+                    //               .showFutureLoadingDialogFullScreen(
+                    //             future: () => widget.client
+                    //                 .userDeviceKeys[widget.client.userID!]!
+                    //                 .startVerification(),
+                    //           );
+                    //           if (req.error != null) return;
+                    //           await KeyVerificationDialog(request: req.result!)
+                    //               .show(context);
+                    //           Navigator.of(context, rootNavigator: false).pop();
+                    //         },
+                    // ),
                     const SizedBox(height: 16),
                     ElevatedButton.icon(
                       style: ElevatedButton.styleFrom(

--- a/lib/pages/bootstrap/tom_bootstrap_dialog.dart
+++ b/lib/pages/bootstrap/tom_bootstrap_dialog.dart
@@ -377,29 +377,29 @@ class TomBootstrapDialogState extends State<TomBootstrapDialog>
   }
 
   Future<void> _wipeRecoveryWord() async {
-    await _deleteRecoveryWordsInteractor.execute().then(
-          (either) => either.fold(
-            (failure) {
-              Logs().i(
-                'TomBootstrapDialogState::_wipeRecoveryWord(): wipe recoveryWords failed',
-              );
-              if (Matrix.of(context).twakeSupported) {
-                setState(
-                  () => _uploadRecoveryKeyState =
-                      UploadRecoveryKeyState.wipeRecoveryFailed,
-                );
-              } else {
-                setState(
-                  () =>
-                      _uploadRecoveryKeyState = UploadRecoveryKeyState.initial,
-                );
-              }
-            },
-            (success) => setState(
+    await _deleteRecoveryWordsInteractor.execute().then((either) {
+      _createBootstrap();
+      either.fold(
+        (failure) {
+          Logs().i(
+            'TomBootstrapDialogState::_wipeRecoveryWord(): wipe recoveryWords failed',
+          );
+          if (Matrix.of(context).twakeSupported) {
+            setState(
+              () => _uploadRecoveryKeyState =
+                  UploadRecoveryKeyState.wipeRecoveryFailed,
+            );
+          } else {
+            setState(
               () => _uploadRecoveryKeyState = UploadRecoveryKeyState.initial,
-            ),
-          ),
-        );
+            );
+          }
+        },
+        (success) => setState(() {
+          _uploadRecoveryKeyState = UploadRecoveryKeyState.initial;
+        }),
+      );
+    });
   }
 
   Future<void> _backUpInRecoveryVault(String? key) async {


### PR DESCRIPTION
## Ticket
**Related issue**
#1766 
## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**
We create the bootstrap dialog at the wrong time, so the state of bootstrap dialog always be `newSSSSKey`, that means, it will call to POST request to upload new key no matter what even when you have got the recovery key success before in tom server.
## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**
The solution is direct. We move the creating bootstrap dialog after we have loaded successfully the roomData and accountData from homeserver. This will make sure that the bootstrap state is correct and will not call to upload recoveryKey everytime we log in.
## Impact description
**If this is not a bug, please explain how the changes affect the project**
Can decrypt message with new account now.
## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**
1. Create a new account (make sure you follow every steps)
2. Create an encrypted chat
3. Send some messages in encrypted chat, then wait for the messages is sent.
4. Log out and log in again
5. You will see that the messages in encrypted chat has been decrypted.
## Pre-merge
**Does anything else need to be done before merging?**
no.
## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/linagora/twake-on-matrix/assets/43041967/9bde5adc-7433-431d-b508-c0776258fa99

- Android:
- IOS:


https://github.com/linagora/twake-on-matrix/assets/43041967/76f8ea95-a6fb-44d6-b0e6-b60e3e51a2e5

