### PR TITLE
Simplify web setup related to libolm

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,19 +73,8 @@ flutter doctor -v
 
 If you only plan to work on the `web` target we recommend installing Google Chrome as it is the default supported target *(Flutter being developped by Google)*.
 
-It is also **required** to have a web ready version of libolm available in the `assets/js/package` folder. You can build a version using:
+It is also **required** to have a web ready version of libolm available in the `assets/js/package` folder. You can download it [here](https://gitlab.matrix.org/matrix-org/olm/-/packages/2190) and copy olm.js and olm.wasm in `assets/js/package`.
 
-```bash
-docker run -v ./assets/js/package:/package nixos/nix:2.22.1
-
-# within the docker
-nix build -v --extra-experimental-features flakes --extra-experimental-features nix-command gitlab:matrix-org/olm/3.2.16?host=gitlab.matrix.org\#javascript
-cp /result/javascript/* /package/. -v
-exit
-
-# back on your host
-sudo chown $(id -u):$(id -g) ./assets/js/package -Rv
-```
 #### Android
 
 - [ ] An implementation of JDK 17 *(tested with openjdk-17.0.13+11)*


### PR DESCRIPTION
During a setup of Twake Chat for web, I ran into the section about libolm.

It seems to be working when downloading olm.js and olm.wasm from here https://gitlab.matrix.org/matrix-org/olm/-/packages/2190 instead of building it with Docker. 

Why do you think ? It seems a lot simpler for me to setup, but I lack the necessary background and maybe it will not work everywhere/everytime ?