### PR TITLE
Bump version to v2.6.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.6.16+2330] - 2025-01-07
+### Fixed
+- Hotfix: Missing state when deleting avatar in chat details edit
+
+### Changed
+- Downgrade ruby to fix building mobile app
+
 ## [2.6.15+2330] - 2025-01-03
 ### Fixed
 - #2152 Fix full-word search for unencrypted messages isn't performed until you put a space after the word

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.6.15+2330
+version: 2.6.16+2330
 
 environment:
   sdk: ">=3.1.3 <4.0.0"


### PR DESCRIPTION
## [2.6.16+2330] - 2025-01-07
### Fixed
- Hotfix: Missing state when deleting avatar in chat details edit

### Changed
- Downgrade ruby to fix building mobile app