### PR TITLE
TW-1980: Convert HEIC files to jpg file

### DIFF
--- a/lib/utils/manager/storage_directory_manager.dart
+++ b/lib/utils/manager/storage_directory_manager.dart
@@ -76,4 +76,15 @@ class StorageDirectoryManager {
         await StorageDirectoryManager.instance.getFileStoreDirectory();
     return '$fileStoreDirectory/$eventId/decrypted-$fileName';
   }
+
+  String convertFileExtension(String filename, String newExtension) {
+    final lastDotIndex = filename.lastIndexOf('.');
+
+    if (lastDotIndex == -1) {
+      return '$filename.$newExtension';
+    } else {
+      final nameWithoutExtension = filename.substring(0, lastDotIndex);
+      return '$nameWithoutExtension.$newExtension';
+    }
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1379,6 +1379,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.9"
+  heif_converter:
+    dependency: "direct main"
+    description:
+      name: heif_converter
+      sha256: "63ffc2a72026942de3fcb61450da197100759936085c8279aef35b995b3c1bb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   highlight:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -185,6 +185,7 @@ dependencies:
   gal: 2.3.0
   auto_size_text: 3.0.0
   flutter_avif: 2.4.1
+  heif_converter: 1.0.0
 
 dev_dependencies:
   build_runner: ^2.3.3


### PR DESCRIPTION
## Ticket
**Related issue**
#1980 
## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**
HEIC, HEIF image format can't display in web platform
## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**
We have to convert HEIC, HEIF format to common image format like JPG when send images from iOS, so that it can be displayed in other platform. 

- `https://pub.dev/packages/image_editor_plus` has an output is raw data not file, so i don't use it, it may freeze the app
## Impact description
**If this is not a bug, please explain how the changes affect the project**

## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**
Try sending HEIC, HEIF files from iOS device, then see that its displayed well in other platforms or not
## Pre-merge
**Does anything else need to be done before merging?**

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/user-attachments/assets/1998e708-dbe0-4c91-ab27-9a613ff81ba7


https://github.com/user-attachments/assets/e42c32d0-075f-47a3-b828-54290686d20e

- Android:

https://github.com/user-attachments/assets/58973c9d-81ec-485d-8f97-e2038abb514a


- IOS: