### PR TITLE
TW-2858: Hide reaction and pinned message events in chat list

### DIFF
--- a/lib/domain/model/room/room_extension.dart
+++ b/lib/domain/model/room/room_extension.dart
@@ -217,7 +217,11 @@ extension RoomExtension on Room {
 
       if (lastEventAvailableInPreview == null ||
           lastEventAvailableInPreview.shouldHideRedactedEvent() ||
-          lastEventAvailableInPreview.shouldHideBannedEvent()) {
+          lastEventAvailableInPreview.shouldHideBannedEvent() ||
+          lastEventAvailableInPreview.type == EventTypes.Reaction ||
+          lastEventAvailableInPreview.relationshipType ==
+              RelationshipTypes.reaction ||
+          lastEventAvailableInPreview.type == EventTypes.RoomPinnedEvents) {
         final lastState = _getLastestRoomState();
 
         if (lastState == null) return null;


### PR DESCRIPTION
## Ticket
**Related issue**

- #2858 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/6ce34200-ff31-451a-b7f2-b58921c472f1


https://github.com/user-attachments/assets/f916c226-7a74-42b7-b3a8-38c29727c6b9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reaction and pinned-message events no longer surface as the "latest" activity in room previews, state displays, or message lists.
  * Previews and conversation threads now show more relevant, user-facing events and improved ordering for recent activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->