### PR TITLE
[Encrypted] Try to upload key to server before logout

### DIFF
--- a/lib/pages/settings_dashboard/settings/settings.dart
+++ b/lib/pages/settings_dashboard/settings/settings.dart
@@ -96,11 +96,24 @@ class SettingsController extends State<Settings> with ConnectPageMixin {
         ConfirmResult.cancel) {
       return;
     }
+
+    await _tryToUploadKeyBackup();
+
     if (PlatformInfos.isMobile) {
       await _logoutActionsOnMobile();
     } else {
       await _logoutActions();
     }
+  }
+
+  Future<void> _tryToUploadKeyBackup() async {
+    await TwakeDialog.showFutureLoadingDialogFullScreen(
+      future: () async {
+        await matrix.client.encryption?.keyManager.uploadInboundGroupSessions();
+      },
+    );
+
+    return;
   }
 
   Future<void> _logoutActionsOnMobile() async {


### PR DESCRIPTION
### Root cause:
- logout in Twake maybe not success if logout_redirect not success
- upload message key in sync event is not success

### Solution:
- upload key first, before loging out
- handle auto upload key in every sync, but not process if before task not completed.

### DoD:
- [x] error handling 
- [x] mobile UX testing 