### PR TITLE
Update contact visibility settings to use selected visibility option

### DIFF
--- a/lib/pages/settings_dashboard/settings_contacts_visibility/settings_contacts_visibility.dart
+++ b/lib/pages/settings_dashboard/settings_contacts_visibility/settings_contacts_visibility.dart
@@ -152,7 +152,7 @@ class SettingsContactsVisibilityController
             selectedVisibilityOptionNotifier.value =
                 SettingsContactsVisibilityEnum.values.firstWhere(
               (option) => option.name == success.userInfoVisibility.visibility,
-              orElse: () => SettingsContactsVisibilityEnum.private,
+              orElse: () => SettingsContactsVisibilityEnum.contacts,
             );
             selectedVisibleFieldNotifier.value =
                 success.userInfoVisibility.visibleFields ?? [];
@@ -197,7 +197,7 @@ class SettingsContactsVisibilityController
             selectedVisibilityOptionNotifier.value =
                 SettingsContactsVisibilityEnum.values.firstWhere(
               (option) => option.name == success.userInfoVisibility.visibility,
-              orElse: () => SettingsContactsVisibilityEnum.private,
+              orElse: () => SettingsContactsVisibilityEnum.contacts,
             );
             selectedVisibleFieldNotifier.value =
                 success.userInfoVisibility.visibleFields ?? [];


### PR DESCRIPTION
## Ticket
## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

https://github.com/user-attachments/assets/aabbaf71-b429-4625-bb7a-4d5762d974a3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Visibility settings now respect the user's selected visibility option when toggling visible fields and, if no explicit option is present, default to "Contacts" instead of "Private". This ensures visibility preferences are applied consistently. Note: if no option is selected, visibility may remain unset until a selection is made.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->