### PR TITLE
TW-2786 Obtain FQDN from UserInfo for Profile Page Edit Button

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3640,6 +3640,7 @@
   "copyLink": "Copy link",
   "@copyLink": {},
   "downloadQrCode": "Download QR code",
+  "couldNotLaunchUrl": "Could not launch URL",
   "@downloadQrCode": {},
   "promoteToAdmin": "Promote to admin",
   "@promoteToAdmin": {

--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3229,6 +3229,5 @@
     "type": "text",
     "placeholders": {}
   },
-  "couldNotLaunchUrl": "Could not launch URL",
-  "@downloadQrCode": {}
+  "couldNotLaunchUrl": "Could not launch URL"
 }

--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3228,5 +3228,7 @@
   "@videoCallJoinCall": {
     "type": "text",
     "placeholders": {}
-  }
+  },
+  "couldNotLaunchUrl": "Could not launch URL",
+  "@downloadQrCode": {}
 }

--- a/lib/domain/model/user_info/user_info.dart
+++ b/lib/domain/model/user_info/user_info.dart
@@ -20,6 +20,7 @@ class UserInfo extends Equatable {
   final String? firstName;
   @JsonKey(name: 'last_name')
   final String? lastName;
+  final String? workplaceFqdn;
 
   const UserInfo({
     this.uid,
@@ -33,6 +34,7 @@ class UserInfo extends Equatable {
     this.timezone,
     this.firstName,
     this.lastName,
+    this.workplaceFqdn,
   });
 
   factory UserInfo.fromJson(Map<String, dynamic> json) =>
@@ -53,5 +55,6 @@ class UserInfo extends Equatable {
     timezone,
     firstName,
     lastName,
+    workplaceFqdn,
   ];
 }

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
@@ -686,10 +686,11 @@ class SettingsProfileController extends State<SettingsProfile>
   @override
   Widget build(BuildContext context) {
     return SettingsProfileCapabilityCheck(
-      builder: (capabilities, _) {
+      builder: (capabilities, userInfo, _) {
         return SettingsProfileView(
           controller: this,
           capabilities: capabilities,
+          userInfo: userInfo,
         );
       },
     );

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
@@ -706,10 +706,11 @@ class SettingsProfileController extends State<SettingsProfile>
   @override
   Widget build(BuildContext context) {
     return SettingsProfileCapabilityCheck(
-      builder: (capabilities, _) {
+      builder: (capabilities, userInfo, _) {
         return SettingsProfileView(
           controller: this,
           capabilities: capabilities,
+          userInfo: userInfo,
         );
       },
     );

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile.dart
@@ -706,6 +706,7 @@ class SettingsProfileController extends State<SettingsProfile>
   @override
   Widget build(BuildContext context) {
     return SettingsProfileCapabilityCheck(
+      userId: client.userID,
       builder: (capabilities, userInfo, _) {
         return SettingsProfileView(
           controller: this,

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_capability_check.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_capability_check.dart
@@ -1,30 +1,55 @@
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/capabilities/get_server_capabilities_state.dart';
+import 'package:fluffychat/domain/app_state/user_info/get_user_info_state.dart';
+import 'package:fluffychat/domain/model/user_info/user_info.dart';
 import 'package:fluffychat/domain/usecase/capabilities/get_server_capabilities_interactor.dart';
+import 'package:fluffychat/domain/usecase/user_info/get_user_info_interactor.dart';
 import 'package:flutter/widgets.dart';
 import 'package:matrix/matrix.dart';
+import 'package:rxdart/rxdart.dart';
 
 class SettingsProfileCapabilityCheck extends StatelessWidget {
   const SettingsProfileCapabilityCheck({
     super.key,
     required this.builder,
     this.child,
+    this.userId,
   });
 
   final Widget? child;
-  final Widget Function(Capabilities? capabilities, Widget? child) builder;
+  final String? userId;
+  final Widget Function(
+    Capabilities? capabilities,
+    UserInfo? userInfo,
+    Widget? child,
+  )
+  builder;
 
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
-      stream: getIt.get<GetServerCapabilitiesInteractor>().execute(),
+      stream: Rx.combineLatest2(
+        getIt.get<GetServerCapabilitiesInteractor>().execute(),
+        getIt.get<GetUserInfoInteractor>().execute(userId: userId),
+        (capabilitiesState, userInfoState) => (
+          capabilitiesState: capabilitiesState,
+          userInfoState: userInfoState,
+        ),
+      ),
       builder: (context, snapshot) {
-        final data = snapshot.data?.fold(
+        final capabilitiesData = snapshot.data?.capabilitiesState.fold(
+          (failure) => failure,
+          (success) => success,
+        );
+        final userInfoData = snapshot.data?.userInfoState.fold(
           (failure) => failure,
           (success) => success,
         );
         return builder(
-          data is GetServerCapabilitiesSuccess ? data.capabilities : null,
+          capabilitiesData is GetServerCapabilitiesSuccess
+              ? capabilitiesData.capabilities
+              : null,
+          userInfoData is GetUserInfoSuccess ? userInfoData.userInfo : null,
           child,
         );
       },

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_view.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_view.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/capabilities/capabilities_extension.dart';
+import 'package:fluffychat/domain/model/user_info/user_info.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_profile/settings_profile.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_profile/settings_profile_item.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_profile/settings_profile_redirection_edit_button.dart';
@@ -21,6 +22,7 @@ import 'package:matrix/matrix.dart';
 class SettingsProfileView extends StatelessWidget {
   final SettingsProfileController controller;
   final Capabilities? capabilities;
+  final UserInfo? userInfo;
 
   static const ValueKey settingsProfileViewMobileKey = ValueKey(
     'settingsProfileViewMobile',
@@ -34,6 +36,7 @@ class SettingsProfileView extends StatelessWidget {
     super.key,
     required this.controller,
     required this.capabilities,
+    required this.userInfo,
   });
 
   @override
@@ -64,6 +67,7 @@ class SettingsProfileView extends StatelessWidget {
               if (!edited) {
                 return SettingsProfileRedirectionEditButton(
                   capabilities: capabilities,
+                  userInfo: userInfo,
                 );
               }
               return Padding(

--- a/lib/pages/settings_dashboard/settings_profile/settings_profile_view.dart
+++ b/lib/pages/settings_dashboard/settings_profile/settings_profile_view.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/presentation/widget_keys/widget_keys.dart';
 import 'package:fluffychat/domain/model/capabilities/capabilities_extension.dart';
+import 'package:fluffychat/domain/model/user_info/user_info.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_profile/settings_profile.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_profile/settings_profile_item.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_profile/settings_profile_redirection_edit_button.dart';
@@ -23,11 +24,13 @@ import 'package:matrix/matrix.dart';
 class SettingsProfileView extends StatelessWidget {
   final SettingsProfileController controller;
   final Capabilities? capabilities;
+  final UserInfo? userInfo;
 
   const SettingsProfileView({
     super.key,
     required this.controller,
     required this.capabilities,
+    required this.userInfo,
   });
 
   @override
@@ -58,6 +61,7 @@ class SettingsProfileView extends StatelessWidget {
               if (!edited) {
                 return SettingsProfileRedirectionEditButton(
                   capabilities: capabilities,
+                  userInfo: userInfo,
                 );
               }
               return Padding(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1745,8 +1745,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: "66d09a271f20243badd92352a8bb5866b430020d"
+      ref: "feature/web-link-generator"
+      resolved-ref: "72323ff6411c5203808068adc2e5500fe010f581"
       url: "git@github.com:linagora/linagora-design-flutter.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1858,9 +1858,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.2.0"
-      resolved-ref: "160531adb37004898cff78009f5ebdbafdf54a32"
-      url: "https://github.com/linagora/linagora-design-flutter.git"
+      ref: "feature/web-link-generator"
+      resolved-ref: fb53f7846079e5fbc37360b3799235ce662ee1c8
+      url: "git@github.com:linagora/linagora-design-flutter.git"
     source: git
     version: "0.2.0"
   linkfy_text:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -333,10 +333,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -1859,7 +1859,7 @@ packages:
     description:
       path: "."
       ref: "feature/web-link-generator"
-      resolved-ref: fb53f7846079e5fbc37360b3799235ce662ee1c8
+      resolved-ref: "9642eeb246b09fb2fc30b4dd4477feb3640e4ca1"
       url: "git@github.com:linagora/linagora-design-flutter.git"
     source: git
     version: "0.2.0"
@@ -1948,18 +1948,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   matrix:
     dependency: "direct main"
     description:
@@ -2062,10 +2062,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -3168,26 +3168,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.12"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -328,6 +328,12 @@ dependency_overrides:
       url: https://github.com/linagora/overflow_view.git
       ref: master
 
+  # TODO: Remove when https://github.com/linagora/linagora-design-flutter/pull/67 is merged
+  linagora_design_flutter:
+    git:
+      url: git@github.com:linagora/linagora-design-flutter.git
+      ref: feature/web-link-generator
+
 cider:
   link_template:
     tag: https://github.com/linagora/twake-on-matrix/releases/tag/%tag% # initial release link template

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -346,6 +346,12 @@ dependency_overrides:
       url: https://github.com/linagora/overflow_view.git
       ref: master
 
+  # TODO: Remove when https://github.com/linagora/linagora-design-flutter/pull/67 is merged
+  linagora_design_flutter:
+    git:
+      url: git@github.com:linagora/linagora-design-flutter.git
+      ref: feature/web-link-generator
+
 cider:
   link_template:
     tag: https://github.com/linagora/twake-on-matrix/releases/tag/%tag% # initial release link template


### PR DESCRIPTION
This PR is to implement the new behavior explained in: https://github.com/linagora/twake-on-matrix/issues/2786

# DoD

- [x] Profile page fetches `GET ${tomserver}/_twake/v1/user_info/{userId}`
- [ ] "Edit" button on the top right corner is visible if the GET result contains: `workplaceFqdn` key
- [x] The "Edit" button redirection URL is constructed using the `workplaceFqdn` value

How to build the redirection URL: https://github.com/linagora/cozy-client/blob/master/packages/cozy-client/src/helpers/urlHelper.js#L27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings profile now supports workplace domain-based redirection URLs in addition to existing direct redirects.
  * The redirection edit button can now appear when a workplace domain configuration is available, enabling workspace-based navigation.

* **Improvements**
  * URL launching now prefers the workplace-based redirect when valid, otherwise falls back to the existing redirect URL.
  * Added clearer, localized feedback when a URL cannot be launched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->