### PR TITLE
Added support for base href customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN nix build -v --extra-experimental-features flakes --extra-experimental-featu
 
 # Building Twake for the web
 FROM --platform=linux/amd64 ghcr.io/cirruslabs/flutter:${FLUTTER_VERSION} AS web-builder
+ARG TWAKECHAT_BASE_HREF="/web/"
 COPY . /app
 WORKDIR /app
 RUN DEBIAN_FRONTEND=noninteractive apt update && \
@@ -22,8 +23,11 @@ RUN --mount=type=ssh,required=true ./scripts/build-web.sh
 
 # Final image
 FROM nginx:alpine AS final-image
+ARG TWAKECHAT_BASE_HREF
+ENV TWAKECHAT_BASE_HREF=${TWAKECHAT_BASE_HREF:-/web/}
 RUN rm -rf /usr/share/nginx/html
-COPY --from=web-builder /app/build/web /usr/share/nginx/html/web/
+COPY --from=web-builder /app/build/web /usr/share/nginx/html${TWAKECHAT_BASE_HREF}
+COPY ./configurations/nginx.conf.template /etc/nginx/templates/default.conf.template
 
 # Specify the port
 EXPOSE 80

--- a/configurations/nginx.conf.template
+++ b/configurations/nginx.conf.template
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+
+    location = / {
+       return 301 ${TWAKECHAT_BASE_HREF};
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -1,7 +1,8 @@
 #!/bin/sh -ve
+TWAKECHAT_BASE_HREF=${TWAKECHAT_BASE_HREF:-/web/}
 flutter config --enable-web
 flutter clean
 flutter pub get
 flutter pub run build_runner build --delete-conflicting-outputs
-flutter build web --release --verbose --source-maps --base-href="/web/"
+flutter build web --release --verbose --source-maps --base-href="$TWAKECHAT_BASE_HREF"
 cp config.sample.json ./build/web/config.json


### PR DESCRIPTION
To test, use the following commands (assuming you already have an SSH key added to your Github account):

```bash
eval $(ssh-agent -s)
ssh-add
docker build --ssh default --build-arg TWAKECHAT_BASE_HREF=<your href> -t twake-web:test .
docker run -d -p 80:80 twake-web:test
```

Then access http://localhost. It will auto redirect to `http://localhost${TWAKECHAT_BASE_HREF}`. By default, `TWAKECHAT_BASE_HREF` defaults to `/web/`

cc @nqhhdev 