### PR TITLE
Bump v2.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.6.8+2330] - 2024-11-13
+### Changed
+
+- Integrate with TWP production
+
 ## [2.6.7+2330] - 2024-10-18
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [2.6.9+2330] - 2024-11-20
+### Fixed
+
+- #2099 Fix design review v2.6.7
+- #2018 Changed power levels in group chats
+- #2122 Fix group information disappeared
+- #2113 Fix text message overlaps time stamp in message bubble
+- #2124 Fixed wrong url when using logout
+- #1849 Fix bug weird grey counter sometimes appears
+- #2068 Fix can't see message after accept invitation
+- #2065 Remove save to gallery button in web
+
+### Added
+
+- #2014 Display phone number as a clickable in message bubble
+- #2128 Implement QR code to download app
+- #2088 Systemize app bar
+- Improve style for error dialog (#2136)
+- #2046 Add Group name validation
+
 ## [2.6.8+2330] - 2024-11-13
 ### Changed
 

--- a/lib/config/config_saas/config_saas.dart
+++ b/lib/config/config_saas/config_saas.dart
@@ -1,10 +1,9 @@
 class ConfigurationSaas {
-  static const String registrationUrl = 'https://sign-up.stg.lin-saas.com/';
+  static const String registrationUrl = 'https://sign-up.twake.app/';
 
-  static const String twakeWorkplaceHomeserver =
-      'https://matrix.stg.lin-saas.com/';
+  static const String twakeWorkplaceHomeserver = 'https://matrix.twake.app';
 
-  static const String homeserver = 'https://matrix.stg.lin-saas.com/';
+  static const String homeserver = 'https://matrix.twake.app';
 
   static const String platform = 'saas';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.6.8+2330
+version: 2.6.9+2330
 
 environment:
   sdk: ">=3.1.3 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.6.7+2330
+version: 2.6.8+2330
 
 environment:
   sdk: ">=3.1.3 <4.0.0"


### PR DESCRIPTION
## [2.6.9+2330] - 2024-11-20
### Fixed

- #2099 Fix design review v2.6.7
- #2018 Changed power levels in group chats
- #2122 Fix group information disappeared
- #2113 Fix text message overlaps time stamp in message bubble
- #2124 Fixed wrong url when using logout
- #1849 Fix bug weird grey counter sometimes appears
- #2068 Fix can't see message after accept invitation
- #2065 Remove save to gallery button in web

### Added

- #2114 Display phone number as a clickable in message bubble
- #2128 Implement QR code to download app
- #2088 Systemize app bar
- Improve style for error dialog (#2136)
- #2046 Add Group name validation