### PR TITLE
TW-2065 remove save to gallery button in web

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1894,7 +1894,9 @@ class ChatController extends State<Chat>
             !selectedEvents.first.isVideoOrImage)
           ChatAppBarActions.saveToDownload,
       ],
-      if (selectedEvents.length == 1 && selectedEvents.first.isVideoOrImage)
+      if (selectedEvents.length == 1 &&
+          selectedEvents.first.isVideoOrImage &&
+          !PlatformInfos.isWeb)
         ChatAppBarActions.saveToGallery,
       ChatAppBarActions.info,
       ChatAppBarActions.report,


### PR DESCRIPTION
## Ticket
- #2065 


## Impact description
 save to gallery button available only on mobile


## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/user-attachments/assets/99b0518a-71e1-4af4-8d8d-4c6c9ca835d0



- Android:

 https://github.com/user-attachments/assets/d1725017-348c-4ff1-8ccd-b11357b5e83f
- IOS: