### PR TITLE
Fix crash when video display in chat with wrong thumbnail information

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,6 +15,7 @@ analyzer:
     todo: ignore
     fixme: ignore
     use_build_context_synchronously: ignore
+    deprecated_member_use: ignore # TODO: remove it when we can remove download image in HtmlMessage
   exclude:
     - lib/generated_plugin_registrant.dart
     - lib/l10n/*.dart

--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -5,6 +5,7 @@ import 'package:fluffychat/pages/chat_draft/draft_chat_empty_widget.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_gen/gen_l10n/l10n.dart';
@@ -97,8 +98,7 @@ class ChatEventList extends StatelessWidget {
                   if (index == 0) {
                     if (controller.timeline!.isRequestingFuture) {
                       return const Center(
-                        child:
-                            CircularProgressIndicator.adaptive(strokeWidth: 2),
+                        child: CupertinoActivityIndicator(),
                       );
                     }
                     if (controller.timeline!.canRequestFuture) {
@@ -119,8 +119,7 @@ class ChatEventList extends StatelessWidget {
                   if (index == events.length + 1) {
                     if (controller.timeline!.isRequestingHistory) {
                       return const Center(
-                        child:
-                            CircularProgressIndicator.adaptive(strokeWidth: 2),
+                        child: CupertinoActivityIndicator(),
                       );
                     }
                     if (controller.timeline!.canRequestHistory) {

--- a/lib/pages/forward/forward_view.dart
+++ b/lib/pages/forward/forward_view.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/pages/forward/forward_view_style.dart';
 import 'package:fluffychat/widgets/app_bars/searchable_app_bar.dart';
 import 'package:fluffychat/widgets/twake_components/twake_fab.dart';
 import 'package:fluffychat/widgets/twake_components/twake_text_button.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
@@ -131,7 +132,7 @@ class _WebActionsButton extends StatelessWidget {
                         alignment: Alignment.centerRight,
                         child: TwakeFloatingActionButton(
                           customIcon:
-                              SizedBox(child: CircularProgressIndicator()),
+                              SizedBox(child: CupertinoActivityIndicator()),
                         ),
                       ),
                     );
@@ -230,7 +231,7 @@ class _ForwardButton extends StatelessWidget {
                   child: Align(
                     alignment: Alignment.centerRight,
                     child: TwakeFloatingActionButton(
-                      customIcon: SizedBox(child: CircularProgressIndicator()),
+                      customIcon: SizedBox(child: CupertinoActivityIndicator()),
                     ),
                   ),
                 );

--- a/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/widgets/avatar/avatar.dart';
 import 'package:fluffychat/widgets/highlight_text.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/twake_components/twake_chip.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
@@ -261,9 +262,7 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
             child: SizedBox(
               width: 16,
               height: 16,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-              ),
+              child: CupertinoActivityIndicator(),
             ),
           );
         }

--- a/lib/utils/matrix_sdk_extensions/download_file_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/download_file_extension.dart
@@ -51,6 +51,9 @@ extension DownloadFileExtension on Event {
       ),
     );
     final downloadLink = mxcUrl.getDownloadLink(room.client);
+    Logs().d(
+      'DownloadFileExtension::downloadOrRetrieveAttachment(): downloadLink = $downloadLink',
+    );
 
     if (await attachment.exists()) {
       if (await attachment.length() ==
@@ -82,10 +85,10 @@ extension DownloadFileExtension on Event {
         },
         cancelToken: cancelToken,
       );
-      if (downloadResponse.statusCode == 200 &&
-          await File(savePath).exists() &&
-          await File(savePath).length() ==
-              getFileSize(getThumbnail: getThumbnail)) {
+      Logs().d(
+        'DownloadFileExtension::downloadOrRetrieveAttachment(): downloadResponse = ${downloadResponse.statusCode}',
+      );
+      if (downloadResponse.statusCode == 200 && await File(savePath).exists()) {
         final fileInfo = FileInfo(
           filename,
           savePath,
@@ -127,6 +130,7 @@ extension DownloadFileExtension on Event {
     getThumbnail = false,
     StreamController<Either<Failure, Success>>? streamController,
   }) async {
+    Logs().i('DownloadFileExtension::_handleDownloadFileDone(): $mxcUrl');
     if (isAttachmentEncrypted) {
       await _handleEncryptedFileEvent(
         mxcUrl: mxcUrl,

--- a/lib/utils/matrix_sdk_extensions/download_file_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/download_file_extension.dart
@@ -50,7 +50,7 @@ extension DownloadFileExtension on Event {
         fileName: filename,
       ),
     );
-    final downloadLink = mxcUrl.getDownloadLink(room.client);
+    final downloadLink = await mxcUrl.getDownloadUri(room.client);
     Logs().d(
       'DownloadFileExtension::downloadOrRetrieveAttachment(): downloadLink = $downloadLink',
     );

--- a/lib/utils/matrix_sdk_extensions/matrix_file_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/matrix_file_extension.dart
@@ -14,6 +14,43 @@ import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:file_saver/file_saver.dart';
 
 extension MatrixFileExtension on MatrixFile {
+  bool isImage() {
+    // List of common image MIME types
+    const imageMimeTypes = [
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/bmp',
+      'image/webp',
+      'image/tiff',
+    ];
+
+    // List of common image file extensions
+    const imageExtensions = [
+      '.jpg',
+      '.jpeg',
+      '.png',
+      '.gif',
+      '.bmp',
+      '.webp',
+      '.tiff',
+    ];
+
+    // Check if the MIME type is in the list, considering null
+    if (imageMimeTypes.contains(mimeType)) {
+      return true;
+    }
+
+    // Check if the file name ends with an image extension
+    for (final ext in imageExtensions) {
+      if (name.toLowerCase().endsWith(ext)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   Future<String?> downloadFile(BuildContext context) async {
     if (PlatformInfos.isWeb) {
       return await downloadFileInWeb(context);

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/hero_page_route.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_avif/flutter_avif.dart';
 import 'package:http/http.dart' as http;
@@ -268,7 +269,7 @@ class _MxcImageState extends State<MxcImage> {
       widget.placeholder?.call(context) ??
       const Center(
         key: Key(placeholderKey),
-        child: CircularProgressIndicator.adaptive(),
+        child: CupertinoActivityIndicator(),
       );
 
   @override

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/utils/extension/mime_type_extension.dart';
 import 'package:fluffychat/utils/interactive_viewer_gallery.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/hero_page_route.dart';
 import 'package:flutter/material.dart';
@@ -189,6 +190,7 @@ class _MxcImageState extends State<MxcImage> {
           final fileInfo = await event.getFileInfo(
             getThumbnail: widget.isThumbnail,
           );
+          Logs().d('MxcImage::Downloaded get file info = $fileInfo');
           if (fileInfo != null && fileInfo.filePath.isNotEmpty) {
             filePath = fileInfo.filePath;
             return;
@@ -198,7 +200,11 @@ class _MxcImageState extends State<MxcImage> {
         final matrixFile = await event.downloadAndDecryptAttachment(
           getThumbnail: widget.isThumbnail,
         );
+        Logs().d(
+          'MxcImage::Downloaded attachment name = ${matrixFile.name} - mimeType = ${matrixFile.mimeType} - bytes = ${matrixFile.bytes?.length}',
+        );
         if (!mounted) return;
+        if (!matrixFile.isImage()) return;
         _imageData = matrixFile.bytes;
         return;
       } catch (e) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1861,7 +1861,7 @@ packages:
     description:
       path: "."
       ref: "twake-supported-0.22.6"
-      resolved-ref: fd3e5bdee26ff46c148381a30887e85450d790b2
+      resolved-ref: dffd31d096174703de7c061fc7ff0ae6250c111a
       url: "git@github.com:linagora/matrix-dart-sdk.git"
     source: git
     version: "0.22.6"
@@ -1870,7 +1870,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "9353b6d6b6c1b9cc9e9a9290ffd0c777c6a0b479"
+      resolved-ref: "0546d46d2f0fa9278cab29f5d95c02627374c50b"
       url: "https://github.com/linagora/dart_matrix_api_lite.git"
     source: git
     version: "1.7.4"
@@ -3227,10 +3227,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.4"
+    version: "14.2.5"
   volume_controller:
     dependency: transitive
     description:

--- a/test/utils/matrix_sdk_extensions/matrix_file_extension_test.dart
+++ b/test/utils/matrix_sdk_extensions/matrix_file_extension_test.dart
@@ -1,0 +1,45 @@
+import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart'; // Adjust based on where MatrixFile is defined
+
+void main() {
+  group('MatrixFileExtension', () {
+    test('should return true for valid image MIME type', () {
+      final file = MatrixFile(name: 'image.jpg', mimeType: 'image/jpeg');
+      expect(file.isImage(), isTrue);
+    });
+
+    test('should return true for valid image file extension', () {
+      final file = MatrixFile(name: 'image.png', mimeType: null);
+      expect(file.isImage(), isTrue);
+    });
+
+    test(
+        'should return true for valid image file extension with null MIME type',
+        () {
+      final file = MatrixFile(name: 'image.gif', mimeType: null);
+      expect(file.isImage(), isTrue);
+    });
+
+    test('should return false for non-image MIME type', () {
+      final file =
+          MatrixFile(name: 'document.pdf', mimeType: 'application/pdf');
+      expect(file.isImage(), isFalse);
+    });
+
+    test('should return false for non-image file extension', () {
+      final file = MatrixFile(name: 'document.txt', mimeType: null);
+      expect(file.isImage(), isFalse);
+    });
+
+    test('should return false for file with no extension', () {
+      final file = MatrixFile(name: 'file_without_extension', mimeType: null);
+      expect(file.isImage(), isFalse);
+    });
+
+    test('should return false for empty file name', () {
+      final file = MatrixFile(name: '', mimeType: null);
+      expect(file.isImage(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
### Root cause
- thumbnail information wrong, but app put the video into preview image for this video
- media uri API endpoint deprecated from spec v1.11 

https://github.com/user-attachments/assets/791abd46-c451-489f-80c2-271dcb588e7f

