### PR TITLE
TW-2739: Fix duplicate /sync calls - Option B (single sync only)

### DIFF
--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -537,26 +537,16 @@ class BackgroundPush {
       if (getFromServer) {
         Logs().v('[Push] Got new clearing push');
         var syncErrored = false;
-        if (client.syncPending) {
-          Logs().v('[Push] waiting for existing sync');
-          // we need to catchError here as the Future might be in a different execution zone
-          await client.oneShotSync().catchError((e) {
-            syncErrored = true;
-            Logs().v('[Push] Error one-shot syncing', e);
-          });
-        }
+        Logs().v('[Push] single oneShotSync');
+        // we need to catchError here as the Future might be in a different execution zone
+        await client.oneShotSync().catchError((e) {
+          syncErrored = true;
+          Logs().v('[Push] Error one-shot syncing', e);
+        });
         if (!syncErrored) {
-          Logs().v('[Push] single oneShotSync');
-          // we need to catchError here as the Future might be in a different execution zone
-          await client.oneShotSync().catchError((e) {
-            syncErrored = true;
-            Logs().v('[Push] Error one-shot syncing', e);
-          });
-          if (!syncErrored) {
-            emptyRooms = client.rooms
-                .where((r) => r.notificationCount == 0)
-                .map((r) => r.id);
-          }
+          emptyRooms = client.rooms
+              .where((r) => r.notificationCount == 0)
+              .map((r) => r.id);
         }
         if (syncErrored) {
           try {


### PR DESCRIPTION
## Summary
- Fixes #2739
- **Option B**: Remove syncPending check and do a single oneShotSync()
- Simplest approach - let the SDK handle sync coordination

## Problem
The code was calling `oneShotSync()` twice when `syncPending` was true:
1. First call was supposed to "wait for existing sync" but actually triggered a NEW sync
2. Second call triggered another sync

This resulted in duplicate `/sync` calls visible in DevTools.

## Solution
Remove the `if (client.syncPending)` block entirely and just do one `oneShotSync()`.
The Matrix SDK handles sync coordination internally via the `prevBatch` token.

## Test plan
- [ ] Trigger a push notification during an ongoing sync
- [ ] Verify in DevTools that only ONE `/sync` call is made
- [ ] Verify events are correctly received
- [ ] Test behavior when `syncPending = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized background sync logic to improve performance and reliability by streamlining synchronization operations and enhancing error handling pathways.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->