### PR TITLE
TW #2739 Remove unnecessary /sync calling

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1061,17 +1061,8 @@ class MatrixState extends State<Matrix>
         state != AppLifecycleState.paused;
     client.backgroundSync = foreground;
     client.syncPresence = foreground ? null : PresenceType.unavailable;
-    trySyncClient();
     client.requestHistoryOnLimitedTimeline = !foreground;
     backgroundPush?.clearAllNotifications();
-  }
-
-  Future<void> trySyncClient() async {
-    try {
-      await client.sync(setPresence: client.syncPresence);
-    } catch (e) {
-      Logs().e('MatrixState::trySyncClient: error - $e');
-    }
   }
 
   Future<void> initSettings() async {


### PR DESCRIPTION
### Desc:
- `tryClientSync` use for trigger quickly `setPresent`, but it is too expensive to call it whenever change app app state