### PR TITLE
Bump v2.6.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.6.18+2330] - 2025-02-19
+### Fixed
+- [Encryption] Fix timeout for first sync
+- [Encryption] Change log level to verbose when enable log
+- [Encryption] Remove timeout for loading dialog
+- #2215 Fix cannot preview share media
+
 ## [2.6.17+2330] - 2025-01-24
 ### Fixed
 - #1139 Toast when copy message

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.6.17+2330
+version: 2.6.18+2330
 
 environment:
   sdk: ">=3.1.3 <4.0.0"


### PR DESCRIPTION
## [2.6.18+2330] - 2025-02-19
### Fixed
- [Encryption] Fix timeout for first sync
- [Encryption] Change log level to verbose when enable log
- [Encryption] Remove timeout for loading dialog
- #2215 Fix cannot preview share media