### PR TITLE
TW-1950: Update markdown when send message in chat

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1876,7 +1876,7 @@ packages:
     description:
       path: "."
       ref: update-convert-markdown
-      resolved-ref: "1cd9873c9f772f948f5c0ac42708c1250073f001"
+      resolved-ref: "9ef4be5582a0a4f890d0db2498dbc02b2635994c"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1875,8 +1875,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: update-convert-markdown
-      resolved-ref: "9ef4be5582a0a4f890d0db2498dbc02b2635994c"
+      ref: "twake-supported-0.22.6"
+      resolved-ref: "8435e632d7bce166085c6426fbfb4173457526f9"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1875,8 +1875,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "twake-supported-0.22.6"
-      resolved-ref: "517ab170450588c9211498508f8110289fea2d81"
+      ref: update-convert-markdown
+      resolved-ref: "1cd9873c9f772f948f5c0ac42708c1250073f001"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   matrix:
     git:
       url: git@github.com:linagora/matrix-dart-sdk.git
-      ref: update-convert-markdown
+      ref: twake-supported-0.22.6
 
   receive_sharing_intent:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   matrix:
     git:
       url: git@github.com:linagora/matrix-dart-sdk.git
-      ref: twake-supported-0.22.6
+      ref: update-convert-markdown
 
   receive_sharing_intent:
     git:


### PR DESCRIPTION
## Need merge
- https://github.com/linagora/matrix-dart-sdk/pull/65

## Ticket
- #1950 

## Root cause

- Enable all extensions in `markdown`

## Solution

- Disable `InlineLatexSyntax ` extension in `markdown`

## Resolved

https://github.com/user-attachments/assets/30be2b5f-69ee-4c2c-a8fd-23096a9d6fb0


https://github.com/user-attachments/assets/ea4b8fd0-ba45-4e65-a7ea-37030bb10187


https://github.com/user-attachments/assets/5c398003-6c89-44c3-a463-ab88db945b3a

