### PR TITLE
Fix wrong highlight message when open chat

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -445,7 +445,7 @@ class ChatController extends State<Chat>
   void _initUnreadLocation(String fullyRead) {
     _markerReadLocation = fullyRead;
     unreadReceivedMessageLocation = _findUnreadReceivedMessageLocation();
-    scrollToEventId(fullyRead);
+    scrollToEventId(fullyRead, highlight: false);
   }
 
   void _tryLoadTimeline() async {


### PR DESCRIPTION
## Root cause
- This is a side effect from ticket #1998 so all the action scroll to message is a highlight. 

## Solution
- In the case when open the chat with new message, jump to the last message and no need to highlight.

## Resolved

- Web:

https://github.com/user-attachments/assets/d5c4632d-65a9-43d7-91fb-fe762b901cb8

- IOS:


https://github.com/user-attachments/assets/983e426f-9e9f-42ba-b999-f0fd11dd6a9b

