### PR TITLE
TW-2695: Fix notification badge display logic to handle race conditions

### DIFF
--- a/lib/pages/chat_list/chat_list_item_style.dart
+++ b/lib/pages/chat_list/chat_list_item_style.dart
@@ -53,12 +53,26 @@ class ChatListItemStyle {
     bool hasNewMessages,
     int notificationCount,
   ) {
-    return notificationCount == 0 && !unread && !hasNewMessages
-        ? 0
-        : (unreadBadgeSize(unread, hasNewMessages, notificationCount > 0) -
-                    unreadBadgePaddingWhenMoreThanOne) *
-                notificationCount.toString().length +
-            unreadBadgePaddingWhenMoreThanOne;
+    // No badge if no new messages and not marked unread
+    if (!hasNewMessages && !unread) {
+      return 0;
+    }
+
+    // If there's a notification count, calculate badge size for the number
+    if (notificationCount > 0) {
+      return (unreadBadgeSize(unread, hasNewMessages, true) -
+                  unreadBadgePaddingWhenMoreThanOne) *
+              notificationCount.toString().length +
+          unreadBadgePaddingWhenMoreThanOne;
+    }
+
+    // If has new messages but no notification count (e.g., mentions-only room with regular messages)
+    // or marked unread, show small badge (14.0 size, no number)
+    if (hasNewMessages || unread) {
+      return unreadBadgeSize(unread, hasNewMessages, false);
+    }
+
+    return 0;
   }
 
   static const double letterSpaceDisplayName = 0.15;

--- a/lib/presentation/mixins/chat_list_item_mixin.dart
+++ b/lib/presentation/mixins/chat_list_item_mixin.dart
@@ -230,7 +230,21 @@ mixin ChatListItemMixin {
   }
 
   bool hasNewMessage(Room room) {
-    return room.notificationCount > 0 || room.hasNewMessages;
+    // If there's a notification count, definitely has new messages
+    if (room.notificationCount > 0) {
+      return true;
+    }
+
+    // For mentions-only rooms, check hasNewMessages
+    // This is important because they won't increment notificationCount for regular messages
+    if (room.pushRuleState == PushRuleState.mentionsOnly &&
+        room.hasNewMessages) {
+      return true;
+    }
+
+    // For notify rooms, only trust notificationCount to avoid race conditions
+    // Don't use hasNewMessages as it can lag behind the actual read state
+    return false;
   }
 
   Color? _handleNotificationColorHasNewMessage(

--- a/test/mixin/chat/chat_list_item_mixin_test.dart
+++ b/test/mixin/chat/chat_list_item_mixin_test.dart
@@ -121,6 +121,10 @@ void main() {
       ) async {
         when(room.pushRuleState).thenReturn(PushRuleState.mentionsOnly);
         when(room.hasNewMessages).thenReturn(true);
+        when(room.notificationCount).thenReturn(0);
+        when(room.highlightCount).thenReturn(0);
+        when(room.markedUnread).thenReturn(false);
+        when(room.membership).thenReturn(Membership.join);
 
         final color = chatListItemMixinTest.notificationColor(
           context: context,
@@ -128,6 +132,27 @@ void main() {
         );
 
         expect(color, LinagoraRefColors.material().tertiary[30]);
+      });
+
+      testWidgets(
+          'WHEN has new message but no notification count\n'
+          'AND pushRuleState is notify\n'
+          'THEN color should be transparent (race condition)\n', (
+        WidgetTester tester,
+      ) async {
+        when(room.pushRuleState).thenReturn(PushRuleState.notify);
+        when(room.hasNewMessages).thenReturn(true);
+        when(room.notificationCount).thenReturn(0);
+        when(room.highlightCount).thenReturn(0);
+        when(room.markedUnread).thenReturn(false);
+        when(room.membership).thenReturn(Membership.join);
+
+        final color = chatListItemMixinTest.notificationColor(
+          context: context,
+          room: room,
+        );
+
+        expect(color, Colors.transparent);
       });
     });
 


### PR DESCRIPTION
## Ticket
- #2695 

### `hasNewMessage`  Expected Behavior 

| Case | pushRuleState | notificationCount | hasNewMessages | Returns | Reason |
|------|----------------|-------------------|----------------|---------|--------|
| **1. Notify room with unread messages** | `notify` | > 0 | true  | **true**  | Standard unread messages with notifications |
| **2. Notify room, fully read**          | `notify` | 0   | false | **false** | Room is completely read |
| **3. Notify room, race condition**      | `notify` | 0   | true  | **false** | Prevents badge during receipt sync lag |
| **4. Mentions-only with mentions**      | `mentionsOnly` | > 0 | true | **true** | User was mentioned/highlighted |
| **5. Mentions-only with regular messages** | `mentionsOnly` | 0 | true | **true** | Key case: Shows badge for unread non-mention messages |
| **6. Mentions-only, fully read**        | `mentionsOnly` | 0 | false | **false** | No unread messages |
| **7. Muted room with messages**         | `dontNotify` | 0 | varies | **false** | Never shows badge for fully muted rooms |
| **8. Marked unread (any state)**        | any | 0 | false | **false** | Handled separately via `room.markedUnread` |


## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

https://github.com/user-attachments/assets/eb32a872-cd0d-4d76-9ff9-631d7e4e53a2

