### PR TITLE
Tw 2001: No previews for video

### DIFF
--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -429,7 +429,9 @@ extension SendFileExtension on Room {
       await File('${tempDir.path}/$fileName').create();
 
   String _generateThumbnailFileName(
-          String formattedDateTime, FileInfo fileInfo,) =>
+    String formattedDateTime,
+    FileInfo fileInfo,
+  ) =>
       '$formattedDateTime${fileInfo.fileName}.${AppConfig.imageCompressFormmat.name}';
 
   Future<ImageFileInfo> convertHeicToJpgImage(ImageFileInfo fileInfo) async {

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -25,7 +25,6 @@ import 'package:image/image.dart' as img;
 import 'package:blurhash_dart/blurhash_dart.dart';
 import 'package:flutter/foundation.dart';
 import 'package:matrix/matrix.dart';
-import 'package:mime/mime.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:video_thumbnail/video_thumbnail.dart';
@@ -706,11 +705,9 @@ extension SendFileExtension on Room {
     }
     Logs().d('Video thumbnail generated', tempThumbnailFile.path);
     uploadStreamController?.add(const Right(GenerateThumbnailSuccess()));
-    final newFileName = '${tempThumbnailFile.path.split("/").last}.jpg';
     final newThumbnail = ImageFileInfo(
-      newFileName,
+      tempThumbnailFile.path.split('/').last,
       tempThumbnailFile.path,
-      customMimeType: lookupMimeType(newFileName) ?? 'image/jpeg',
       fileSize,
       width: width,
       height: height,

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -25,6 +25,7 @@ import 'package:image/image.dart' as img;
 import 'package:blurhash_dart/blurhash_dart.dart';
 import 'package:flutter/foundation.dart';
 import 'package:matrix/matrix.dart';
+import 'package:mime/mime.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:video_thumbnail/video_thumbnail.dart';
@@ -628,10 +629,13 @@ extension SendFileExtension on Room {
         height = imageDimension.height.toInt();
       }
       uploadStreamController?.add(const Right(GenerateThumbnailSuccess()));
+      final newFileName =
+          '${result.name}.${AppConfig.imageCompressFormmat.name}';
       return ImageFileInfo(
-        '${result.name}.${AppConfig.imageCompressFormmat.name}',
+        newFileName,
         result.path,
         size,
+        customMimeType: lookupMimeType(newFileName) ?? 'image/jpeg',
         width: width,
         height: height,
       );
@@ -706,9 +710,11 @@ extension SendFileExtension on Room {
     }
     Logs().d('Video thumbnail generated', tempThumbnailFile.path);
     uploadStreamController?.add(const Right(GenerateThumbnailSuccess()));
+    final newFileName = '${tempThumbnailFile.path.split("/").last}.jpg';
     final newThumbnail = ImageFileInfo(
-      tempThumbnailFile.path.split("/").last,
+      newFileName,
       tempThumbnailFile.path,
+      customMimeType: lookupMimeType(newFileName) ?? 'image/jpeg',
       fileSize,
       width: width,
       height: height,

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -94,7 +94,7 @@ extension SendFileExtension on Room {
 
       final formattedDateTime = DateTime.now().getFormattedCurrentDateTime();
       final fileName = _generateThumbnailFileName(formattedDateTime, fileInfo);
-      final targetPath = await _getTargetParh(tempDir, fileName);
+      final targetPath = await _createThumbnailFile(tempDir, fileName);
       await _generateThumbnail(
         fileInfo as ImageFileInfo,
         targetPath: targetPath.path,
@@ -425,7 +425,7 @@ extension SendFileExtension on Room {
     return eventId;
   }
 
-  Future<File> _getTargetParh(Directory tempDir, String fileName) async =>
+  Future<File> _createThumbnailFile(Directory tempDir, String fileName) async =>
       await File('${tempDir.path}/$fileName').create();
 
   String _generateThumbnailFileName(

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -93,9 +93,8 @@ extension SendFileExtension on Room {
       }
 
       final formattedDateTime = DateTime.now().getFormattedCurrentDateTime();
-      final fileName =
-          '$formattedDateTime${fileInfo.fileName}.${AppConfig.imageCompressFormmat.name}';
-      final targetPath = await File('${tempDir.path}/$fileName').create();
+      final fileName = _generateThumbnailFileName(formattedDateTime, fileInfo);
+      final targetPath = await _getTargetParh(tempDir, fileName);
       await _generateThumbnail(
         fileInfo as ImageFileInfo,
         targetPath: targetPath.path,
@@ -426,6 +425,13 @@ extension SendFileExtension on Room {
     return eventId;
   }
 
+  Future<File> _getTargetParh(Directory tempDir, String fileName) async =>
+      await File('${tempDir.path}/$fileName').create();
+
+  String _generateThumbnailFileName(
+          String formattedDateTime, FileInfo fileInfo,) =>
+      '$formattedDateTime${fileInfo.fileName}.${AppConfig.imageCompressFormmat.name}';
+
   Future<ImageFileInfo> convertHeicToJpgImage(ImageFileInfo fileInfo) async {
     final convertedFilePath =
         StorageDirectoryManager.instance.convertFileExtension(
@@ -706,7 +712,7 @@ extension SendFileExtension on Room {
     Logs().d('Video thumbnail generated', tempThumbnailFile.path);
     uploadStreamController?.add(const Right(GenerateThumbnailSuccess()));
     final newThumbnail = ImageFileInfo(
-      tempThumbnailFile.path.split('/').last,
+      tempThumbnailFile.path.split("/").last,
       tempThumbnailFile.path,
       fileSize,
       width: width,

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -94,17 +94,16 @@ extension SendFileExtension on Room {
       }
 
       final formattedDateTime = DateTime.now().getFormattedCurrentDateTime();
-      final targetPath =
-          await File('${tempDir.path}/$formattedDateTime${fileInfo.fileName}')
-              .create();
-      fileInfo = fileInfo as ImageFileInfo;
+      final fileName =
+          '$formattedDateTime${fileInfo.fileName}.${AppConfig.imageCompressFormmat.name}';
+      final targetPath = await File('${tempDir.path}/$fileName').create();
       await _generateThumbnail(
-        fileInfo,
+        fileInfo as ImageFileInfo,
         targetPath: targetPath.path,
         uploadStreamController: uploadStreamController,
       );
       thumbnail = ImageFileInfo(
-        fileInfo.fileName,
+        fileName,
         targetPath.path,
         await targetPath.length(),
         width: fileInfo.width,
@@ -629,13 +628,10 @@ extension SendFileExtension on Room {
         height = imageDimension.height.toInt();
       }
       uploadStreamController?.add(const Right(GenerateThumbnailSuccess()));
-      final newFileName =
-          '${result.name}.${AppConfig.imageCompressFormmat.name}';
       return ImageFileInfo(
-        newFileName,
+        result.name,
         result.path,
         size,
-        customMimeType: lookupMimeType(newFileName) ?? 'image/jpeg',
         width: width,
         height: height,
       );

--- a/lib/presentation/extensions/send_file_web_extension.dart
+++ b/lib/presentation/extensions/send_file_web_extension.dart
@@ -443,8 +443,7 @@ extension SendFileWebExtension on Room {
         const Right(GenerateThumbnailSuccess()),
       );
 
-      final thumbnailFileName =
-          '${originalFile.name}.${AppConfig.videoThumbnailFormat.name.toLowerCase()}';
+      final thumbnailFileName = _getVideoThumbnailFileName(originalFile);
 
       return MatrixImageFile(
         bytes: result,
@@ -466,6 +465,9 @@ extension SendFileWebExtension on Room {
       return null;
     }
   }
+
+  String _getVideoThumbnailFileName(MatrixVideoFile originalFile) =>
+      '${originalFile.name}.${AppConfig.videoThumbnailFormat.name.toLowerCase()}';
 
   Future<int?> _getVideoDuration(
     MatrixVideoFile originalFile,

--- a/lib/presentation/extensions/send_file_web_extension.dart
+++ b/lib/presentation/extensions/send_file_web_extension.dart
@@ -110,10 +110,7 @@ extension SendFileWebExtension on Room {
               .unsigned![fileSendingStatusKey] =
           FileSendingStatus.generatingThumbnail.name;
       await handleImageFakeSync(fakeImageEvent);
-      thumbnail ??= await generateVideoThumbnail(
-        file,
-        uploadStreamController: uploadStreamController,
-      );
+      thumbnail ??= await generateVideoThumbnail(file);
     }
 
     EncryptedFile? encryptedFile;

--- a/lib/presentation/extensions/send_file_web_extension.dart
+++ b/lib/presentation/extensions/send_file_web_extension.dart
@@ -169,7 +169,7 @@ extension SendFileWebExtension on Room {
             : null;
         if (uploadThumbnail != null && uploadThumbnail.bytes != null) {
           final uploadThumbnailResponse = await mediaApi.uploadFileWeb(
-            file: file,
+            file: uploadThumbnail,
             cancelToken: cancelToken,
             onSendProgress: (receive, total) {
               uploadStreamController?.add(


### PR DESCRIPTION
## Ticket
#2001 
## Root cause
- We accidentally upload the original file instead of thumbnail file
- We do not use correct file mimeType for thumbnail
## Solution
- Upload original file -> thumbnail file
- add mimeType for thumbnail when sending video

## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**
- Send video, image in multiple platform to see if have thumbnail or not
## Resolved
**Attach screenshots or videos demonstrating the changes**
- Android:

https://github.com/user-attachments/assets/2bb4eded-8918-451a-b559-45113884a9f0


- Web:

https://github.com/user-attachments/assets/d119b838-5c06-4ed0-828a-748a7c856334


- IOS: