### PR TITLE
TW-2739: Fix duplicate /sync calls - Option C (remove syncPending block)

### DIFF
--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -537,26 +537,16 @@ class BackgroundPush {
       if (getFromServer) {
         Logs().v('[Push] Got new clearing push');
         var syncErrored = false;
-        if (client.syncPending) {
-          Logs().v('[Push] waiting for existing sync');
-          // we need to catchError here as the Future might be in a different execution zone
-          await client.oneShotSync().catchError((e) {
-            syncErrored = true;
-            Logs().v('[Push] Error one-shot syncing', e);
-          });
-        }
+        Logs().v('[Push] single oneShotSync');
+        // we need to catchError here as the Future might be in a different execution zone
+        await client.oneShotSync().catchError((e) {
+          syncErrored = true;
+          Logs().v('[Push] Error one-shot syncing', e);
+        });
         if (!syncErrored) {
-          Logs().v('[Push] single oneShotSync');
-          // we need to catchError here as the Future might be in a different execution zone
-          await client.oneShotSync().catchError((e) {
-            syncErrored = true;
-            Logs().v('[Push] Error one-shot syncing', e);
-          });
-          if (!syncErrored) {
-            emptyRooms = client.rooms
-                .where((r) => r.notificationCount == 0)
-                .map((r) => r.id);
-          }
+          emptyRooms = client.rooms
+              .where((r) => r.notificationCount == 0)
+              .map((r) => r.id);
         }
         if (syncErrored) {
           try {


### PR DESCRIPTION
## Summary
- Fixes #2739
- **Option C**: Completely remove the redundant syncPending check block
- This option emphasizes that the entire check was flawed and should be removed

## Problem
The code was calling `oneShotSync()` twice when `syncPending` was true:
1. First call was supposed to "wait for existing sync" but actually triggered a NEW sync
2. Second call triggered another sync

This resulted in duplicate `/sync` calls visible in DevTools.

## Solution
Remove the entire `if (client.syncPending)` block as it was:
1. Not doing what the comment said (waiting for existing sync)
2. Actually making the problem worse by triggering additional syncs
3. Redundant because the SDK handles sync coordination internally

## Note
This is functionally identical to Option B, but presented as "removing broken code" rather than "simplifying logic".

## Test plan
- [ ] Trigger a push notification during an ongoing sync
- [ ] Verify in DevTools that only ONE `/sync` call is made
- [ ] Verify events are correctly received
- [ ] Test behavior when `syncPending = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized the background synchronization process by eliminating redundant operations and streamlining the control flow. This improves sync efficiency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->