### PR TITLE
TW-2516 Handle Android navigation buttons cover chat input

### DIFF
--- a/lib/pages/chat/chat_input_row.dart
+++ b/lib/pages/chat/chat_input_row.dart
@@ -4,6 +4,7 @@ import 'package:fluffychat/pages/chat/chat_input_row_style.dart';
 import 'package:fluffychat/pages/chat/chat_input_row_web.dart';
 import 'package:fluffychat/pages/chat/reply_display.dart';
 import 'package:fluffychat/resource/image_paths.dart';
+import 'package:fluffychat/utils/android_utils.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -76,18 +77,15 @@ class ChatInputRow extends StatelessWidget {
           ),
         );
 
-        if (isAndroidNavigationButtonsEnabled(context)) {
+        if (AndroidUtils.isNavigationButtonsEnabled(
+          systemGestureInsets: MediaQuery.systemGestureInsetsOf(context),
+        )) {
           return SafeArea(child: child);
         }
 
         return child;
       },
     );
-  }
-
-  bool isAndroidNavigationButtonsEnabled(BuildContext context) {
-    return PlatformInfos.isAndroid &&
-        MediaQuery.systemGestureInsetsOf(context).left == 0;
   }
 
   EdgeInsetsGeometry _paddingInputRow({
@@ -98,7 +96,10 @@ class ChatInputRow extends StatelessWidget {
       return EdgeInsets.zero;
     }
 
-    if (isKeyboardVisible || isAndroidNavigationButtonsEnabled(context)) {
+    if (isKeyboardVisible ||
+        AndroidUtils.isNavigationButtonsEnabled(
+          systemGestureInsets: MediaQuery.systemGestureInsetsOf(context),
+        )) {
       return EdgeInsets.zero;
     }
     return const EdgeInsets.only(

--- a/lib/utils/android_utils.dart
+++ b/lib/utils/android_utils.dart
@@ -1,0 +1,12 @@
+import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:flutter/widgets.dart';
+
+class AndroidUtils {
+  const AndroidUtils._();
+
+  static bool isNavigationButtonsEnabled({
+    required EdgeInsets systemGestureInsets,
+  }) {
+    return PlatformInfos.isAndroid && systemGestureInsets.left == 0;
+  }
+}

--- a/lib/utils/responsive/responsive_utils.dart
+++ b/lib/utils/responsive/responsive_utils.dart
@@ -19,7 +19,8 @@ class ResponsiveUtils {
 
   static const double defaultSizeBodyLayoutDesktop = 280;
   static const double heightBottomNavigation = 72;
-  static const double heightBottomNavigationBar = 48;
+  static const double
+      heightBottomNavigationWhenAndroidNavigationButtonsEnabled = 64;
 
   static const double bodyWithRightColumnRatio = 0.64;
   static const double groupDetailsMinWidth = 370;

--- a/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body_view.dart
+++ b/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body_view.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat_list/chat_list.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_tab.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings/settings.dart';
+import 'package:fluffychat/utils/android_utils.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/layouts/adaptive_layout/adaptive_scaffold_primary_navigation.dart';
 import 'package:fluffychat/widgets/layouts/adaptive_layout/adaptive_scaffold_view_style.dart';
@@ -216,7 +217,7 @@ class _ColumnPageView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PageView(
+    final child = PageView(
       controller: pageController,
       physics: const NeverScrollableScrollPhysics(),
       children: [
@@ -243,6 +244,14 @@ class _ColumnPageView extends StatelessWidget {
         ),
       ],
     );
+
+    if (AndroidUtils.isNavigationButtonsEnabled(
+      systemGestureInsets: MediaQuery.systemGestureInsetsOf(context),
+    )) {
+      return SafeArea(child: child);
+    }
+
+    return child;
   }
 
   Widget _triggerPageViewBuilder({
@@ -270,7 +279,9 @@ class _ColumnPageView extends StatelessWidget {
           builder: (_) {
             return Container(
               decoration: AppAdaptiveScaffoldBodyViewStyle.navBarBorder,
-              height: ResponsiveUtils.heightBottomNavigation,
+              height: _bottomNavBarHeight(
+                MediaQuery.systemGestureInsetsOf(context),
+              ),
               padding: AppAdaptiveScaffoldBodyViewStyle.paddingBottomNavigation,
               child: ListView(
                 physics: const NeverScrollableScrollPhysics(),
@@ -294,6 +305,16 @@ class _ColumnPageView extends StatelessWidget {
         ),
       },
     );
+  }
+
+  double _bottomNavBarHeight(EdgeInsets systemGestureInsets) {
+    if (AndroidUtils.isNavigationButtonsEnabled(
+      systemGestureInsets: systemGestureInsets,
+    )) {
+      return ResponsiveUtils
+          .heightBottomNavigationWhenAndroidNavigationButtonsEnabled;
+    }
+    return ResponsiveUtils.heightBottomNavigation;
   }
 
   List<NavigationDestination> getNavigationDestinations(BuildContext context) {


### PR DESCRIPTION
## Ticket
- #2516 

## Resolved
- Web:
<img width="4064" height="2384" alt="web" src="https://github.com/user-attachments/assets/9f135afd-db34-4fa4-b44a-fb92fb8ebab5" />

- Android:

[android.webm](https://github.com/user-attachments/assets/22a399f9-316c-4e94-9a39-561e963781ab)

- IOS:

https://github.com/user-attachments/assets/5cfbd9b1-1aca-46df-a664-3bc63202d79b

