### PR TITLE
TW-2863 GITHUB_PATH only available for subsequent steps

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -57,6 +57,9 @@ jobs:
           echo "${{ env.ANDROID_SDK_ROOT }}/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
           echo "${{ env.ANDROID_SDK_ROOT }}/platform-tools" >> "$GITHUB_PATH"
           echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
+
+      - name: Check flutter and sdkmanager version
+        run: |
           flutter --version
           sdkmanager --version
 


### PR DESCRIPTION
#2863

Root cause: 
- The GITHUB_PATH is only available for subsequent steps of the Github Action

Solution: 
 - add only paths to GITHUB_PATH first
 - check flutter and sdkmanager version in the next step
 
 Test:
- Workflow is working again in: https://github.com/linagora/twake-on-matrix/actions/runs/21614649496/job/62290660902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to include diagnostic checks for build tool versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->