### PR TITLE
TW-1974: Fix cannot jump to reply

### DIFF
--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -128,18 +128,11 @@ class ChatEventList extends StatelessWidget {
                       );
                     }
                     if (controller.timeline!.canRequestHistory) {
-                      return Builder(
-                        builder: (context) {
-                          WidgetsBinding.instance.addPostFrameCallback(
-                            (_) => controller.requestHistory(),
-                          );
-                          return Center(
-                            child: IconButton(
-                              onPressed: controller.requestHistory,
-                              icon: const Icon(Icons.refresh_outlined),
-                            ),
-                          );
-                        },
+                      return Center(
+                        child: IconButton(
+                          onPressed: controller.requestHistory,
+                          icon: const Icon(Icons.refresh_outlined),
+                        ),
                       );
                     }
                     return const SizedBox.shrink();

--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -174,7 +174,10 @@ class ChatEventList extends StatelessWidget {
                             onSelect: controller.onSelectMessage,
                             selectMode: controller.selectMode,
                             scrollToEventId: (String eventId) =>
-                                controller.scrollToEventId(eventId),
+                                controller.scrollToEventId(
+                              eventId,
+                              highlight: true,
+                            ),
                             selected: controller.selectedEvents
                                 .any((e) => e.eventId == event.eventId),
                             timeline: controller.timeline!,

--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -128,11 +128,18 @@ class ChatEventList extends StatelessWidget {
                       );
                     }
                     if (controller.timeline!.canRequestHistory) {
-                      return Center(
-                        child: IconButton(
-                          onPressed: controller.requestHistory,
-                          icon: const Icon(Icons.refresh_outlined),
-                        ),
+                      return Builder(
+                        builder: (context) {
+                          WidgetsBinding.instance.addPostFrameCallback(
+                            (_) => controller.requestHistory(),
+                          );
+                          return Center(
+                            child: IconButton(
+                              onPressed: controller.requestHistory,
+                              icon: const Icon(Icons.refresh_outlined),
+                            ),
+                          );
+                        },
                       );
                     }
                     return const SizedBox.shrink();

--- a/lib/pages/chat/chat_pinned_events/pinned_events_controller.dart
+++ b/lib/pages/chat/chat_pinned_events/pinned_events_controller.dart
@@ -79,21 +79,27 @@ class PinnedEventsController {
     void Function(String)? scrollToEventId,
   }) async {
     final nextIndex = _nextIndexOfPinnedMessage(pinnedEvents);
-    final event = pinnedEvents[nextIndex];
+    final nextEvent = pinnedEvents[nextIndex];
+    final currentEvent = currentPinnedEventNotifier.value;
     Logs().d(
-      "PinnedEventsController()::jumpToPinnedMessage(): eventID: ${event?.eventId}",
+      "PinnedEventsController()::jumpToPinnedMessage(): eventID: ${nextEvent?.eventId}",
     );
-    if (event != null) {
-      currentPinnedEventNotifier.value = event;
+    if (currentEvent != null) {
+      currentPinnedEventNotifier.value = nextEvent;
       if (scrollToEventId != null) {
-        scrollToEventId.call(event.eventId);
+        scrollToEventId.call(currentEvent.eventId);
       }
     }
   }
 
   int currentIndexOfPinnedMessage(List<Event?> pinnedEvents) {
     final index = pinnedEvents.indexWhere(
-      (event) => event?.eventId == currentPinnedEventNotifier.value?.eventId,
+      (event) {
+        Logs().d(
+          "PinnedEventsController()::currentIndexOfPinnedMessage(): ${currentPinnedEventNotifier.value?.eventId}",
+        );
+        return event?.eventId == currentPinnedEventNotifier.value?.eventId;
+      },
     );
     if (index < 0) {
       currentPinnedEventNotifier.value = pinnedEvents.first;


### PR DESCRIPTION
### Ticket
- #1974 

## Resolved

- For load more:
   - I updated logic to load more in chat. When user scrolls to the last element of the list message, we're display a refresh icon and call back to request history. 

- Updated the highlight message when click to reply message

- Remove old logic ( `requestHistory` ) of listen scroll in chat
- Web:

https://github.com/user-attachments/assets/6c606b29-4eea-47ea-b273-d3d186b476ba


- IOS:

https://github.com/user-attachments/assets/5cf5494b-c760-437d-9038-1fb3b94e389f

