### PR TITLE
HOTFIX Duplicate member on load more

### DIFF
--- a/lib/presentation/mixins/chat_details_tab_mixin.dart
+++ b/lib/presentation/mixins/chat_details_tab_mixin.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_page_view/chat_details_members_page.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_page_view/chat_details_page_enum.dart';
@@ -117,24 +118,15 @@ mixin ChatDetailsTabMixin<T extends StatefulWidget>
 
   void _requestMoreMembersAction() async {
     final currentMembersCount = _displayMembersNotifier.value?.length ?? 0;
-    _currentMembersCount += _membersPerPage;
-
     final members = _membersNotifier.value;
-    if (members != null && currentMembersCount < members.length) {
-      final endIndex = _currentMembersCount > members.length
-          ? members.length
-          : _currentMembersCount;
-      final newMembers = members.sublist(currentMembersCount, endIndex);
-      _displayMembersNotifier.value = [
-        ...?_displayMembersNotifier.value,
-        ...newMembers,
-      ];
-    } else {
-      _displayMembersNotifier.value = [
-        ...?_displayMembersNotifier.value,
-        ...?members,
-      ];
+    if (members == null || currentMembersCount >= members.length) return;
+
+    if (_currentMembersCount < members.length) {
+      _currentMembersCount += _membersPerPage;
     }
+
+    final endIndex = min(_currentMembersCount, members.length);
+    _displayMembersNotifier.value = members.sublist(0, endIndex);
   }
 
   void _initDisplayMembers() {


### PR DESCRIPTION
## Issue

https://github.com/user-attachments/assets/1a92c32f-10b5-4034-b79b-a5c64858cb41

## Root cause
- Improper handling when click load more after adding member to group chat

## Resolved

https://github.com/user-attachments/assets/97f2bf8e-abd1-488e-ad8f-fd8006f85c5b
