### PR TITLE
TW-2018 Changed power levels in group chats

### DIFF
--- a/lib/pages/new_group/new_group_chat_info.dart
+++ b/lib/pages/new_group/new_group_chat_info.dart
@@ -106,6 +106,8 @@ class NewGroupChatInfoController extends State<NewGroupChatInfo>
         urlAvatar: urlAvatar,
         powerLevelContentOverride: {
           'events': powerLevelManager.getDefaultPowerLevelEventForMember(),
+          'invite': powerLevelManager.getAdminPowerLevel(),
+          'kick': powerLevelManager.getAdminPowerLevel(),
         },
       ),
     );

--- a/lib/utils/power_level_manager.dart
+++ b/lib/utils/power_level_manager.dart
@@ -14,13 +14,15 @@ class PowerLevelManager {
     return DefaultPowerLevelMember.user.powerLevel;
   }
 
+  int getAdminPowerLevel() => DefaultPowerLevelMember.admin.powerLevel;
+
   Map<String, dynamic> getDefaultPowerLevelEventForMember() {
     return {
       EventTypes.RoomPinnedEvents: getUserPowerLevel(),
-      EventTypes.RoomName: getUserPowerLevel(),
-      EventTypes.RoomAvatar: getUserPowerLevel(),
+      EventTypes.RoomName: getAdminPowerLevel(),
+      EventTypes.RoomAvatar: getAdminPowerLevel(),
       EventTypes.RoomMember: getUserPowerLevel(),
-      EventTypes.RoomTopic: getUserPowerLevel(),
+      EventTypes.RoomTopic: getAdminPowerLevel(),
     };
   }
 }

--- a/test/utils/power_level_manager_test.dart
+++ b/test/utils/power_level_manager_test.dart
@@ -1,0 +1,40 @@
+import 'package:fluffychat/utils/power_level_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fluffychat/config/default_power_level_member.dart';
+import 'package:matrix/matrix.dart';
+
+void main() {
+  group('PowerLevelManager', () {
+    late PowerLevelManager powerLevelManager;
+
+    setUp(() {
+      powerLevelManager = PowerLevelManager();
+    });
+
+    test('should return correct power levels for each event type', () {
+      final userPowerLevel = DefaultPowerLevelMember.user.powerLevel;
+      final adminPowerLevel = DefaultPowerLevelMember.admin.powerLevel;
+      final result = powerLevelManager.getDefaultPowerLevelEventForMember();
+
+      expect(result[EventTypes.RoomPinnedEvents], equals(userPowerLevel));
+      expect(result[EventTypes.RoomName], equals(adminPowerLevel));
+      expect(result[EventTypes.RoomAvatar], equals(adminPowerLevel));
+      expect(result[EventTypes.RoomMember], equals(userPowerLevel));
+      expect(result[EventTypes.RoomTopic], equals(adminPowerLevel));
+    });
+
+    test('should contain all expected event types', () {
+      final result = powerLevelManager.getDefaultPowerLevelEventForMember();
+      expect(
+        result.keys,
+        containsAll([
+          EventTypes.RoomPinnedEvents,
+          EventTypes.RoomName,
+          EventTypes.RoomAvatar,
+          EventTypes.RoomMember,
+          EventTypes.RoomTopic,
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Ticket
#2018 


## Impact description
only the admin can :
-Change group chat avatar
-Change name of the group chat
-Change group chat description
-Add members
-Remove members

## Resolved
**Attach screenshots or videos demonstrating the changes**

https://github.com/user-attachments/assets/f6145003-4935-4a77-9b8d-021a13a81245

