### PR TITLE
TW-1887: improve notification permission request on web

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -17,6 +17,7 @@ import 'package:fluffychat/utils/room_status_extension.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/mixins/popup_menu_widget_style.dart';
 import 'package:fluffychat/widgets/mixins/twake_context_menu_mixin.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:fluffychat/utils/extension/global_key_extension.dart';
 import 'package:inview_notifier_list/inview_notifier_list.dart';
@@ -1971,6 +1972,16 @@ class ChatController extends State<Chat>
     }
   }
 
+  void requestNotificationPermission() {
+    if (kIsWeb) {
+      try {
+        html.Notification.requestPermission();
+      } catch (e) {
+        Logs().e("Error requesting notification permission: $e");
+      }
+    }
+  }
+
   @override
   void dispose() {
     unregisterPasteShortcutListeners();
@@ -2015,7 +2026,10 @@ class ChatController extends State<Chat>
   Widget build(BuildContext context) {
     return MouseRegion(
       onHover: (_) => _resetLocationPath(),
-      child: ChatView(this, key: widget.key),
+      child: GestureDetector(
+        onTap: requestNotificationPermission,
+        child: ChatView(this, key: widget.key),
+      ),
     );
   }
 }

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -17,7 +17,6 @@ import 'package:fluffychat/utils/room_status_extension.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/mixins/popup_menu_widget_style.dart';
 import 'package:fluffychat/widgets/mixins/twake_context_menu_mixin.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:fluffychat/utils/extension/global_key_extension.dart';
 import 'package:inview_notifier_list/inview_notifier_list.dart';
@@ -1973,7 +1972,7 @@ class ChatController extends State<Chat>
   }
 
   void requestNotificationPermission() {
-    if (kIsWeb) {
+    if (PlatformInfos.isWeb) {
       try {
         html.Notification.requestPermission();
       } catch (e) {

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -8,12 +8,14 @@ import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
 import 'package:go_router/go_router.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
+import 'package:universal_html/html.dart' as html hide File;
 
 enum ArchivedRoomAction { delete, rejoin }
 
@@ -42,6 +44,14 @@ class ChatListItem extends StatelessWidget with ChatListItemMixin {
   });
 
   void clickAction(BuildContext context) async {
+    if (kIsWeb) {
+      try {
+        html.Notification.requestPermission();
+      } catch (e) {
+        Logs().e("Error requesting notification permission: $e");
+      }
+    }
+
     if (onTap != null) return onTap!();
     switch (room.membership) {
       case Membership.ban:

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -6,9 +6,9 @@ import 'package:fluffychat/pages/chat_list/chat_list_item_subtitle.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_item_title.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -44,7 +44,7 @@ class ChatListItem extends StatelessWidget with ChatListItemMixin {
   });
 
   void clickAction(BuildContext context) async {
-    if (kIsWeb) {
+    if (PlatformInfos.isWeb) {
       try {
         html.Notification.requestPermission();
       } catch (e) {

--- a/lib/widgets/local_notifications_extension.dart
+++ b/lib/widgets/local_notifications_extension.dart
@@ -63,14 +63,22 @@ extension LocalNotificationsExtension on MatrixState {
           method: ThumbnailMethod.crop,
         );
     if (kIsWeb) {
-      _audioPlayer.play();
-      js.context.callMethod("handleNotifications", [
-        title,
-        body,
-        icon,
-        eventUpdate.roomID,
-        eventUpdate.eventId,
-      ]);
+      try {
+        await _audioPlayer.play();
+      } catch (e) {
+        Logs().e('Can not play notification sound on this browser');
+      }
+
+      try {
+        js.context.callMethod("handleNotifications", [
+          title,
+          body,
+          icon,
+          eventUpdate.roomID,
+        ]);
+      } catch (e) {
+        Logs().e('Can not display notification on this browser: $e');
+      }
     } else if (Platform.isLinux) {
       final appIconUrl = room.avatar?.getThumbnail(
         room.client,

--- a/lib/widgets/local_notifications_extension.dart
+++ b/lib/widgets/local_notifications_extension.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
-import 'package:fluffychat/presentation/extensions/event_update_extension.dart';
 import 'package:flutter/foundation.dart';
 
 import 'package:desktop_lifecycle/desktop_lifecycle.dart';

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -887,20 +887,6 @@ class MatrixState extends State<Matrix>
         .then((value) => AppConfig.experimentalVoip = value);
   }
 
-  // bool _hasClicked = false;
-
-  // Future<void> _handleFirstClick() async {
-  //   print("tez: _handleFirstClick() _hasClicked: $_hasClicked");
-  //   if (PlatformInfos.isWeb && !_hasClicked) {
-  //     // final res = html.Notification.requestPermission();
-  //     final res = await Permission.notification.request();
-  //     print("tez: Notification.requestPermission() res: $res");
-  //     setState(() {
-  //       _hasClicked = true;
-  //     });
-  //   }
-  // }
-
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -364,7 +364,6 @@ class MatrixState extends State<Matrix>
         currentClient.onUiaRequest.stream.listen(uiaRequestHandler);
     if (PlatformInfos.isWeb || PlatformInfos.isLinux) {
       currentClient.onSync.stream.first.then((s) {
-        html.Notification.requestPermission();
         onNotification[name] ??= currentClient.onEvent.stream
             .where(
               (e) =>
@@ -887,6 +886,20 @@ class MatrixState extends State<Matrix>
         .getItemBool(SettingKeys.experimentalVoip, AppConfig.experimentalVoip)
         .then((value) => AppConfig.experimentalVoip = value);
   }
+
+  // bool _hasClicked = false;
+
+  // Future<void> _handleFirstClick() async {
+  //   print("tez: _handleFirstClick() _hasClicked: $_hasClicked");
+  //   if (PlatformInfos.isWeb && !_hasClicked) {
+  //     // final res = html.Notification.requestPermission();
+  //     final res = await Permission.notification.request();
+  //     print("tez: Notification.requestPermission() res: $res");
+  //     setState(() {
+  //       _hasClicked = true;
+  //     });
+  //   }
+  // }
 
   @override
   void dispose() {


### PR DESCRIPTION
## Ticket
[**Related issue**](https://github.com/linagora/twake-on-matrix/issues/1887)

## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**
On web the notification permission was asked when the app starts. But for some browsers it should be on an action of the user. 
Also sound can't be played on some browsers causing exception before displaying the notification.

## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**
For sound a try catch has been added to avoid to be stuck.
The notification permission is asked when clicked on chat list item but still also when starting the app for browsers who can handle it.

But the notification display conditions changes from one browser to an other.

## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**
- [ ] Test on all browsers
- [ ] With the browser on foreground without being on the room where you will receive message
- [ ] With the browser on background

## Pre-merge
**Does anything else need to be done before merging?**
no

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
Opera (only sounds, notification display when the browser is closing.. will try to handle this later)

[ici.webm](https://github.com/user-attachments/assets/af14fefa-6850-4e70-acdb-c8fa79b96327)

Chromium

[Capture vidéo du 17-07-2024 08:52:16.webm](https://github.com/user-attachments/assets/71e25707-9d5f-4af5-a96e-34a59811ddbd)

Chrome

[Capture vidéo du 17-07-2024 08:50:16.webm](https://github.com/user-attachments/assets/de9fceb2-2f4a-4a9b-8245-2a9ca7d13c01)

Edge

[Capture vidéo du 17-07-2024 08:39:49.webm](https://github.com/user-attachments/assets/855fdad6-35c9-49b1-ac37-f82469ab0176)

Firefox

[Capture vidéo du 17-07-2024 08:37:15.webm](https://github.com/user-attachments/assets/ec5421eb-a4bd-4b3f-9a4f-a4ba743a27c5)

