### PR TITLE
Set uploaded appbundles status to completed

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -37,7 +37,7 @@ platform :android do
     track = "internal"
     upload_to_play_store(track: track,
                          aab: '../build/app/outputs/bundle/release/app-release.aab',
-                         release_status: "draft")
+                         release_status: "completed")
   end
 
   lane :deploy_candidate do


### PR DESCRIPTION
Since our app is stable, we don't need to upload as draft release in internal track any more.