### PR TITLE
TW-1994: Fix load more for chat search

### DIFF
--- a/lib/pages/search/server_search_controller.dart
+++ b/lib/pages/search/server_search_controller.dart
@@ -89,7 +89,25 @@ class ServerSearchController with SearchDebouncerMixin {
         if (success is ServerSearchChatSuccess) {
           updateNextBatch(success.nextBatch);
           if (success.results?.isEmpty == true) {
-            searchResultsNotifier.value = PresentationServerSideEmptySearch();
+            if (isLoadingMoreNotifier.value) {
+              searchResultsNotifier.value = PresentationServerSideSearch(
+                searchResults: [
+                  if (searchResultsNotifier.value
+                      is PresentationServerSideSearch)
+                    ...(searchResultsNotifier.value
+                            as PresentationServerSideSearch)
+                        .searchResults,
+                  ...success.results ?? <Result>[],
+                ]
+                    .where(
+                      (result) =>
+                          result.isDisplayableResult(context: currentContext),
+                    )
+                    .toList(),
+              );
+            } else {
+              searchResultsNotifier.value = PresentationServerSideEmptySearch();
+            }
           } else {
             searchResultsNotifier.value = PresentationServerSideSearch(
               searchResults: [


### PR DESCRIPTION
## Ticket
- #1994 

## Root cause

- When using load more for chat search, missing the condition.

## Resolved
- Web:

https://github.com/user-attachments/assets/056ecd6d-b848-4e4a-ad6c-0373a5ba8656


https://github.com/user-attachments/assets/e8648103-6157-4d0d-bfd2-335880b2082e


- IOS:

https://github.com/user-attachments/assets/20e74586-8e84-4d6c-925f-6415f0abab0c

