### PR TITLE
TW-2608: Fix avatar of Deleted message was not display when config was not turned on

### DIFF
--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -155,7 +155,6 @@ extension LocalizedBody on Event {
       EventTypes.Message,
       EventTypes.Sticker,
       EventTypes.Encrypted,
-      EventTypes.Redaction,
     }.contains(comparedEvent.type);
 
     final isPreviousOrNextEventRedacted = {


### PR DESCRIPTION
## Ticket

- #2608 

## Resolved
**Attach screenshots or videos demonstrating the changes**

https://github.com/user-attachments/assets/57246362-0994-4b93-a342-cd094bff9564

