### PR TITLE
TW-2841 Fix date format as phone number

### DIFF
--- a/lib/utils/matrix_sdk_extensions/matrix_locals.dart
+++ b/lib/utils/matrix_sdk_extensions/matrix_locals.dart
@@ -195,9 +195,7 @@ class MatrixLocals extends MatrixLocalizations {
 
   @override
   String removedBy(Event redactedEvent) {
-    return l10n.removedBy(
-      redactedEvent.senderFromMemoryOrFallback.displayName ?? '',
-    );
+    return l10n.deletedMessage;
   }
 
   @override

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
@@ -74,7 +74,7 @@ class TwakeLinkPreviewController extends State<TwakeLinkPreview>
               text: widget.localizedBody,
               textStyle: widget.richTextStyle,
               linkStyle: widget.linkStyle,
-              linkTypes: const [LinkType.url, LinkType.phone],
+              linkTypes: const [LinkType.url, LinkType.phone, LinkType.date],
               textAlign: TextAlign.start,
               onTapDownLink: (tapDownDetails, link) => handleOnTappedLinkHtml(
                 context: context,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1755,7 +1755,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "6690e87f19e024d70b68efbc70d2159c34b5d0fc"
+      resolved-ref: "21818487a4b701fd453a72ad3f3e0d78e3184238"
       url: "git@github.com:linagora/linkfy_text.git"
     source: git
     version: "1.1.6"


### PR DESCRIPTION
## Ticket
- #2841 

## Pre-merge
- https://github.com/linagora/linkfy_text/pull/2

## Resolved
<img width="226" height="283" alt="Screenshot 2026-01-21 at 3 35 57 PM" src="https://github.com/user-attachments/assets/560fa7ca-9995-47e0-9bc1-0dda32ff2e52" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date-type links are now recognized and tappable in message previews.

* **Changes**
  * Redacted messages now display a uniform deletion message across all conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->