### PR TITLE
TW-2150 fix confirm button not displaying when changing group avatar

### DIFF
--- a/lib/pages/chat_details/chat_details_edit.dart
+++ b/lib/pages/chat_details/chat_details_edit.dart
@@ -79,7 +79,7 @@ class ChatDetailsEditController extends State<ChatDetailsEdit>
   final MenuController menuController = MenuController();
 
   final isEditedGroupInfoNotifier = ValueNotifier<bool>(false);
-  final isValidGroupNameNotifier = ValueNotifier<bool>(false);
+  final isValidGroupNameNotifier = ValueNotifier<bool>(true);
 
   Client get client => Matrix.of(context).client;
 
@@ -483,6 +483,8 @@ class ChatDetailsEditController extends State<ChatDetailsEdit>
     groupNameEmptyNotifier.value = groupNameTextEditingController.text.isEmpty;
 
     groupNameTextEditingController.addListener(() {
+      isValidGroupNameNotifier.value =
+          getErrorMessage(groupNameTextEditingController.text) == null;
       if (_isEditAvatar) {
         return;
       }
@@ -490,8 +492,6 @@ class ChatDetailsEditController extends State<ChatDetailsEdit>
           groupNameTextEditingController.text != room?.name;
       groupNameEmptyNotifier.value =
           groupNameTextEditingController.text.isEmpty;
-      isValidGroupNameNotifier.value =
-          getErrorMessage(groupNameTextEditingController.text) == null;
     });
   }
 


### PR DESCRIPTION
## Ticket
- #2150

- side effect from  #2119 

## Root cause
  The initial value for `isValidGroupNameNotifier` is set to false as a result  the button is not displayed when you only change the avatar
   ### bug demo

https://github.com/user-attachments/assets/9b32e9f3-4a63-4920-a460-051798e4ee3d



## Solution


## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/user-attachments/assets/da0404ee-ef59-4414-96b8-b2233db72c4f



- Android:
- IOS: