### PR TITLE
TW-1963: update search keyword matching

### DIFF
--- a/lib/domain/model/room/room_list_extension.dart
+++ b/lib/domain/model/room/room_list_extension.dart
@@ -13,11 +13,19 @@ extension RoomListExtension on List<Room> {
     )
         .map((room) => room.toRecentChatSearchModel(matrixLocalizations))
         .where(
-          (model) =>
-              model.displayName != null &&
-              model.displayName!.toLowerCase().contains(
-                    keyword.toLowerCase(),
-                  ),
+          (model) {
+            final matchedMatrixId = model.directChatMatrixID
+                    ?.toLowerCase()
+                    .contains(keyword.toLowerCase()) ??
+                false;
+
+            final matchedName = model.displayName
+                    ?.toLowerCase()
+                    .contains(keyword.toLowerCase()) ??
+                false;
+
+            return matchedName || matchedMatrixId;
+          },
         )
         .take(limit ?? length)
         .toList();

--- a/lib/domain/model/room/room_list_extension.dart
+++ b/lib/domain/model/room/room_list_extension.dart
@@ -3,6 +3,22 @@ import 'package:fluffychat/domain/model/search/recent_chat_model.dart';
 import 'package:matrix/matrix.dart';
 
 extension RoomListExtension on List<Room> {
+  bool _matchedMatrixId(RecentChatSearchModel model, String keyword) {
+    return model.directChatMatrixID
+            ?.toLowerCase()
+            .contains(keyword.toLowerCase()) ??
+        false;
+  }
+
+  bool _matchedName(RecentChatSearchModel model, String keyword) {
+    return model.displayName?.toLowerCase().contains(keyword.toLowerCase()) ??
+        false;
+  }
+
+  bool _matchedNameOrMatrixId(RecentChatSearchModel model, String keyword) {
+    return _matchedName(model, keyword) || _matchedMatrixId(model, keyword);
+  }
+
   List<RecentChatSearchModel> searchRecentChat({
     required MatrixLocalizations matrixLocalizations,
     required String keyword,
@@ -13,19 +29,7 @@ extension RoomListExtension on List<Room> {
     )
         .map((room) => room.toRecentChatSearchModel(matrixLocalizations))
         .where(
-          (model) {
-            final matchedMatrixId = model.directChatMatrixID
-                    ?.toLowerCase()
-                    .contains(keyword.toLowerCase()) ??
-                false;
-
-            final matchedName = model.displayName
-                    ?.toLowerCase()
-                    .contains(keyword.toLowerCase()) ??
-                false;
-
-            return matchedName || matchedMatrixId;
-          },
+          (model) => _matchedNameOrMatrixId(model, keyword),
         )
         .take(limit ?? length)
         .toList();

--- a/lib/pages/search/search_contacts_and_chats_controller.dart
+++ b/lib/pages/search/search_contacts_and_chats_controller.dart
@@ -96,13 +96,7 @@ class SearchContactsAndChatsController with SearchDebouncerMixin, SearchMixin {
         return false;
       }
 
-      final matchedName =
-          contact.displayName!.toLowerCase().contains(keyword.toLowerCase());
-
-      final matchedEmail =
-          contact.email!.toLowerCase().contains(keyword.toLowerCase());
-
-      return matchedName || matchedEmail;
+      return _doesMatchKeyword(contact, keyword);
     }).toList();
     _searchRecentChatInteractor
         .execute(
@@ -124,6 +118,23 @@ class SearchContactsAndChatsController with SearchDebouncerMixin, SearchMixin {
         );
       },
     );
+  }
+
+  bool _doesMatchKeyword(PresentationSearch recentChat, String keyword) {
+    final matchedMatrixId = recentChat.directChatMatrixID
+            ?.toLowerCase()
+            .contains(keyword.toLowerCase()) ??
+        false;
+
+    final matchedName =
+        recentChat.displayName?.toLowerCase().contains(keyword.toLowerCase()) ??
+            false;
+
+    final matchedEmail =
+        recentChat.email?.toLowerCase().contains(keyword.toLowerCase()) ??
+            false;
+
+    return matchedName || matchedEmail || matchedMatrixId;
   }
 
   void onSearchBarChanged(String keyword) {

--- a/lib/pages/search/search_contacts_and_chats_controller.dart
+++ b/lib/pages/search/search_contacts_and_chats_controller.dart
@@ -83,21 +83,8 @@ class SearchContactsAndChatsController with SearchDebouncerMixin, SearchMixin {
         .toList();
     final tomContactPresentationSearchMatched = tomPresentationSearchContacts
         .expand((contact) => contact.toPresentationSearch())
-        .where((contact) {
-      if (contact is! ContactPresentationSearch) {
-        return false;
-      }
-
-      if (contact.displayName == null) {
-        return false;
-      }
-
-      if (contact.email == null) {
-        return false;
-      }
-
-      return _doesMatchKeyword(contact, keyword);
-    }).toList();
+        .where((contact) => _doesMatchKeyword(contact, keyword))
+        .toList();
     _searchRecentChatInteractor
         .execute(
       keyword: keyword,
@@ -120,21 +107,43 @@ class SearchContactsAndChatsController with SearchDebouncerMixin, SearchMixin {
     );
   }
 
-  bool _doesMatchKeyword(PresentationSearch recentChat, String keyword) {
-    final matchedMatrixId = recentChat.directChatMatrixID
+  bool _matchedMatrixId(PresentationSearch contact, String keyword) {
+    return contact.directChatMatrixID
             ?.toLowerCase()
             .contains(keyword.toLowerCase()) ??
         false;
+  }
 
-    final matchedName =
-        recentChat.displayName?.toLowerCase().contains(keyword.toLowerCase()) ??
-            false;
+  bool _matchedName(PresentationSearch contact, String keyword) {
+    return contact.displayName?.toLowerCase().contains(keyword.toLowerCase()) ??
+        false;
+  }
 
-    final matchedEmail =
-        recentChat.email?.toLowerCase().contains(keyword.toLowerCase()) ??
-            false;
+  bool _matchedEmail(PresentationSearch contact, String keyword) {
+    return contact.email?.toLowerCase().contains(keyword.toLowerCase()) ??
+        false;
+  }
 
-    return matchedName || matchedEmail || matchedMatrixId;
+  bool _matchedContactInfo(PresentationSearch contact, String keyword) {
+    return _matchedName(contact, keyword) ||
+        _matchedEmail(contact, keyword) ||
+        _matchedMatrixId(contact, keyword);
+  }
+
+  bool _doesMatchKeyword(PresentationSearch contact, String keyword) {
+    if (contact is! ContactPresentationSearch) {
+      return false;
+    }
+
+    if (contact.displayName == null) {
+      return false;
+    }
+
+    if (contact.email == null) {
+      return false;
+    }
+
+    return _matchedContactInfo(contact, keyword);
   }
 
   void onSearchBarChanged(String keyword) {


### PR DESCRIPTION
## Ticket
**Related issue**
https://github.com/linagora/twake-on-matrix/issues/1963

## Need merge first

- #1982 

## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**
Search keywork did not include matrix id. Also the `!` without checking first if the thing is null or not throwed some errors which blocked the search.


## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**
Add matrix id matchers
Check if value is null, if it is return a boolean as default value.

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Chrome

[Capture vidéo du 25-07-2024 21:24:31.webm](https://github.com/user-attachments/assets/02b55b38-df68-49b9-8ff5-c0232ae7874c)

- Android:

https://github.com/user-attachments/assets/a96bd246-4005-4543-94fb-2e06200e61d0

- IOS: