### PR TITLE
TW-1996-removed-activated-status-in-accounts-tab

### DIFF
--- a/lib/pages/new_private_chat/widget/contact_status_widget.dart
+++ b/lib/pages/new_private_chat/widget/contact_status_widget.dart
@@ -24,8 +24,7 @@ class ContactStatusWidget extends StatelessWidget {
         children: [
           SvgPicture.asset(
             ImagePaths.icStatus,
-            // ignore: deprecated_member_use
-            color: inactiveColor,
+            colorFilter: ColorFilter.mode(inactiveColor!, BlendMode.srcIn),
           ),
           Text(
             " ${L10n.of(context)!.inactive}",

--- a/lib/pages/new_private_chat/widget/contact_status_widget.dart
+++ b/lib/pages/new_private_chat/widget/contact_status_widget.dart
@@ -17,23 +17,26 @@ class ContactStatusWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          SvgPicture.asset(
-            ImagePaths.icStatus,
-            colorFilter: ColorFilter.mode(inactiveColor!, BlendMode.srcIn),
-          ),
-          Text(
-            " ${L10n.of(context)!.inactive}",
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: inactiveColor,
+    return status == ContactStatus.inactive
+        ? Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                SvgPicture.asset(
+                  ImagePaths.icStatus,
+                  colorFilter:
+                      ColorFilter.mode(inactiveColor!, BlendMode.srcIn),
                 ),
-          ),
-        ],
-      ),
-    );
+                Text(
+                  " ${L10n.of(context)!.inactive}",
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: inactiveColor,
+                      ),
+                ),
+              ],
+            ),
+          )
+        : const SizedBox.shrink();
   }
 }

--- a/lib/pages/new_private_chat/widget/contact_status_widget.dart
+++ b/lib/pages/new_private_chat/widget/contact_status_widget.dart
@@ -13,7 +13,6 @@ class ContactStatusWidget extends StatelessWidget {
     required this.status,
   });
 
-  final Color? activeColor = LinagoraRefColors.material().secondary[40];
   final Color? inactiveColor = LinagoraRefColors.material().neutral[60];
 
   @override
@@ -26,21 +25,14 @@ class ContactStatusWidget extends StatelessWidget {
           SvgPicture.asset(
             ImagePaths.icStatus,
             // ignore: deprecated_member_use
-            color: status == ContactStatus.active ? activeColor : inactiveColor,
+            color: inactiveColor,
           ),
-          status == ContactStatus.active
-              ? Text(
-                  " ${L10n.of(context)!.online}",
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: activeColor,
-                      ),
-                )
-              : Text(
-                  " ${L10n.of(context)!.inactive}",
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: inactiveColor,
-                      ),
+          Text(
+            " ${L10n.of(context)!.inactive}",
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: inactiveColor,
                 ),
+          ),
         ],
       ),
     );

--- a/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
@@ -85,7 +85,8 @@ class ExpansionContactListTile extends StatelessWidget {
                             ),
                           ],
                           const SizedBox(width: 8.0),
-                          if (contact.status == ContactStatus.inactive)
+                          if (contact.status != null &&
+                              contact.status == ContactStatus.inactive)
                             ContactStatusWidget(
                               status: contact.status!,
                             ),

--- a/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
@@ -85,7 +85,7 @@ class ExpansionContactListTile extends StatelessWidget {
                             ),
                           ],
                           const SizedBox(width: 8.0),
-                          if (contact.status != null)
+                          if (contact.status == ContactStatus.inactive)
                             ContactStatusWidget(
                               status: contact.status!,
                             ),

--- a/test/pages/new_private_chat/widget/contact_status_widget_test.dart
+++ b/test/pages/new_private_chat/widget/contact_status_widget_test.dart
@@ -1,0 +1,47 @@
+import 'package:fluffychat/pages/new_private_chat/widget/contact_status_widget.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:fluffychat/domain/model/contact/contact_status.dart';
+import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
+
+void main() {
+  group('ContactStatusWidget', () {
+    testWidgets('renders correctly for inactive status',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          home: Scaffold(
+            body: ContactStatusWidget(status: ContactStatus.inactive),
+          ),
+        ),
+      );
+
+      expect(find.byType(SvgPicture), findsOneWidget);
+
+      expect(find.byType(Text), findsOneWidget);
+
+      final svgPicture = tester.widget<SvgPicture>(find.byType(SvgPicture));
+      expect(
+        svgPicture.colorFilter,
+        ColorFilter.mode(
+          LinagoraRefColors.material().neutral[60]!,
+          BlendMode.srcIn,
+        ),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+      expect(text.style?.color, LinagoraRefColors.material().neutral[60]);
+      expect(
+        text.style?.fontSize,
+        Theme.of(tester.element(find.byType(ContactStatusWidget)))
+            .textTheme
+            .bodySmall
+            ?.fontSize,
+      );
+    });
+  });
+}

--- a/test/pages/new_private_chat/widget/contact_status_widget_test.dart
+++ b/test/pages/new_private_chat/widget/contact_status_widget_test.dart
@@ -43,5 +43,22 @@ void main() {
             ?.fontSize,
       );
     });
+
+    testWidgets('renders correctly for active status',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          home: Scaffold(
+            body: ContactStatusWidget(status: ContactStatus.active),
+          ),
+        ),
+      );
+
+      expect(find.byType(SvgPicture), findsNothing);
+      expect(find.byType(Text), findsNothing);
+      expect(find.byType(SizedBox), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Ticket
 #1996 

## Root cause
 

## Solution
According to the [figma design](https://www.figma.com/design/uLw3iWnOEGaRlJnfPz4Pv0/Twake-%5BMatrix%5D?node-id=25783-37873&t=2LUxJI6eCDu1cVUk-0 ) only the Not-Activated status should be kept

## Impact description
 the activated status in contacts tab is removed

## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**



## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:


https://github.com/user-attachments/assets/a5696b73-e888-4d16-bb37-398a85fc50c8




- Android:

[contacts_demo1.webm](https://github.com/user-attachments/assets/77994f9a-ff3a-431e-afcd-6f41bc8d32c4)



- IOS: