### PR TITLE
TW-2163: Fix avatar cut off when change new image

### DIFF
--- a/lib/widgets/stream_image_view.dart
+++ b/lib/widgets/stream_image_view.dart
@@ -66,7 +66,7 @@ class StreamImageViewerState extends State<StreamImageViewer> {
           maxScale: 5.0,
           child: Image.memory(
             bytes.bytes!,
-            fit: BoxFit.contain,
+            fit: BoxFit.cover,
             gaplessPlayback: true,
           ),
         );


### PR DESCRIPTION
## Ticket
- #2163 

## Root cause
- When using `Image` with property is `fit: BoxFit.contain` As large as possible while still containing the source entirely within the target box.
- https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_contain.png

## Solution
- Change property to `fit: BoxFit.cover` As small as possible while still covering the entire target box.
- https://flutter.github.io/assets-for-api-docs/assets/painting/box_fit_cover.png

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/user-attachments/assets/18c197a9-3909-4499-ad50-5cb5428b11cf

- Mobile:

https://github.com/user-attachments/assets/18ec2f2c-159a-4f09-b1f2-27c9252a169c
