### PR TITLE
TW-2848: Removed italic style in chat list item

### DIFF
--- a/lib/presentation/mixins/chat_list_item_mixin.dart
+++ b/lib/presentation/mixins/chat_list_item_mixin.dart
@@ -46,8 +46,6 @@ mixin ChatListItemMixin {
           overflow: TextOverflow.ellipsis,
           style: ListItemStyle.subtitleTextStyle(
             fontFamily: 'Inter',
-          ).copyWith(
-            fontStyle: event.text.isEmpty ? FontStyle.italic : null,
           ),
         );
       },
@@ -77,11 +75,8 @@ mixin ChatListItemMixin {
         softWrap: false,
         maxLines: 2,
         overflow: TextOverflow.ellipsis,
-        style: ChatLitSubSubtitleTextStyleView.textStyle
-            .textStyle(room, context)
-            .copyWith(
-              fontStyle: FontStyle.italic,
-            ),
+        style:
+            ChatLitSubSubtitleTextStyleView.textStyle.textStyle(room, context),
       );
     }
 
@@ -146,8 +141,6 @@ mixin ChatListItemMixin {
                 overflow: TextOverflow.ellipsis,
                 style: ListItemStyle.subtitleTextStyle(
                   fontFamily: 'Inter',
-                ).copyWith(
-                  fontStyle: event.text.isEmpty ? FontStyle.italic : null,
                 ),
               ),
       ],


### PR DESCRIPTION
## Ticket
**Related issue**
- #2848 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/428ef2e1-368d-41e8-867d-9a4630c18dc7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Chat list item subtitles no longer render in italic for regular conversations when event text is empty; italic styling remains for group chat invitations. No functional behavior or public APIs were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->