### PR TITLE
Add permission dialog for gallery access and improve divider padding in settings

### DIFF
--- a/lib/pages/personal_qr/personal_qr.dart
+++ b/lib/pages/personal_qr/personal_qr.dart
@@ -2,8 +2,10 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/pages/personal_qr/personal_qr_view.dart';
+import 'package:fluffychat/utils/permission_dialog.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/permission_service.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
@@ -72,6 +74,24 @@ class PersonalQrController extends State<PersonalQr> {
 
       final permissionGranted = await _requestStoragePermissions();
       if (!permissionGranted) {
+        showDialog(
+          useRootNavigator: false,
+          context: context,
+          builder: (_) {
+            return PermissionDialog(
+              icon: const Icon(Icons.photo),
+              permission: Permission.photos,
+              explainTextRequestPermission: Text(
+                L10n.of(context)!.explainPermissionToGallery(
+                  AppConfig.applicationName,
+                ),
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              onAcceptButton: () =>
+                  PermissionHandlerService().goToSettingsForPermissionActions(),
+            );
+          },
+        );
         return;
       }
 

--- a/lib/pages/settings_dashboard/settings/settings_view.dart
+++ b/lib/pages/settings_dashboard/settings/settings_view.dart
@@ -195,9 +195,7 @@ class SettingsView extends StatelessWidget {
                         ? const SizedBox()
                         : Padding(
                             padding:
-                                SettingsViewStyle.settingsItemDividerPadding(
-                              context,
-                            ),
+                                SettingsViewStyle.settingsItemDividerPadding(),
                             child: Divider(
                               color: LinagoraStateLayer(
                                 LinagoraSysColors.material().surfaceTint,

--- a/lib/pages/settings_dashboard/settings/settings_view_style.dart
+++ b/lib/pages/settings_dashboard/settings/settings_view_style.dart
@@ -35,11 +35,12 @@ class SettingsViewStyle {
   static const double borderRadius = 4.0;
   static const double settingsItemDividerHeight = 1.0;
   static const double settingsItemDividerThikness = 1;
-  static EdgeInsets settingsItemDividerPadding(BuildContext context) =>
-      EdgeInsets.only(
+
+  static EdgeInsets settingsItemDividerPadding() => const EdgeInsets.only(
         left: 48.0,
-        right: responsiveUtils.isMobile(context) ? 0 : 8.0,
+        right: 8.0,
       );
+
   static EdgeInsets profileItemDividerPadding(BuildContext context) =>
       EdgeInsets.only(
         right: responsiveUtils.isMobile(context) ? 0 : 16.0,

--- a/lib/pages/settings_dashboard/settings_security/settings_security_view.dart
+++ b/lib/pages/settings_dashboard/settings_security/settings_security_view.dart
@@ -77,6 +77,16 @@ class SettingsSecurityView extends StatelessWidget {
                     ),
                   ),
                   Padding(
+                    padding: SettingsViewStyle.settingsItemDividerPadding(),
+                    child: Divider(
+                      color: LinagoraStateLayer(
+                        LinagoraSysColors.material().surfaceTint,
+                      ).opacityLayer3,
+                      thickness: SettingsViewStyle.settingsItemDividerThikness,
+                      height: SettingsViewStyle.settingsItemDividerHeight,
+                    ),
+                  ),
+                  Padding(
                     padding: SettingsViewStyle.bodySettingsScreenPadding,
                     child: ValueListenableBuilder(
                       valueListenable: controller.ignoredUsersNotifier,
@@ -106,9 +116,7 @@ class SettingsSecurityView extends StatelessWidget {
                     ),
                   ),
                   Padding(
-                    padding: SettingsViewStyle.settingsItemDividerPadding(
-                      context,
-                    ),
+                    padding: SettingsViewStyle.settingsItemDividerPadding(),
                     child: Divider(
                       color: LinagoraStateLayer(
                         LinagoraSysColors.material().surfaceTint,
@@ -150,9 +158,7 @@ class SettingsSecurityView extends StatelessWidget {
                         ),
                       ),
                       Padding(
-                        padding: SettingsViewStyle.settingsItemDividerPadding(
-                          context,
-                        ),
+                        padding: SettingsViewStyle.settingsItemDividerPadding(),
                         child: Divider(
                           color: LinagoraStateLayer(
                             LinagoraSysColors.material().surfaceTint,


### PR DESCRIPTION
## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

https://github.com/user-attachments/assets/d490b628-b1e6-464a-aef2-511deb70e34c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Storage permission denial during download now displays a dialog prompting users to grant permission or access settings.

* **Style**
  * Added visual divider in security settings between contact visibility and blocked users items for improved visual separation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->