### PR TITLE
[TESTING] TW-1935: Change `dragDevices` to disable scrolling in a ListView when hovers over the screen

### DIFF
--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -76,8 +76,6 @@ class ChatEventList extends StatelessWidget {
         behavior: ScrollConfiguration.of(context).copyWith(
           dragDevices: {
             PointerDeviceKind.touch,
-            PointerDeviceKind.mouse,
-            PointerDeviceKind.trackpad,
           },
         ),
         child: SelectionTextContainer(


### PR DESCRIPTION
## Ticket
 - #1935 

## Solution
- `dragDevices` Configuration:
  - Only include `PointerDeviceKind.touch` in the `dragDevices `set.
  - Exclude` PointerDeviceKind.mouse` and other devices to disable mouse/trackpad scrolling.
  
- Use `ScrollConfiguration`:
  - Wrap the entire app or a specific widget subtree with a `ScrollConfiguration` to enforce this behavior.

## Resolved

- Web:
- Android:
- IOS: