### PR TITLE
TW-2852 Handle search external matrix id when contact is not ready

### DIFF
--- a/lib/pages/contacts_tab/contacts_tab_body_view.dart
+++ b/lib/pages/contacts_tab/contacts_tab_body_view.dart
@@ -252,6 +252,12 @@ class _SliverContactsList extends StatelessWidget {
                 return child!;
               }
 
+              if (!PlatformInfos.isWeb) {
+                if (controller.phoneBookFilterSuccess) {
+                  return child!;
+                }
+              }
+
               final externalContact = success.contact;
               return _SilverExternalContact(
                 controller: controller,

--- a/lib/pages/new_group/contacts_selection_view.dart
+++ b/lib/pages/new_group/contacts_selection_view.dart
@@ -230,6 +230,11 @@ class ContactsSelectionView extends StatelessWidget {
                   .presentationRecentContactNotifier.value.isNotEmpty) {
                 return child!;
               }
+              if (!PlatformInfos.isWeb) {
+                if (controller.phoneBookFilterSuccess) {
+                  return child!;
+                }
+              }
               return SliverToBoxAdapter(
                 child: ContactItem(
                   contact: success.contact,

--- a/lib/pages/new_private_chat/new_private_chat_view.dart
+++ b/lib/pages/new_private_chat/new_private_chat_view.dart
@@ -63,6 +63,7 @@ class NewPrivateChatView extends StatelessWidget {
               goToSettingsForPermissionActions: () =>
                   controller.displayContactPermissionDialog(context),
               goToCreateContact: () => showAddContactDialog(context),
+              phoneBookFilterSuccess: controller.phoneBookFilterSuccess,
             ),
           ],
         ),

--- a/lib/pages/new_private_chat/widget/expansion_list.dart
+++ b/lib/pages/new_private_chat/widget/expansion_list.dart
@@ -33,6 +33,7 @@ class ExpansionList extends StatelessWidget {
   final Function()? closeContactsWarningBanner;
   final Function()? goToSettingsForPermissionActions;
   final VoidCallback? goToCreateContact;
+  final bool phoneBookFilterSuccess;
 
   const ExpansionList({
     super.key,
@@ -46,6 +47,7 @@ class ExpansionList extends StatelessWidget {
     this.goToSettingsForPermissionActions,
     required this.presentationPhonebookContactNotifier,
     this.goToCreateContact,
+    required this.phoneBookFilterSuccess,
   });
 
   @override
@@ -116,6 +118,11 @@ class ExpansionList extends StatelessWidget {
             }
 
             if (success is PresentationExternalContactSuccess) {
+              if (!PlatformInfos.isWeb) {
+                if (phoneBookFilterSuccess) {
+                  return child!;
+                }
+              }
               return TwakeInkWell(
                 onTap: () {
                   onContactTap(

--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -73,6 +73,12 @@ mixin class ContactsViewControllerMixin {
 
   PermissionStatus? contactsPermissionStatus;
 
+  bool get phoneBookFilterSuccess =>
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is GetPhonebookContactsSuccess,
+      );
+
   Future displayContactPermissionDialog(BuildContext context) async {
     final fetchContactsPermissionStatus =
         await _permissionHandlerService.contactsPermissionStatus;


### PR DESCRIPTION
## Ticket
- #2852 

## Root cause
When contact is fetching or fails to fetch, even when user type correct matrix id format in search, no result will be shown.

## Resolved
[1.webm](https://github.com/user-attachments/assets/a208f5c5-1657-4838-925a-6d1f87634296)

[2.webm](https://github.com/user-attachments/assets/5d3cfe8b-802c-4d46-9cae-284fe228dec9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized external-contact detection so suggestions are evaluated once and applied consistently across contact lists and empty-result flows.
  * Propagated a new phonebook-filter success flag through relevant contact list components to unify rendering decisions.

* **Bug Fixes**
  * Removed platform-specific short-circuits so external-contact suggestions are no longer skipped in certain failure, empty, or non-web paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->