### PR TITLE
TW-2100: Update image type supported when picking new avatar

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -130,6 +130,13 @@ abstract class AppConfig {
   static const imageCompressFormmat = CompressFormat.jpeg;
   static const videoThumbnailFormat = ImageFormat.JPEG;
 
+  static const List<String> allowedExtensionsSupportedAvatar = [
+    'png',
+    'jpg',
+    'jpeg',
+    'jfif',
+  ];
+
   static String? issueId;
 
   static int defaultMaxUploadAvtarSizeInBytes = 10 * (1024 * 1024);

--- a/lib/presentation/mixins/pick_avatar_mixin.dart
+++ b/lib/presentation/mixins/pick_avatar_mixin.dart
@@ -41,7 +41,8 @@ mixin PickAvatarMixin {
       PickingAvatarUIState(),
     );
     final result = await FilePicker.platform.pickFiles(
-      type: FileType.image,
+      type: FileType.custom,
+      allowedExtensions: AppConfig.allowedExtensionsSupportedAvatar,
       withReadStream: true,
     );
     if (result == null || result.files.single.readStream == null) {


### PR DESCRIPTION
## Ticket
 - #2100 

## Solution
- Only supported for image type `png`  `jpg`  `jpeg`   `jfif` when picking new avatar on web
- Refer Telegram web

- Web:

## Settings Profile 
https://github.com/user-attachments/assets/f72755f3-0132-4ccf-b804-c64991adc423

## Group profile
https://github.com/user-attachments/assets/f96b89e4-f0f5-44e1-811e-515a5c00ccc6

## Create new group
https://github.com/user-attachments/assets/97775313-3bf4-4149-95dc-0e1635b2c5a5

