### PR TITLE
Added support for nginx port customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN --mount=type=ssh,required=true ./scripts/build-web.sh
 FROM nginx:alpine AS final-image
 ARG TWAKECHAT_BASE_HREF
 ENV TWAKECHAT_BASE_HREF=${TWAKECHAT_BASE_HREF:-/web/}
+ENV TWAKECHAT_LISTEN_PORT="80"
 RUN rm -rf /usr/share/nginx/html
 COPY --from=web-builder /app/build/web /usr/share/nginx/html${TWAKECHAT_BASE_HREF}
 COPY ./configurations/nginx.conf.template /etc/nginx/templates/default.conf.template

--- a/configurations/nginx.conf.template
+++ b/configurations/nginx.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen ${TWAKECHAT_LISTEN_PORT};
 
     location = / {
        return 301 ${TWAKECHAT_BASE_HREF};


### PR DESCRIPTION
Use `TWAKECHAT_LISTEN_PORT` at run to customize:

```bash
docker run -p <your port>:<your port> -e TWAKECHAT_LISTEN_PORT=<your port> ...
```

cc @nqhhdev 