### PR TITLE
TW-2113: Fix text message overlaps time stamp in message bubble

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -31,6 +31,8 @@ abstract class AppConfig {
   static double bubbleSizeFactor = 1;
   static double fontSizeFactor = 1;
 
+  static const double messagePadding = 16.0;
+
   static String sampleValue = 'sampleValue';
 
   ///`REGISTRATION_URL`: Registration URL for public platform, sample is `https://example.com`

--- a/lib/pages/chat/events/message/message_content_builder_mixin.dart
+++ b/lib/pages/chat/events/message/message_content_builder_mixin.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat/events/message_time_style.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
@@ -93,8 +94,7 @@ mixin MessageContentBuilderMixin {
     Event event,
     double maxWidth,
   ) {
-    const double leftMessagePadding = 8.0;
-    final double messageMaxWidth = maxWidth - leftMessagePadding;
+    final double messageMaxWidth = maxWidth - AppConfig.messagePadding;
     return TextPainter(
       textScaler: MediaQuery.of(context).textScaler,
       text: TextSpan(
@@ -162,7 +162,7 @@ mixin MessageContentBuilderMixin {
     double maxWidth,
   ) {
     const spaceMessageAndTime = 4.0;
-    const paddingMessage = 16.0;
+    const paddingMessage = AppConfig.messagePadding;
 
     final paintedMessageText = _paintMessageText(
       context,


### PR DESCRIPTION
## Ticket
- #2113 

## Root cause
- Wrong padding message

- Web:

https://github.com/user-attachments/assets/1cff1e06-d373-46b7-8ff8-0791043b2943

- Mobile:

![Simulator Screenshot - iPhone 15 - 2024-11-11 at 13 55 25](https://github.com/user-attachments/assets/05836332-9c65-4adc-ac55-fc6650b770b6)
