### PR TITLE
TW-2169 added avatar and name for sender messages in web

### DIFF
--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -311,12 +311,19 @@ class _MessageState extends State<Message> {
     );
   }
 
+  bool shouldDisplayAvatar(bool sameSender, bool ownMessage) {
+    return sameSender &&
+        (!ownMessage || !Message.responsiveUtils.isMobile(context));
+  }
+
   Widget _placeHolderWidget(bool sameSender, bool ownMessage, Event event) {
-    if (widget.selectMode || event.room.isDirectChat) {
+    if (widget.selectMode ||
+        (event.room.isDirectChat &&
+            Message.responsiveUtils.isMobile(context))) {
       return const SizedBox();
     }
 
-    if (sameSender && !ownMessage) {
+    if (shouldDisplayAvatar(sameSender, ownMessage)) {
       return Padding(
         padding: MessageStyle.paddingAvatar,
         child: FutureBuilder<User?>(

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -14,8 +14,8 @@ import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
+import 'package:fluffychat/presentation/mixins/message_avatar_mixin.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
-import 'package:fluffychat/widgets/avatar/avatar.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/swipeable.dart';
 import 'package:flutter/material.dart';
@@ -99,7 +99,7 @@ class Message extends StatefulWidget {
   State<Message> createState() => _MessageState();
 }
 
-class _MessageState extends State<Message> {
+class _MessageState extends State<Message> with MessageAvatarMixin {
   InViewState? inViewState;
 
   final inviewNotifier = ValueNotifier(false);
@@ -187,10 +187,13 @@ class _MessageState extends State<Message> {
             : MainAxisAlignment.start;
 
         final rowChildren = <Widget>[
-          _placeHolderWidget(
-            widget.event.isSameSenderWith(widget.previousEvent),
-            widget.event.isOwnMessage,
-            widget.event,
+          placeHolderWidget(
+            widget.onAvatarTap,
+            event: widget.event,
+            sameSender: widget.event.isSameSenderWith(widget.previousEvent),
+            ownMessage: widget.event.isOwnMessage,
+            context: context,
+            selectMode: widget.selectMode,
           ),
           Expanded(
             child: MessageContentWithTimestampBuilder(
@@ -308,43 +311,6 @@ class _MessageState extends State<Message> {
           ],
         );
       },
-    );
-  }
-
-  bool shouldDisplayAvatar(bool sameSender, bool ownMessage) {
-    return sameSender &&
-        (!ownMessage || !Message.responsiveUtils.isMobile(context));
-  }
-
-  Widget _placeHolderWidget(bool sameSender, bool ownMessage, Event event) {
-    if (widget.selectMode ||
-        (event.room.isDirectChat &&
-            Message.responsiveUtils.isMobile(context))) {
-      return const SizedBox();
-    }
-
-    if (shouldDisplayAvatar(sameSender, ownMessage)) {
-      return Padding(
-        padding: MessageStyle.paddingAvatar,
-        child: FutureBuilder<User?>(
-          future: event.fetchSenderUser(),
-          builder: (context, snapshot) {
-            final user = snapshot.data ?? event.senderFromMemoryOrFallback;
-            return Avatar(
-              size: MessageStyle.avatarSize,
-              fontSize: MessageStyle.fontSize,
-              mxContent: user.avatarUrl,
-              name: user.calcDisplayname(),
-              onTap: () => widget.onAvatarTap!(event),
-            );
-          },
-        ),
-      );
-    }
-
-    return const Padding(
-      padding: MessageStyle.paddingAvatar,
-      child: SizedBox(width: MessageStyle.avatarSize),
     );
   }
 

--- a/lib/pages/chat/events/message/message_content_builder.dart
+++ b/lib/pages/chat/events/message/message_content_builder.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/pages/chat/events/message/reply_content_widget.dart';
 import 'package:fluffychat/pages/chat/events/message_content.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
+import 'message.dart';
 
 class MessageContentBuilder extends StatelessWidget
     with MessageContentBuilderMixin {
@@ -46,6 +47,7 @@ class MessageContentBuilder extends StatelessWidget
       ownMessage: event.isOwnMessage,
       hideDisplayName: event.hideDisplayName(
         nextEvent,
+        Message.responsiveUtils.isMobile(context),
       ),
     );
     final stepWidth = sizeMessageBubble?.totalMessageWidth;

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -138,8 +138,10 @@ class MessageContentWithTimestampBuilder extends StatelessWidget {
                               Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
-                              event.hideDisplayName(nextEvent) ||
-                                      event.hideDisplayNameInBubbleChat
+                              event.hideDisplayName(
+                                nextEvent,
+                                responsiveUtils.isMobile(context),
+                              )
                                   ? const SizedBox()
                                   : DisplayNameWidget(
                                       event: event,

--- a/lib/presentation/mixins/message_avatar_mixin.dart
+++ b/lib/presentation/mixins/message_avatar_mixin.dart
@@ -1,0 +1,56 @@
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/pages/chat/events/message/message_style.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/widgets/avatar/avatar.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
+mixin MessageAvatarMixin {
+  ResponsiveUtils responsive = getIt.get<ResponsiveUtils>();
+
+  bool _shouldDisplayAvatar(
+    bool sameSender,
+    bool ownMessage,
+    BuildContext context,
+  ) {
+    return sameSender && !(ownMessage && responsive.isMobile(context));
+  }
+
+  Widget placeHolderWidget(
+    Function(Event)? onAvatarTap, {
+    required bool sameSender,
+    required bool ownMessage,
+    required Event event,
+    required BuildContext context,
+    required bool selectMode,
+  }) {
+    if (selectMode ||
+        (event.room.isDirectChat && responsive.isMobile(context))) {
+      return const SizedBox();
+    }
+
+    if (_shouldDisplayAvatar(sameSender, ownMessage, context)) {
+      return Padding(
+        padding: MessageStyle.paddingAvatar,
+        child: FutureBuilder<User?>(
+          future: event.fetchSenderUser(),
+          builder: (context, snapshot) {
+            final user = snapshot.data ?? event.senderFromMemoryOrFallback;
+            return Avatar(
+              size: MessageStyle.avatarSize,
+              fontSize: MessageStyle.fontSize,
+              mxContent: user.avatarUrl,
+              name: user.calcDisplayname(),
+              onTap: () => onAvatarTap!(event),
+            );
+          },
+        ),
+      );
+    }
+
+    return const Padding(
+      padding: MessageStyle.paddingAvatar,
+      child: SizedBox(width: MessageStyle.avatarSize),
+    );
+  }
+}

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -176,9 +176,8 @@ extension LocalizedBody on Event {
         MessageTypes.File,
       }.contains(messageType);
 
-  bool hideDisplayName(Event? nextEvent) =>
-      isOwnMessage ||
-      room.isDirectChat ||
+  bool hideDisplayName(Event? nextEvent, bool isMobile) =>
+      isMobile && (isOwnMessage || room.isDirectChat) ||
       !isSameSenderWith(nextEvent) ||
       type == EventTypes.Encrypted;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1877,7 +1877,7 @@ packages:
     description:
       path: "."
       ref: "twake-supported-0.22.6"
-      resolved-ref: "04ec6f3b9ece8e64e031cbe5c6e8164dc2ec7f2d"
+      resolved-ref: "58585a19abc4693d96eab4f8dad9c56bf8699cc1"
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"

--- a/test/mixin/message_avatar_mixin_test.dart
+++ b/test/mixin/message_avatar_mixin_test.dart
@@ -1,0 +1,298 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:fluffychat/config/localizations/localization_service.dart';
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/presentation/mixins/message_avatar_mixin.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/widgets/avatar/avatar.dart';
+import 'package:fluffychat/widgets/theme_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localized_locales/flutter_localized_locales.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:matrix/matrix.dart';
+import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'message_avatar_mixin_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<User>(),
+  MockSpec<Room>(),
+])
+class MockMessageAvatarUtils with MessageAvatarMixin {}
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late MockMessageAvatarUtils mockMessageAvatarUtils;
+  late Room room;
+  late User user;
+  late Event event;
+  setUpAll(() {
+    final getIt = GetIt.instance;
+    getIt.registerSingleton(ResponsiveUtils());
+    mockMessageAvatarUtils = MockMessageAvatarUtils();
+  });
+
+  group('Tests for when the avatar next to a message should be displayed ', () {
+    setUp(() {
+      room = MockRoom();
+      user = MockUser();
+      event = Event(
+        content: {
+          'body': 'Test message',
+          'msgtype': 'm.text',
+        },
+        type: 'm.room.message',
+        eventId: '7365636s6r64300:example.com',
+        senderId: '@bob:example.com',
+        originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
+        room: room,
+      );
+    });
+    Future<void> runTest(
+      WidgetTester tester, {
+      required Event event,
+      required bool selectMode,
+      required bool sameSender,
+      required bool ownMessage,
+      required Size screenSize,
+      required bool isDirectChat,
+    }) async {
+      when(room.requestUser(event.senderId, ignoreErrors: true))
+          .thenAnswer((_) async => user);
+      when(room.unsafeGetUserFromMemoryOrFallback(event.senderId))
+          .thenReturn(user);
+      when(user.avatarUrl).thenReturn(Uri.tryParse("fakeImage"));
+      when(user.calcDisplayname()).thenReturn('Test');
+      when(event.room.isDirectChat).thenReturn(isDirectChat);
+      Widget? widget;
+      await tester.pumpWidget(
+        ThemeBuilder(
+          builder: (context, themeMode, primaryColor) => MaterialApp(
+            locale: const Locale('en'),
+            localizationsDelegates: const [
+              LocaleNamesLocalizationsDelegate(),
+              L10n.delegate,
+              GlobalMaterialLocalizations.delegate,
+              GlobalCupertinoLocalizations.delegate,
+              GlobalWidgetsLocalizations.delegate,
+            ],
+            supportedLocales: LocalizationService.supportedLocales,
+            theme: TwakeThemes.buildTheme(
+              context,
+              Brightness.light,
+              primaryColor,
+            ),
+            builder: (context, child) => MediaQuery(
+              data: MediaQueryData(
+                size: screenSize,
+              ),
+              child: child!,
+            ),
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  widget = mockMessageAvatarUtils.placeHolderWidget(
+                    (_) {},
+                    sameSender: sameSender,
+                    ownMessage: ownMessage,
+                    event: event,
+                    context: context,
+                    selectMode: selectMode,
+                  );
+                  return widget!;
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+    }
+
+    group('Web-sized screens', () {
+      const webSize = Size(1200, 800);
+
+      testWidgets(
+        'Should display Avatar when Own message in group chat',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: false,
+            sameSender: true,
+            ownMessage: true,
+            screenSize: webSize,
+            isDirectChat: false,
+          );
+          verify(room.requestUser(event.senderId, ignoreErrors: true))
+              .called(1);
+          expect(find.byType(Avatar), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Should display Avatar when Own message in direct chat',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: false,
+            sameSender: true,
+            ownMessage: true,
+            screenSize: webSize,
+            isDirectChat: true,
+          );
+          verify(room.requestUser(event.senderId, ignoreErrors: true))
+              .called(1);
+          expect(find.byType(Avatar), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Should return Avatar when Not my message in direct chat',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: false,
+            sameSender: true,
+            ownMessage: false,
+            screenSize: webSize,
+            isDirectChat: true,
+          );
+          verify(room.requestUser(event.senderId, ignoreErrors: true))
+              .called(1);
+          expect(find.byType(Avatar), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Should return Avatar when not my message in group chat',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: false,
+            sameSender: true,
+            ownMessage: false,
+            screenSize: webSize,
+            isDirectChat: false,
+          );
+          verify(room.requestUser(event.senderId, ignoreErrors: true))
+              .called(1);
+          expect(find.byType(Avatar), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Should return SizedBox when Select mode is active',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: true,
+            sameSender: true,
+            ownMessage: false,
+            screenSize: webSize,
+            isDirectChat: true,
+          );
+          verifyNever(room.requestUser(event.senderId, ignoreErrors: true));
+          expect(find.byType(SizedBox), findsOneWidget);
+        },
+      );
+    });
+    group('Mobile-sized screens', () {
+      const mobileSize = Size(400, 800);
+
+      testWidgets(
+        'Should return SizedBox when Own message in group chat',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: false,
+            sameSender: true,
+            ownMessage: true,
+            isDirectChat: false,
+            screenSize: mobileSize,
+          );
+          verifyNever(room.requestUser(event.senderId, ignoreErrors: true));
+          expect(find.byType(SizedBox), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Should return SizedBox when Own message in direct chat',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: false,
+            sameSender: true,
+            ownMessage: true,
+            screenSize: mobileSize,
+            isDirectChat: true,
+          );
+          verifyNever(room.requestUser(event.senderId, ignoreErrors: true));
+          expect(find.byType(SizedBox), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Should return SizedBox when Not my message in direct chat',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: false,
+            sameSender: true,
+            ownMessage: false,
+            screenSize: mobileSize,
+            isDirectChat: true,
+          );
+          verifyNever(room.requestUser(event.senderId, ignoreErrors: true));
+          expect(find.byType(SizedBox), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Should return Avatar when Not my message in group chat',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: false,
+            sameSender: true,
+            ownMessage: false,
+            screenSize: mobileSize,
+            isDirectChat: false,
+          );
+          verify(room.requestUser(event.senderId, ignoreErrors: true))
+              .called(1);
+          expect(find.byType(Avatar), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Should return SizedBox when Select mode is active',
+        (WidgetTester tester) async {
+          await runTest(
+            tester,
+            event: event,
+            selectMode: true,
+            sameSender: true,
+            ownMessage: false,
+            screenSize: mobileSize,
+            isDirectChat: true,
+          );
+          verifyNever(room.requestUser(event.senderId, ignoreErrors: true));
+          expect(find.byType(SizedBox), findsOneWidget);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Ticket
- #2169 

## Impact description
 Added avatar and username for sent messages/images inside a chat

## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**

## Pre-merge

- https://github.com/linagora/matrix-dart-sdk/pull/70

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
![avatarnameofsender](https://github.com/user-attachments/assets/4566bb7e-1ab9-452e-98e9-8f21f7e88fdd)

![nameimage](https://github.com/user-attachments/assets/4158ab00-792b-4722-89c8-7253159105bb)

![file](https://github.com/user-attachments/assets/133ca806-5154-44cf-8767-3b775a8352e6)


- Android:
- IOS: