### PR TITLE
TW-2522 Fix cannot receive shared media when app terminated

### DIFF
--- a/lib/pages/chat_list/receive_sharing_intent_mixin.dart
+++ b/lib/pages/chat_list/receive_sharing_intent_mixin.dart
@@ -122,13 +122,6 @@ mixin ReceiveSharingIntentMixin<T extends StatefulWidget> on State<T> {
       onError: print,
     );
 
-    // For sharing images coming from outside the app while the app is closed
-    ReceiveSharingIntent.instance.getInitialMedia().then((value) {
-      _clearPendingSharedFiles();
-      _processIncomingSharedFiles(value);
-      ReceiveSharingIntent.instance.reset();
-    });
-
     // For receiving shared Uris
     final appLinks = AppLinks();
     intentUriStreamSubscription =
@@ -138,5 +131,16 @@ mixin ReceiveSharingIntentMixin<T extends StatefulWidget> on State<T> {
       TwakeApp.gotInitialLink = true;
       appLinks.getInitialLinkString().then(_processIncomingUris);
     }
+  }
+
+  Future<void> checkInitialSharingMedia() async {
+    if (!PlatformInfos.isMobile) return;
+
+    // For sharing images coming from outside the app while the app is closed
+    await ReceiveSharingIntent.instance.getInitialMedia().then((value) {
+      _clearPendingSharedFiles();
+      _processIncomingSharedFiles(value);
+      ReceiveSharingIntent.instance.reset();
+    });
   }
 }

--- a/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body.dart
+++ b/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body.dart
@@ -164,6 +164,7 @@ class AppAdaptiveScaffoldBodyController extends State<AppAdaptiveScaffoldBody>
     super.initState();
     activeRoomIdNotifier.value = widget.activeRoomId;
     resetLocationPathWithLoginToken();
+    matrix.checkInitialSharingMedia();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (mounted) {
         await matrix.retrievePersistedActiveClient();


### PR DESCRIPTION
## Ticket
- #2522 

## Root cause
https://github.com/linagora/twake-on-matrix/blob/c8d25d8e482e09cb537aae23ed4d8e2b567ca70f/lib/pages/chat_list/receive_sharing_intent_mixin.dart#L58-L60

When the app is terminated and gets waken up by other apps, the sharing logic stops at these lines

## Solution
Get the initial sharing data AFTER user's already logged in.

## Resolved
- Android:

[sharing-android.webm](https://github.com/user-attachments/assets/97ca951d-6633-4ba9-8f87-aea460fd74b3)

- IOS:

https://github.com/user-attachments/assets/095a061b-b241-4866-a2fb-a9c1bab00e14

