### PR TITLE
TW-2739: Fix duplicate /sync calls - Option A (wait for existing sync)

### DIFF
--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -538,12 +538,15 @@ class BackgroundPush {
         Logs().v('[Push] Got new clearing push');
         var syncErrored = false;
         if (client.syncPending) {
-          Logs().v('[Push] waiting for existing sync');
-          // we need to catchError here as the Future might be in a different execution zone
-          await client.oneShotSync().catchError((e) {
+          Logs().v('[Push] waiting for existing sync to complete');
+          try {
+            await client.onSync.stream.first.timeout(
+              const Duration(seconds: 30),
+            );
+          } catch (e) {
+            Logs().v('[Push] Error waiting for sync', e);
             syncErrored = true;
-            Logs().v('[Push] Error one-shot syncing', e);
-          });
+          }
         }
         if (!syncErrored) {
           Logs().v('[Push] single oneShotSync');


### PR DESCRIPTION
## Summary
- Fixes #2739
- **Option A**: Wait for existing sync to complete before triggering a new one
- Replaces the first `oneShotSync()` call with `onSync.stream.first.timeout()` to actually wait for an existing sync

## Problem
The code was calling `oneShotSync()` twice when `syncPending` was true:
1. First call was supposed to "wait for existing sync" but actually triggered a NEW sync
2. Second call triggered another sync

This resulted in duplicate `/sync` calls visible in DevTools.

## Solution
Replace the first `oneShotSync()` with `client.onSync.stream.first.timeout()` which properly waits for the current sync to complete.

## Test plan
- [ ] Trigger a push notification during an ongoing sync
- [ ] Verify in DevTools that only ONE `/sync` call is made
- [ ] Verify events are correctly received
- [ ] Test behavior when `syncPending = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background synchronization reliability with enhanced timeout handling and error recovery to ensure sync operations complete properly or fail gracefully.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->