### PR TITLE
TW-2214: Fix Wrong behaviour when sharing a file from other app to Twake

### DIFF
--- a/lib/pages/chat_list/receive_sharing_intent_mixin.dart
+++ b/lib/pages/chat_list/receive_sharing_intent_mixin.dart
@@ -86,9 +86,9 @@ mixin ReceiveSharingIntentMixin<T extends StatefulWidget> on State<T> {
     if (_intentOpenApp(text)) {
       return;
     }
-    openSharePage();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      UrlLauncher(context, url: text).openMatrixToUrl();
+      UrlLauncher(TwakeApp.routerKey.currentContext!, url: text)
+          .openMatrixToUrl();
     });
   }
 


### PR DESCRIPTION
## Ticket
- #2214

## Root cause
- Open the share screen 2 times
- Wrong when using context 


## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS: