### PR TITLE
TW-2877 Restore homeserver on connected

### DIFF
--- a/lib/presentation/mixins/connectivity_mixin.dart
+++ b/lib/presentation/mixins/connectivity_mixin.dart
@@ -12,12 +12,12 @@ mixin ConnectivityMixin<T extends StatefulWidget> on State<T> {
 
   Future<void> onConnect();
 
-  late final Throttle<bool?> _throttle;
+  late final Debouncer<bool?> _debouncer;
 
   @override
   void initState() {
     super.initState();
-    _throttle = Throttle<bool?>(
+    _debouncer = Debouncer<bool?>(
       const Duration(seconds: 5),
       initialValue: null,
       onChanged: (value) async {
@@ -32,13 +32,13 @@ mixin ConnectivityMixin<T extends StatefulWidget> on State<T> {
         .get<NetworkConnectionService>()
         .getStreamInstance()
         .listen((event) {
-          _throttle.value = event != ConnectivityResult.none;
+          _debouncer.value = event != ConnectivityResult.none;
         });
   }
 
   @override
   void dispose() {
-    _throttle.cancel();
+    _debouncer.cancel();
     _connectivitySubscription?.cancel();
     super.dispose();
   }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1195,6 +1195,7 @@ class MatrixState extends State<Matrix>
 
   @override
   Future<void> onConnect() async {
+    if (client.homeserver != null) return;
     await _refreshHomeserverInformation(client);
   }
 


### PR DESCRIPTION
## Ticket
- #2877 

## Root cause
When `client.checkHomeserver` method is called but something went wrong (internet connection issue e.g.), inside of that method:
```dart
// ...
} catch (_) {
  homeserver = null;
  rethrow;
}
```

## Solution
Reassign homeserver on regain connection

## Resolved

https://github.com/user-attachments/assets/c6b272c3-540b-48c7-b500-380e15239c7d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved network resilience: the app now detects restored internet connectivity and automatically refreshes homeserver information so server data stays current when reconnecting or switching networks.
  * Better reconnection behavior: homeserver data refresh is triggered on connection events to reduce stale data and improve continuity after interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->