### PR TITLE
Allow users be removed by swiping left

### DIFF
--- a/lib/pages/chat_details/participant_list_item/participant_list_item.dart
+++ b/lib/pages/chat_details/participant_list_item/participant_list_item.dart
@@ -38,26 +38,29 @@ class ParticipantListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final child = Opacity(
-      opacity: member.membership == Membership.join ? 1 : 0.5,
-      child: TwakeInkWell(
-        onTap: () async => await _onItemTap(context),
-        onLongPress: () => onSelectMember?.call(member),
-        child: TwakeListItem(
-          height: 72,
-          padding: const EdgeInsets.all(8),
-          child: Row(
-            children: [
-              _ParticipantSelectionToggleButton(
-                selectionMode: selectionMode,
-                onTap: () => onSelectMember?.call(member),
-              ),
-              Avatar(
+    final child = TwakeInkWell(
+      onTap: () async => await _onItemTap(context),
+      onLongPress: () => onSelectMember?.call(member),
+      child: TwakeListItem(
+        height: 72,
+        padding: const EdgeInsets.all(8),
+        child: Row(
+          children: [
+            _ParticipantSelectionToggleButton(
+              selectionMode: selectionMode,
+              onTap: () => onSelectMember?.call(member),
+            ),
+            Opacity(
+              opacity: member.membership == Membership.join ? 1 : 0.5,
+              child: Avatar(
                 mxContent: member.avatarUrl,
                 name: member.calcDisplayname(),
               ),
-              const SizedBox(width: 8.0),
-              Expanded(
+            ),
+            const SizedBox(width: 8.0),
+            Expanded(
+              child: Opacity(
+                opacity: member.membership == Membership.join ? 1 : 0.5,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -105,8 +108,8 @@ class ParticipantListItem extends StatelessWidget {
                   ],
                 ),
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Ticket
- https://www.notion.so/linagora/Mobile-swipe-left-to-REMOVE-member-from-chat-22262718bad1806aa457ffadad3d821d
- https://www.notion.so/linagora/Mobile-Toast-when-user-tries-to-remove-more-powerful-member-from-chat-22262718bad180109d30ee6a6b3270aa

## Pre-merge
- https://github.com/linagora/twake-on-matrix/pull/2448

## Resolved
### Swipe

https://github.com/user-attachments/assets/f3159a89-3730-444f-a30a-f572a1199afc

### Toast when long press

https://github.com/user-attachments/assets/4fb4ef7a-1fdb-4f23-b7cf-eec6e712c45a

### Toast when swipe

https://github.com/user-attachments/assets/f6ae291c-c4c1-4e04-859e-fad8ed7fc7f1

