### PR TITLE
TW-2861 Add loading to switch account

### DIFF
--- a/lib/domain/contact_manager/contacts_manager.dart
+++ b/lib/domain/contact_manager/contacts_manager.dart
@@ -455,18 +455,15 @@ class ContactsManager {
   }
 
   Future<void> cancelAllSubscriptions() async {
-    if (tomContactsSubscription != null) {
-      await tomContactsSubscription?.cancel();
-    }
-    if (federationPhonebookContactsSubscription != null) {
-      await federationPhonebookContactsSubscription?.cancel();
-    }
-    if (twakePhonebookContactsSubscription != null) {
-      await twakePhonebookContactsSubscription?.cancel();
-    }
-    if (postAddressBookSubscription != null) {
-      await postAddressBookSubscription?.cancel();
-    }
+    await Future.wait([
+      if (tomContactsSubscription != null) tomContactsSubscription!.cancel(),
+      if (federationPhonebookContactsSubscription != null)
+        federationPhonebookContactsSubscription!.cancel(),
+      if (twakePhonebookContactsSubscription != null)
+        twakePhonebookContactsSubscription!.cancel(),
+      if (postAddressBookSubscription != null)
+        postAddressBookSubscription!.cancel(),
+    ]);
     if (_isSynchronizing) {
       _isSynchronizing = false;
     }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1149,7 +1149,7 @@ class MatrixState extends State<Matrix>
   }
 
   Future<void> cancelListenSynchronizeContacts() async {
-    _contactsManager.cancelAllSubscriptions();
+    await _contactsManager.cancelAllSubscriptions();
   }
 
   void handleShowQrCodeDownload(bool show) {


### PR DESCRIPTION
## Ticket
- #2861 

## Root cause
There's no visual cue when the app is preparing to switch account, making user mistakenly judge as the app fails to switch account.

## Solution
Add loading indicator when switching account.

## Resolved

[account-switch.webm](https://github.com/user-attachments/assets/9cab6fe6-cc29-4d91-829b-1d6be8c8384f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a loading dialog when switching accounts for clearer feedback; account-switch actions now support async workflows.

* **Bug Fixes**
  * Prevents errors when UI unmounts during account switches by guarding post-operation UI updates.
  * Ensures subscription cancellations are awaited to avoid timing-related issues.

* **Performance**
  * Cancels multiple subscriptions concurrently for faster, more efficient background cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->