### PR TITLE
HOTFIX Empty message bubble

### DIFF
--- a/lib/pages/chat/events/message/message_content_builder_mixin.dart
+++ b/lib/pages/chat/events/message/message_content_builder_mixin.dart
@@ -49,10 +49,7 @@ mixin MessageContentBuilderMixin {
         _getMessageMetrics(context, event, maxWidth, isEdited: isEdited);
 
     if (ownMessage || hideDisplayName) {
-      return MessageMetrics(
-        totalMessageWidth: messageMetrics.totalMessageWidth,
-        isNeedAddNewLine: messageMetrics.isNeedAddNewLine,
-      );
+      return messageMetrics;
     }
 
     const rightSpaceDisplayName = 16.0;
@@ -195,6 +192,23 @@ mixin MessageContentBuilderMixin {
         ),
       ),
     );
+
+    // Validate that the text range is not empty to avoid invalid selection
+    if (lastLineRange.start == lastLineRange.end) {
+      // When text range is empty (malformed message), ensure minimum bubble width
+      // Use at least the width needed for timestamp + padding
+      final minContentWidth = messageTimeAndPaddingWidth;
+      final contentWidth = max(messageTextWidth, minContentWidth);
+      final totalWidth = contentWidth + paddingMessage;
+
+      final totalMessageWidth = totalWidth < maxWidth ? totalWidth : maxWidth;
+
+      return MessageMetrics(
+        totalMessageWidth: totalMessageWidth,
+        isNeedAddNewLine: true,
+      );
+    }
+
     final List<TextBox> lastLineBoxes = paintedMessageText.getBoxesForSelection(
       TextSelection(
         baseOffset: lastLineRange.start,

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -273,7 +273,7 @@ extension LocalizedBody on Event {
   }
 
   bool isDisplayOnlyEmoji() {
-    return onlyEmotes && numberEmotes < 7;
+    return onlyEmotes && numberEmotes > 0 && numberEmotes < 7;
   }
 
   TextStyle? textStyleForOnlyEmoji(BuildContext context) {


### PR DESCRIPTION
## Ticket
```console
══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
The following assertion was thrown building LayoutBuilder:
Assertion failed:
file:///Users/dangdat/Desktop/dev/flutter/packages/flutter/lib/src/painting/text_painter.dart:1619:12
text_painter.dart:1619
selection.isValid
is not true

The relevant error-causing widget was:
  LayoutBuilder
  LayoutBuilder:file:///Users/dangdat/Desktop/dev/linagora-master/twake-on-matrix/lib/pages/chat/events/message/message_content_builder.dart:36:12

When the exception was thrown, this was the stack:
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 266:3             throw_
errors.dart:266
dart-sdk/lib/_internal/js_dev_runtime/private/profile.dart 117:39                       assertFailed
profile.dart:117
package:flutter/src/painting/text_painter.dart 1619:21                                  getBoxesForSelection
text_painter.dart:1619
package:fluffychat/pages/chat/events/message/message_content_builder_mixin.dart 198:59  [_getMessageMetrics]
message_content_builder_mixin.dart:198
package:fluffychat/pages/chat/events/message/message_content_builder_mixin.dart 49:9    getSizeMessageBubbleWidth
message_content_builder_mixin.dart:49
package:fluffychat/pages/chat/events/message/message_content_builder.dart 46:35
```

## Root cause
Message is empty text

## Resolved
<img width="225" height="98" alt="Screenshot 2025-12-12 at 1 59 29 PM" src="https://github.com/user-attachments/assets/1f2507bb-634d-4709-a06d-c8505b348e9a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message bubble sizing calculations for better accuracy when displaying own messages and when display names are hidden.
  * Fixed emoji-only message detection to properly determine when messages should render as emoji-based content.
  * Enhanced handling of empty or malformed text ranges in message metrics calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->