### PR TITLE
TW-1968: Break UI when search with keyword

### DIFF
--- a/lib/utils/string_extension.dart
+++ b/lib/utils/string_extension.dart
@@ -251,10 +251,13 @@ extension StringCasingExtension on String {
       ];
     }
 
+    // Escape special characters in the highlightText
+    final escapedHighlightText = RegExp.escape(highlightText);
+
     // Split the text into parts by the search word and create a TextSpan for
     // each part. The search word is not case sensitive.
     final List<TextSpan> spans = splitMapJoinToList<TextSpan>(
-      RegExp(highlightText, caseSensitive: false),
+      RegExp(escapedHighlightText, caseSensitive: false),
       onMatch: (Match match) {
         return TextSpan(
           text: match.group(0),

--- a/test/utils/string_extension_test.dart
+++ b/test/utils/string_extension_test.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/utils/string_extension.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -375,6 +376,227 @@ void main() {
         'NOT CONTAINS innerText\n'
         'THEN return an empty string\n', () {
       expect('<a href="https://example.com"></a>'.extractInnerText(), isEmpty);
+    });
+  });
+
+  group('buildHighlightTextSpans tests', () {
+    test(
+        'buildHighlightTextSpans handles special * and \\ characters in highlightText',
+        () {
+      const text =
+          'This is a test string with special characters like * and \\.';
+      const highlightText = '* and \\';
+      final expectedSpans = [
+        const TextSpan(
+          text: 'This is a test string with special characters like ',
+          style: TextStyle(color: Colors.black),
+        ),
+        const TextSpan(text: '* and \\', style: TextStyle(color: Colors.red)),
+        const TextSpan(text: '.', style: TextStyle(color: Colors.black)),
+      ];
+
+      final result = text.buildHighlightTextSpans(
+        highlightText,
+        style: const TextStyle(color: Colors.black),
+        highlightStyle: const TextStyle(color: Colors.red),
+      );
+
+      expect(result.length, expectedSpans.length);
+
+      for (int i = 0; i < result.length; i++) {
+        expect(result[i].text, expectedSpans[i].text);
+        expect(result[i].style, expectedSpans[i].style);
+      }
+    });
+
+    test(
+        'buildHighlightTextSpans handles special \\ characters in highlightText',
+        () {
+      const text = 'This is a test string with special characters like 123\\.';
+      const highlightText = '123';
+      final expectedSpans = [
+        const TextSpan(
+          text: 'This is a test string with special characters like ',
+          style: TextStyle(color: Colors.black),
+        ),
+        const TextSpan(text: '123', style: TextStyle(color: Colors.red)),
+        const TextSpan(text: '\\.', style: TextStyle(color: Colors.black)),
+      ];
+
+      final result = text.buildHighlightTextSpans(
+        highlightText,
+        style: const TextStyle(color: Colors.black),
+        highlightStyle: const TextStyle(color: Colors.red),
+      );
+
+      expect(result.length, expectedSpans.length);
+
+      for (int i = 0; i < result.length; i++) {
+        expect(result[i].text, expectedSpans[i].text);
+        expect(result[i].style, expectedSpans[i].style);
+      }
+    });
+
+    test('buildHighlightTextSpans handles special characters in highlightText',
+        () {
+      const text = 'This is a test string with special characters like 123.';
+      const highlightText = '123';
+      final expectedSpans = [
+        const TextSpan(
+          text: 'This is a test string with special characters like ',
+          style: TextStyle(color: Colors.black),
+        ),
+        const TextSpan(text: '123', style: TextStyle(color: Colors.red)),
+        const TextSpan(text: '.', style: TextStyle(color: Colors.black)),
+      ];
+
+      final result = text.buildHighlightTextSpans(
+        highlightText,
+        style: const TextStyle(color: Colors.black),
+        highlightStyle: const TextStyle(color: Colors.red),
+      );
+
+      expect(result.length, expectedSpans.length);
+
+      for (int i = 0; i < result.length; i++) {
+        expect(result[i].text, expectedSpans[i].text);
+        expect(result[i].style, expectedSpans[i].style);
+      }
+    });
+
+    test('buildHighlightTextSpans handles special characters in highlightText',
+        () {
+      const text = 'This is a test string with special characters like 123.';
+      const highlightText = '123.';
+      final expectedSpans = [
+        const TextSpan(
+          text: 'This is a test string with special characters like ',
+          style: TextStyle(color: Colors.black),
+        ),
+        const TextSpan(text: '123.', style: TextStyle(color: Colors.red)),
+        const TextSpan(text: '', style: TextStyle(color: Colors.black)),
+      ];
+
+      final result = text.buildHighlightTextSpans(
+        highlightText,
+        style: const TextStyle(color: Colors.black),
+        highlightStyle: const TextStyle(color: Colors.red),
+      );
+
+      expect(result.length, expectedSpans.length);
+
+      for (int i = 0; i < result.length; i++) {
+        expect(result[i].text, expectedSpans[i].text);
+        expect(result[i].style, expectedSpans[i].style);
+      }
+    });
+
+    test('buildHighlightTextSpans handles special characters in highlightText',
+        () {
+      const text = 'This is a test string with special characters like 123\\';
+      const highlightText = '123\\';
+      final expectedSpans = [
+        const TextSpan(
+          text: 'This is a test string with special characters like ',
+          style: TextStyle(color: Colors.black),
+        ),
+        const TextSpan(text: '123\\', style: TextStyle(color: Colors.red)),
+        const TextSpan(text: '', style: TextStyle(color: Colors.black)),
+      ];
+
+      final result = text.buildHighlightTextSpans(
+        highlightText,
+        style: const TextStyle(color: Colors.black),
+        highlightStyle: const TextStyle(color: Colors.red),
+      );
+
+      expect(result.length, expectedSpans.length);
+
+      for (int i = 0; i < result.length; i++) {
+        expect(result[i].text, expectedSpans[i].text);
+        expect(result[i].style, expectedSpans[i].style);
+      }
+    });
+
+    test('buildHighlightTextSpans handles special characters in highlightText',
+        () {
+      const text = 'This is a test string with special characters like 123@@++';
+      const highlightText = '123@@++';
+      final expectedSpans = [
+        const TextSpan(
+          text: 'This is a test string with special characters like ',
+          style: TextStyle(color: Colors.black),
+        ),
+        const TextSpan(text: '123@@++', style: TextStyle(color: Colors.red)),
+        const TextSpan(text: '', style: TextStyle(color: Colors.black)),
+      ];
+
+      final result = text.buildHighlightTextSpans(
+        highlightText,
+        style: const TextStyle(color: Colors.black),
+        highlightStyle: const TextStyle(color: Colors.red),
+      );
+
+      expect(result.length, expectedSpans.length);
+
+      for (int i = 0; i < result.length; i++) {
+        expect(result[i].text, expectedSpans[i].text);
+        expect(result[i].style, expectedSpans[i].style);
+      }
+    });
+
+    test('buildHighlightTextSpans handles special characters in highlightText',
+        () {
+      const text = 'This is a test string with special characters like .123';
+      const highlightText = '.123';
+      final expectedSpans = [
+        const TextSpan(
+          text: 'This is a test string with special characters like ',
+          style: TextStyle(color: Colors.black),
+        ),
+        const TextSpan(text: '.123', style: TextStyle(color: Colors.red)),
+        const TextSpan(text: '', style: TextStyle(color: Colors.black)),
+      ];
+
+      final result = text.buildHighlightTextSpans(
+        highlightText,
+        style: const TextStyle(color: Colors.black),
+        highlightStyle: const TextStyle(color: Colors.red),
+      );
+
+      expect(result.length, expectedSpans.length);
+
+      for (int i = 0; i < result.length; i++) {
+        expect(result[i].text, expectedSpans[i].text);
+        expect(result[i].style, expectedSpans[i].style);
+      }
+    });
+
+    test('buildHighlightTextSpans handles special characters in highlightText',
+        () {
+      const text = 'This is a test string with special characters like \\123';
+      const highlightText = '\\123';
+      final expectedSpans = [
+        const TextSpan(
+          text: 'This is a test string with special characters like ',
+          style: TextStyle(color: Colors.black),
+        ),
+        const TextSpan(text: '\\123', style: TextStyle(color: Colors.red)),
+        const TextSpan(text: '', style: TextStyle(color: Colors.black)),
+      ];
+
+      final result = text.buildHighlightTextSpans(
+        highlightText,
+        style: const TextStyle(color: Colors.black),
+        highlightStyle: const TextStyle(color: Colors.red),
+      );
+
+      expect(result.length, expectedSpans.length);
+
+      for (int i = 0; i < result.length; i++) {
+        expect(result[i].text, expectedSpans[i].text);
+        expect(result[i].style, expectedSpans[i].style);
+      }
     });
   });
 }


### PR DESCRIPTION
### Ticket
- #1968 

### Solution
- Create a test case to verify that the `buildHighlightTextSpans` method correctly handles special characters in the `highlightText`.
- Ensure the test case checks for proper escaping and highlighting of the text.

## Resolved
- Web:
- IOS:

https://github.com/user-attachments/assets/22e75d69-6c1b-4bbe-8f82-d85ae37c4cef

