### PR TITLE
TW-1901: crash app when open play video mobile

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -6,7 +6,9 @@ import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:matrix/matrix.dart';
+import 'package:video_thumbnail/video_thumbnail.dart';
 
 abstract class AppConfig {
   static ResponsiveUtils responsive = getIt.get<ResponsiveUtils>();
@@ -115,6 +117,8 @@ abstract class AppConfig {
   static const String iOSKeychainSharingAccount = 'app.twake.ios.chat.sessions';
   static const int maxFilesSendPerDialog = 6;
   static const bool supportMultipleAccountsInTheSameHomeserver = false;
+  static const imageCompressFormmat = CompressFormat.jpeg;
+  static const videoThumbnailFormat = ImageFormat.JPEG;
 
   static String? issueId;
 

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -575,7 +575,7 @@ extension SendFileExtension on Room {
         originalFile.filePath,
         targetPath,
         quality: AppConfig.thumbnailQuality,
-        format: CompressFormat.jpeg,
+        format: AppConfig.imageCompressFormmat,
       );
       if (result == null) return null;
       final size = await result.length();
@@ -591,7 +591,7 @@ extension SendFileExtension on Room {
       }
       uploadStreamController?.add(const Right(GenerateThumbnailSuccess()));
       return ImageFileInfo(
-        result.name,
+        '${result.name}.${AppConfig.imageCompressFormmat.name}',
         result.path,
         size,
         width: width,

--- a/lib/presentation/extensions/send_file_web_extension.dart
+++ b/lib/presentation/extensions/send_file_web_extension.dart
@@ -372,6 +372,7 @@ extension SendFileWebExtension on Room {
       final result = await FlutterImageCompress.compressWithList(
         originalFile.bytes!,
         quality: AppConfig.thumbnailQuality,
+        format: AppConfig.imageCompressFormmat,
       );
 
       final blurHash = await runBenchmarked(
@@ -385,7 +386,7 @@ extension SendFileWebExtension on Room {
 
       return MatrixImageFile(
         bytes: result,
-        name: originalFile.name,
+        name: '${originalFile.name}.${AppConfig.imageCompressFormmat.name}',
         mimeType: originalFile.mimeType,
         width: originalFile.width,
         height: originalFile.height,
@@ -425,9 +426,10 @@ extension SendFileWebExtension on Room {
         );
         throw exception;
       }
+
       final result = await VideoThumbnail.thumbnailData(
         video: url,
-        imageFormat: ImageFormat.JPEG,
+        imageFormat: AppConfig.videoThumbnailFormat,
         quality: AppConfig.thumbnailQuality,
       );
       final thumbnailBitmap = await convertUint8ListToBitmap(result);
@@ -442,7 +444,8 @@ extension SendFileWebExtension on Room {
 
       return MatrixImageFile(
         bytes: result,
-        name: originalFile.name,
+        name:
+            '${originalFile.name}.${AppConfig.videoThumbnailFormat.name.toLowerCase()}',
         mimeType: originalFile.mimeType,
         width: thumbnailBitmap?.width,
         height: thumbnailBitmap?.height,

--- a/lib/utils/matrix_sdk_extensions/download_file_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/download_file_extension.dart
@@ -276,6 +276,10 @@ extension DownloadFileExtension on Event {
       throw "getFileInfo: This event hasn't any attachment or thumbnail.";
     }
 
+    if (getThumbnail && thumbnailMimetype.startsWith('image') != true) {
+      throw ('getFileInfo: This event has a thumbnail but it is not an image.');
+    }
+
     final isFileEncrypted =
         getThumbnail ? isThumbnailEncrypted : isAttachmentEncrypted;
     if (isEncryptionDisabled(isFileEncrypted)) {

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -188,9 +188,7 @@ class _MxcImageState extends State<MxcImage> {
             getThumbnail: widget.isThumbnail,
           );
           if (fileInfo != null && fileInfo.filePath.isNotEmpty) {
-            setState(() {
-              filePath = fileInfo.filePath;
-            });
+            filePath = fileInfo.filePath;
             return;
           }
         }
@@ -203,10 +201,6 @@ class _MxcImageState extends State<MxcImage> {
         return;
       } catch (e) {
         Logs().e('MxcImage::Error while downloading image: $e');
-      } finally {
-        setState(() {
-          isLoadDone = true;
-        });
       }
       if (!mounted) return;
     }


### PR DESCRIPTION
## Ticket
**Related issue**
#1901 
## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**
Sometimes the thumbnail of video is not an image (this is due to testing or old video or maybe come from another platform), so that when display to screen, it will throw an exception during decode the image.
![image](https://github.com/user-attachments/assets/a0ccf45c-c271-4b88-8fd0-a73434cb40a7)

## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**
Now when create a thumbnail, we will add the extension which indicate its an image, and in the receiver side, if the thumbnail is not the image, we will throw an exception and handle the exception.
## Impact description
**If this is not a bug, please explain how the changes affect the project**

## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**
Try to send video and image in both normal chat and encrypted chat
## Pre-merge
**Does anything else need to be done before merging?**

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/user-attachments/assets/4bd42166-e03b-48d7-ac92-a90f0a24b870



- Android:

https://github.com/user-attachments/assets/d4427093-aab3-49d4-a367-aaae51554a59


- IOS:

https://github.com/user-attachments/assets/e204565f-4f22-4382-a240-364960769f3c


