### PR TITLE
TW-2157: Fix can't mark a chat as unread

### DIFF
--- a/lib/presentation/mixins/chat_list_item_mixin.dart
+++ b/lib/presentation/mixins/chat_list_item_mixin.dart
@@ -213,19 +213,50 @@ mixin ChatListItemMixin {
     required BuildContext context,
     required Room room,
   }) {
+    /// highlightCount or Invitation
     if (room.highlightCount > 0 || room.membership == Membership.invite) {
       return Theme.of(context).colorScheme.primary;
     }
-    if (room.notificationCount > 0 &&
-        room.pushRuleState != PushRuleState.notify) {
-      return LinagoraRefColors.material().tertiary[30];
+
+    if (hasNewMessage(room)) {
+      return _handleNotificationColorHasNewMessage(
+        room,
+        context,
+      );
     }
+
     if (room.markedUnread) {
-      return LinagoraRefColors.material().tertiary[30];
-    }
-    if (room.notificationCount > 0) {
-      return Theme.of(context).colorScheme.primary;
+      return _handleNotificationColorMarkedUnread(
+        context: context,
+        room: room,
+      );
     }
     return Colors.transparent;
+  }
+
+  bool hasNewMessage(Room room) {
+    return room.notificationCount > 0 || room.hasNewMessages;
+  }
+
+  Color? _handleNotificationColorHasNewMessage(
+    Room room,
+    BuildContext context,
+  ) {
+    if (room.pushRuleState == PushRuleState.mentionsOnly) {
+      return LinagoraRefColors.material().tertiary[30];
+    } else {
+      return Theme.of(context).colorScheme.primary;
+    }
+  }
+
+  Color? _handleNotificationColorMarkedUnread({
+    required BuildContext context,
+    required Room room,
+  }) {
+    if (room.pushRuleState == PushRuleState.mentionsOnly) {
+      return LinagoraRefColors.material().tertiary[30];
+    } else {
+      return Theme.of(context).colorScheme.primary;
+    }
   }
 }

--- a/lib/presentation/mixins/chat_list_item_mixin.dart
+++ b/lib/presentation/mixins/chat_list_item_mixin.dart
@@ -213,14 +213,17 @@ mixin ChatListItemMixin {
     required BuildContext context,
     required Room room,
   }) {
+    if (room.highlightCount > 0 || room.membership == Membership.invite) {
+      return Theme.of(context).colorScheme.primary;
+    }
     if (room.notificationCount > 0 &&
         room.pushRuleState != PushRuleState.notify) {
       return LinagoraRefColors.material().tertiary[30];
     }
-    if (room.notificationCount > 0) {
-      return Theme.of(context).colorScheme.primary;
+    if (room.markedUnread) {
+      return LinagoraRefColors.material().tertiary[30];
     }
-    if (room.membership == Membership.invite) {
+    if (room.notificationCount > 0) {
       return Theme.of(context).colorScheme.primary;
     }
     return Colors.transparent;

--- a/test/mixin/chat/chat_list_item_mixin_test.dart
+++ b/test/mixin/chat/chat_list_item_mixin_test.dart
@@ -26,85 +26,144 @@ void main() {
       chatListItemMixinTest = ChatListItemMixinTest();
     });
 
-    testWidgets(
-        'WHEN notification count is zero\n'
-        'AND room is unmuted\n'
-        'THEN color should have transparent\n', (
-      WidgetTester tester,
-    ) async {
-      when(room.notificationCount).thenReturn(0);
-      when(room.pushRuleState).thenReturn(PushRuleState.notify);
+    group('Test highlight message and invitation', () {
+      testWidgets(
+          'WHEN group is invite\n'
+          'THEN color should have color primary\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.membership).thenReturn(Membership.invite);
 
-      final color = chatListItemMixinTest.notificationColor(
-        context: context,
-        room: room,
-      );
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
 
-      expect(color, Colors.transparent);
+        expect(color, Theme.of(context).colorScheme.primary);
+      });
+
+      testWidgets(
+          'WHEN has new message with mention\n'
+          'AND highlight count is greater than zero\n'
+          'AND pushRuleState is notify\n'
+          'THEN color should be primary\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.pushRuleState).thenReturn(PushRuleState.mentionsOnly);
+        when(room.highlightCount).thenReturn(1);
+
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
+
+        expect(color, Theme.of(context).colorScheme.primary);
+      });
     });
 
-    testWidgets(
-        'WHEN group is invite\n'
-        'THEN color should have color primary\n', (
-      WidgetTester tester,
-    ) async {
-      when(room.membership).thenReturn(Membership.invite);
+    group('Test room has new message', () {
+      testWidgets(
+          'WHEN notification count is zero\n'
+          'AND pushRuleState is notify\n'
+          'THEN color should have transparent\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.notificationCount).thenReturn(0);
+        when(room.pushRuleState).thenReturn(PushRuleState.notify);
 
-      final color = chatListItemMixinTest.notificationColor(
-        context: context,
-        room: room,
-      );
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
 
-      expect(color, Theme.of(context).colorScheme.primary);
+        expect(color, Colors.transparent);
+      });
+
+      testWidgets(
+          'WHEN notification count is greater than zero\n'
+          'AND pushRuleState is notify\n'
+          'THEN color should be primary\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.notificationCount).thenReturn(5);
+        when(room.pushRuleState).thenReturn(PushRuleState.notify);
+
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
+
+        expect(color, Theme.of(context).colorScheme.primary);
+      });
+
+      testWidgets(
+          'WHEN notification count is greater than zero\n'
+          'AND pushRuleState is mentionsOnly\n'
+          'THEN color should be tertiary[30]\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.notificationCount).thenReturn(5);
+        when(room.pushRuleState).thenReturn(PushRuleState.mentionsOnly);
+
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
+
+        expect(color, LinagoraRefColors.material().tertiary[30]);
+      });
+
+      testWidgets(
+          'WHEN has new message \n'
+          'AND pushRuleState is mentionsOnly\n'
+          'THEN color should be tertiary[30]\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.pushRuleState).thenReturn(PushRuleState.mentionsOnly);
+        when(room.hasNewMessages).thenReturn(true);
+
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
+
+        expect(color, LinagoraRefColors.material().tertiary[30]);
+      });
     });
 
-    testWidgets(
-        'WHEN notification count is greater than zero\n'
-        'AND room is unmuted\n'
-        'THEN color should be primary\n', (
-      WidgetTester tester,
-    ) async {
-      when(room.notificationCount).thenReturn(5);
-      when(room.pushRuleState).thenReturn(PushRuleState.notify);
+    group('Test room is mark as unread', () {
+      testWidgets(
+          'WHEN marked unread for room\n'
+          'AND pushRuleState is notify\n'
+          'THEN color should be primary]\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.markedUnread).thenReturn(true);
 
-      final color = chatListItemMixinTest.notificationColor(
-        context: context,
-        room: room,
-      );
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
 
-      expect(color, Theme.of(context).colorScheme.primary);
-    });
+        expect(color, Theme.of(context).colorScheme.primary);
+      });
 
-    testWidgets(
-        'WHEN notification count is greater than zero\n'
-        'AND room is muted\n'
-        'THEN color should be tertiary[30]\n', (
-      WidgetTester tester,
-    ) async {
-      when(room.notificationCount).thenReturn(5);
-      when(room.pushRuleState).thenReturn(PushRuleState.dontNotify);
+      testWidgets(
+          'WHEN marked unread for room\n'
+          'AND pushRuleState is mentionsOnly\n'
+          'THEN color should be primary]\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.markedUnread).thenReturn(true);
+        when(room.pushRuleState).thenReturn(PushRuleState.mentionsOnly);
 
-      final color = chatListItemMixinTest.notificationColor(
-        context: context,
-        room: room,
-      );
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
 
-      expect(color, LinagoraRefColors.material().tertiary[30]);
-    });
-
-    testWidgets(
-        'WHEN marked unread for room\n'
-        'THEN color should be tertiary[30]\n', (
-      WidgetTester tester,
-    ) async {
-      when(room.markedUnread).thenReturn(true);
-
-      final color = chatListItemMixinTest.notificationColor(
-        context: context,
-        room: room,
-      );
-
-      expect(color, LinagoraRefColors.material().tertiary[30]);
+        expect(color, LinagoraRefColors.material().tertiary[30]);
+      });
     });
   });
 }

--- a/test/mixin/chat/chat_list_item_mixin_test.dart
+++ b/test/mixin/chat/chat_list_item_mixin_test.dart
@@ -91,5 +91,20 @@ void main() {
 
       expect(color, LinagoraRefColors.material().tertiary[30]);
     });
+
+    testWidgets(
+        'WHEN marked unread for room\n'
+        'THEN color should be tertiary[30]\n', (
+      WidgetTester tester,
+    ) async {
+      when(room.markedUnread).thenReturn(true);
+
+      final color = chatListItemMixinTest.notificationColor(
+        context: context,
+        room: room,
+      );
+
+      expect(color, LinagoraRefColors.material().tertiary[30]);
+    });
   });
 }


### PR DESCRIPTION
## Ticket
- #2157 
- #2154

## Root cause
- Side effect from PR #2134 
- Missing conditions for mark unread

## Resolved

- Web:

https://github.com/user-attachments/assets/1ce3a464-70bc-4859-920c-94bc9d831a2c

- Android:
- IOS: