### PR TITLE
TW-2402: Automatically jump to the latest message after go to search result

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1897,7 +1897,7 @@ class ChatController extends State<Chat>
         ? currentLocation.substring(0, queryIndex)
         : currentLocation;
     Logs().d("Chat::_resetLocationPath: New - $newLocation");
-    html.window.location.href = newLocation;
+    html.window.history.replaceState(null, '', newLocation);
   }
 
   void handlePopBackFromPinnedScreen(Object? popResult) async {


### PR DESCRIPTION
## Ticket

- #2402 

## Root cause

Setting `html.window.location.href = newLocation;` 

- In a Flutter web app causes a full page reload (hard navigation), because it instructs the browser to navigate to a new URL, reloading the entire app

## Solution

- Remove old logic and use the `replaceState()` method of the [History](https://developer.mozilla.org/en-US/docs/Web/API/History) interface modifies the current history entry, replacing it with the state object and URL passed in the method parameters. This method is particularly useful when you want to update the state object or URL of the current history entry in response to some user action.

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/user-attachments/assets/15d9b6e2-9b83-4b13-81bd-2089d27e41f3

