### PR TITLE
TW-1964: handle full matrix id on presentationContactNotifier fail

### DIFF
--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -236,17 +236,23 @@ mixin class ContactsViewControllerMixin {
         contactsManager.getContactsNotifier().value.fold(
       (failure) {
         if (failure is GetContactsFailure) {
-          return Left(
-            GetPresentationContactsFailure(
-              keyword: keyword,
+          return _handleSearchExternalContact(
+            keyword,
+            otherResult: Left(
+              GetPresentationContactsFailure(
+                keyword: keyword,
+              ),
             ),
           );
         }
 
         if (failure is GetContactsIsEmpty) {
-          return Left(
-            GetPresentationContactsEmpty(
-              keyword: keyword,
+          return _handleSearchExternalContact(
+            keyword,
+            otherResult: Left(
+              GetPresentationContactsEmpty(
+                keyword: keyword,
+              ),
             ),
           );
         }
@@ -296,17 +302,23 @@ mixin class ContactsViewControllerMixin {
         contactsManager.getPhonebookContactsNotifier().value.fold(
       (failure) {
         if (failure is GetPhonebookContactsFailure) {
-          return Left(
-            GetPresentationContactsFailure(
-              keyword: keyword,
+          return _handleSearchExternalContact(
+            keyword,
+            otherResult: Left(
+              GetPresentationContactsFailure(
+                keyword: keyword,
+              ),
             ),
           );
         }
 
         if (failure is GetPhonebookContactsIsEmpty) {
-          return Left(
-            GetPresentationContactsEmpty(
-              keyword: keyword,
+          return _handleSearchExternalContact(
+            keyword,
+            otherResult: Left(
+              GetPresentationContactsEmpty(
+                keyword: keyword,
+              ),
             ),
           );
         }
@@ -336,6 +348,25 @@ mixin class ContactsViewControllerMixin {
         return Right(success);
       },
     );
+  }
+
+  Either<Failure, Success> _handleSearchExternalContact(
+    String keyword, {
+    required Either<Failure, Success> otherResult,
+  }) {
+    if (keyword.isValidMatrixId && keyword.startsWith("@")) {
+      return Right(
+        PresentationExternalContactSuccess(
+          contact: PresentationContact(
+            matrixId: keyword,
+            displayName: keyword.substring(1),
+            type: ContactType.external,
+          ),
+        ),
+      );
+    } else {
+      return otherResult;
+    }
   }
 
   Future<void> _refreshRecentContacts({


### PR DESCRIPTION
## Ticket
**Related issue**
https://github.com/linagora/twake-on-matrix/issues/1964


## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**
The external search was not handled on presentationContactNotifier failure

## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**
handle this case

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
Chrome:

[Capture vidéo du 26-07-2024 14:42:10.webm](https://github.com/user-attachments/assets/216654e4-56d1-4010-b77f-cc822e371a2c)

[Capture vidéo du 26-07-2024 14:36:51.webm](https://github.com/user-attachments/assets/5231c6ac-0181-4e5d-bf32-49ee6ee7f168)


- Android:


https://github.com/user-attachments/assets/9ce18539-b5f2-48c0-80cc-25a31ce145e5



- IOS: