### PR TITLE
Bump version 2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## [2.16.0+2330] - 2025-11-25
+### Added
+- #2679 Caption for files
+- #2667 Show events when create new chat (#2678)
+- #2635 Add typing timer to receiver
+- #2649: Add ability to copy text from Display name/group chat name (#2650)
+- [E2E Test] Un pin and pin chat (#2645)
+
+### Changed
+- #2681: Update notification management fonts for improved readability
+- #2660: Improve invite more than ten members when creating a group chat (#2661)
+- #2646: Improve QR code display for new users without active chat rooms (#2647)
+- #2652: Update layout in contact creation modal
+- #2655: Show user info into profile views of user
+- #2622 Support real time update contact in chat
+- #2663 Handle add 10 or more members to chat
+- Improve context menu display for small screens in message content (#2673)
+- Cache last events for faster load speed
+- Load last events from parent
+- Add loading when sorting rooms
+- Separate sort loading from syncStatus loading
+- Increase sort loading size
+- Better hide reacted event handling
+- Remove recent chat in Share and Forward view
+- Remove unused code, Try catch init settings
+
+### Fixed
+- #2674 Update message status when sent with error (#2675)
+- #2665 Fix select message jump to bottom
+- #2628 Handle scroll jump after load more future events (#2629)
+- TW #2076 Prevent forever loop when not found event in timeline (#2624)
+- #2631: Fix wrong image is sent when you share from your gallery by Twake
+- #2630 Fix Firefox has to paste twice
+- HOTFIX Fail invite dialog web
+- HOTFIX Sort loading notifier exception
+- HOTFIX GH Action pages deploy (#2671)
+
 ## [2.14.3+2330] - 2025-10-28
 ### Fixed
 - #2626 Send caption with other file in separate message bubble 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.14.3+2330
+version: 2.16.0+2330
 
 environment:
   sdk: ">=3.3.0 <4.0.0"


### PR DESCRIPTION
## [2.16.0+2330] - 2025-11-25
### Added
- #2667 Show events when create new chat (#2678)
- #2635 Add typing timer to receiver
- #2649: Add ability to copy text from Display name/group chat name (#2650)
- [E2E Test] Un pin and pin chat (#2645)

### Changed
- #2681: Update notification management fonts for improved readability
- #2660: Improve invite more than ten members when creating a group chat (#2661)
- #2646: Improve QR code display for new users without active chat rooms (#2647)
- #2652: Update layout in contact creation modal
- #2655: Show user info into profile views of user
- #2622 Support real time update contact in chat
- #2663 Handle add 10 or more members to chat
- Improve context menu display for small screens in message content (#2673)
- Cache last events for faster load speed
- Load last events from parent
- Add loading when sorting rooms
- Separate sort loading from syncStatus loading
- Increase sort loading size
- Better hide reacted event handling
- Remove recent chat in Share and Forward view
- Remove unused code, Try catch init settings

### Fixed
- #2674 Update message status when sent with error (#2675)
- #2665 Fix select message jump to bottom
- #2628 Handle scroll jump after load more future events (#2629)
- TW #2076 Prevent forever loop when not found event in timeline (#2624)
- #2631: Fix wrong image is sent when you share from your gallery by Twake
- #2630 Fix Firefox has to paste twice
- HOTFIX Fail invite dialog web
- HOTFIX Sort loading notifier exception
- HOTFIX GH Action pages deploy (#2671)