### PR TITLE
Bump version to v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.6.1+2330] - 2024-07-25
+
+### Fixed
+
+- #1959 Spelling errors
+- #1966 Hotfix: can't get contact on web
+- #1976 Hotfix: prominent disclosure update
+- #1971 Fix navigation problem in forward pages
+- #1979 Crash app when open play video mobile
+- #1967 Support send multiple file in draft chat
+
 ## [2.6.0+2330] - 2024-07-18
 
 ### Fixed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.6.0+2330
+version: 2.6.1+2330
 
 environment:
   sdk: ">=3.1.3 <4.0.0"


### PR DESCRIPTION
## [2.6.1+2330] - 2024-07-25

### Fixed

- #1959 Spelling errors
- #1966 Hotfix: can't get contact on web
- #1976 Hotfix: prominent disclosure update
- #1971 Fix navigation problem in forward pages
- #1979 Crash app when open play video mobile
- #1967 Support send multiple file in draft chat