### PR TITLE
TW-2674 Update message status when sent with error

### DIFF
--- a/lib/pages/chat/seen_by_row.dart
+++ b/lib/pages/chat/seen_by_row.dart
@@ -39,12 +39,12 @@ class SeenByRow extends StatelessWidget {
     List<User> seenByUsers, {
     EventStatus? eventStatus,
   }) {
-    if (eventStatus == null || eventStatus == EventStatus.sending) {
-      return MessageStatus.sending;
-    }
-
     if (eventStatus == EventStatus.error) {
       return MessageStatus.error;
+    }
+
+    if (eventStatus == null || eventStatus == EventStatus.sending) {
+      return MessageStatus.sending;
     }
 
     if (eventStatus == EventStatus.sent || seenByUsers.isEmpty) {


### PR DESCRIPTION
## Ticket
- #2674 

## Root cause
https://github.com/linagora/twake-on-matrix/blob/c12283c9de15b2975fadd3ed751cc64c6e525b84/lib/pages/chat/seen_by_row.dart#L50-L52
When sending message with error, `seenByUsers.isEmpty` is `true`

## Solution
https://github.com/linagora/twake-on-matrix/blob/c12283c9de15b2975fadd3ed751cc64c6e525b84/lib/pages/chat/seen_by_row.dart#L46-L48
Put this condition higher

## Resolved
<img width="1290" height="2796" alt="Simulator Screenshot - iPhone 16 Plus - 2025-11-13 at 11 14 33" src="https://github.com/user-attachments/assets/2f72b0bf-6b20-4bbc-87ac-d1662f41b49d" />
