### PR TITLE
TW-2064: Fix cancel button in forward screen on web

### DIFF
--- a/lib/pages/forward/forward_view.dart
+++ b/lib/pages/forward/forward_view.dart
@@ -13,7 +13,6 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:linagora_design_flutter/colors/linagora_state_layer.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
 import 'package:matrix/matrix.dart';
@@ -146,7 +145,7 @@ class _WebActionsButton extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 TwakeTextButton(
-                  onTap: () => context.pop(),
+                  onTap: () => Navigator.of(context).pop(),
                   message: L10n.of(context)!.cancel,
                   borderHover: ForwardViewStyle.webActionsButtonBorder,
                   margin: ForwardViewStyle.webActionsButtonMargin,


### PR DESCRIPTION
## Ticket
- #2064 

## Root cause
- In this screen on web, using `Navigation` to open forward screen, however when click on button cancel using `go_router` so can't close this screen.

## Solution
- Use `Navigation` when click on cancel button

## Resolved
- Web:


https://github.com/user-attachments/assets/2487f363-bbd0-4fe6-8d18-34dc715eec84


- Mobile:

https://github.com/user-attachments/assets/b1694df7-2e43-4345-8e93-ed84c871faed

