### PR TITLE
Implement new cozy-external-bridge setup

### DIFF
--- a/.github/workflows/clean-up-gh-pages.yaml
+++ b/.github/workflows/clean-up-gh-pages.yaml
@@ -16,6 +16,9 @@ jobs:
   cleanup:
     name: Remove preview deployment
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-writes
+      cancel-in-progress: false
 
     steps:
       - name: Checkout gh-pages branch

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -11,7 +11,8 @@ jobs:
     name: Deploy preview versions on pull requests
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      group: gh-pages-writes
+      cancel-in-progress: false
     permissions:
       deployments: write
       pull-requests: write
@@ -75,7 +76,7 @@ jobs:
         env:
           FOLDER: ${{ github.event.pull_request.number }}
         run: |
-          echo "URL=https://$GITHUB_REPOSITORY_OWNER.github.io/${GITHUB_REPOSITORY##*/}/$FOLDER" >> $GITHUB_OUTPUT
+          echo "URL=https://$GITHUB_REPOSITORY_OWNER.github.io/${GITHUB_REPOSITORY##*/}/$FOLDER" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
@@ -84,7 +85,6 @@ jobs:
           publish_dir: build/web
           keep_files: true
           destination_dir: "${{ github.event.pull_request.number }}"
-          force_orphan: true
 
       - name: Find deployment comment
         uses: peter-evans/find-comment@v3

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -98,7 +98,8 @@ abstract class AppConfig {
   static const String sourceCodeUrl =
       'https://github.com/linagora/twake-on-matrix';
   static String supportUrl = 'https://twake.app/support';
-  static String cozyExternalBridgeVersion = '0.16.1';
+  static String cozyExternalBridgeVersion = '1.2.1';
+  static List<String> cozyExternalBridgeAllowlist = ['.twake.app', '.lin-saas.com','.lin-saas.dev'];
   static bool renderHtml = true;
   static bool hideRedactedEvents = false;
   static bool hideUnknownEvents = true;
@@ -193,6 +194,11 @@ abstract class AppConfig {
     defaultValue: ConfigurationSaas.homeserver,
   );
 
+  static const String _cozyExternalBridgeAllowlistEnv = String.fromEnvironment(
+    'COZY_EXTERNAL_BRIDGE_ALLOWLIST',
+    defaultValue: '.twake.app,.lin-saas.com,.lin-saas.dev',
+  );
+
   static void loadEnvironment() {
     twakeWorkplaceHomeserver = _twakeWorkplaceHomeserverEnv;
 
@@ -213,6 +219,14 @@ abstract class AppConfig {
     homeserver = _homeserverEnv;
 
     Logs().i('[Public Platform] AppConfig():: HOME_SERVER $_homeserverEnv');
+
+    cozyExternalBridgeAllowlist = _cozyExternalBridgeAllowlistEnv
+        .split(',')
+        .map((i) => i.trim())
+        .where((i) => i.isNotEmpty)
+        .toList();
+
+    Logs().i('[Public Platform] AppConfig():: COZY_EXTERNAL_BRIDGE_ALLOWLIST $_cozyExternalBridgeAllowlistEnv');
   }
 
   static bool get isSaasPlatForm => _platformEnv == 'saas';
@@ -301,6 +315,12 @@ abstract class AppConfig {
     if (json['cozy_external_bridge_version'] is String &&
         json['cozy_external_bridge_version'].isNotEmpty) {
       cozyExternalBridgeVersion = json['cozy_external_bridge_version'];
+    }
+    if (json['cozy_external_bridge_allowlist'] is List &&
+        json['cozy_external_bridge_allowlist'].isNotEmpty) {
+      cozyExternalBridgeAllowlist = json['cozy_external_bridge_allowlist']
+        .whereType<String>()
+        .toList();
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,7 +67,7 @@ void main() async {
   if (PlatformInfos.isWeb) {
     CozyConfigManager()
         .injectCozyScript(AppConfig.cozyExternalBridgeVersion)
-        .then((value) => CozyConfigManager().initialize());
+        .then((value) => CozyConfigManager().initialize(validUrlSuffixes: AppConfig.cozyExternalBridgeAllowlist));
   }
 
   // Started in foreground mode.

--- a/lib/widgets/layouts/adaptive_layout/adaptive_scaffold_appbar.dart
+++ b/lib/widgets/layouts/adaptive_layout/adaptive_scaffold_appbar.dart
@@ -50,14 +50,11 @@ class _AdaptiveScaffoldAppBarState extends State<AdaptiveScaffoldAppBar> {
       },
     );
 
-    return FutureBuilder(
-      future: CozyConfigManager().isInsideCozy,
-      builder: (context, snapshot) {
-        if (!snapshot.hasData || !snapshot.data!) return child;
+    if(CozyConfigManager().isInContainer) {
+      return const SizedBox();
+    }
 
-        return const SizedBox();
-      },
-    );
+    return child;
   }
 }
 

--- a/lib/widgets/local_notifications_extension.dart
+++ b/lib/widgets/local_notifications_extension.dart
@@ -67,9 +67,9 @@ extension LocalNotificationsExtension on MatrixState {
           method: ThumbnailMethod.crop,
         );
     if (kIsWeb) {
-      final isInsideCozy = await CozyConfigManager().isInsideCozy;
+      final isInContainer = CozyConfigManager().isInContainer;
       _audioPlayer.play();
-      if (isInsideCozy) {
+      if (isInContainer) {
         CozyConfigManager().sendNotification(title, body);
         return;
       }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -528,8 +528,8 @@ class MatrixState extends State<Matrix>
 
   Future<void> _requestNotificationPermission() async {
     try {
-      final isInsideCozy = await CozyConfigManager().isInsideCozy;
-      if (isInsideCozy) {
+      final isInContainer = CozyConfigManager().isInContainer;
+      if (isInContainer) {
         CozyConfigManager().requestNotificationPermission();
       } else {
         html.Notification.requestPermission();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1745,8 +1745,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: "66d09a271f20243badd92352a8bb5866b430020d"
+      ref: "feat/update-cozy-external-bridge-setup"
+      resolved-ref: "4331015b1f10c4b2033493e756ebf86398185d8d"
       url: "git@github.com:linagora/linagora-design-flutter.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   linagora_design_flutter:
     git:
       url: git@github.com:linagora/linagora-design-flutter.git
-      ref: master
+      ref: feat/update-cozy-external-bridge-setup
   flutter_matrix_html:
     git:
       url: https://github.com/linagora/flutter_matrix_html.git
@@ -327,6 +327,12 @@ dependency_overrides:
     git:
       url: https://github.com/linagora/overflow_view.git
       ref: master
+  
+  # Fix dependency conflict between flutter_emoji_mart and linagora_design_flutter
+  linagora_design_flutter:
+    git:
+      url: git@github.com:linagora/linagora-design-flutter.git
+      ref: feat/update-cozy-external-bridge-setup
 
 cider:
   link_template:


### PR DESCRIPTION
Pre-merge: https://github.com/linagora/linagora-design-flutter/pull/69

I will need to update pubspec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Added a configurable allowlist for the external bridge (defaults: .twake.app, .lin-saas.com, .lin-saas.dev)
  * Updated external bridge default version to 1.2.1
  * Environment and JSON loading now respect the allowlist and log its resolved value

* **Updates**
  * Simplified container detection paths for app bar, notifications, and permission requests to use a synchronous in-container check

* **Chores**
  * Adjusted a design dependency reference to a feature branch
<!-- end of auto-generated comment: release notes by coderabbit.ai -->