### PR TITLE
fix: chat list shows message as read whereas this was not the case

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,8 +18,10 @@ analyzer:
     deprecated_member_use: ignore # TODO: remove it when we can remove download image in HtmlMessage
   exclude:
     - lib/generated_plugin_registrant.dart
+    - test_bundle.dart
+    - integration_test/test_bundle.dart
     - lib/l10n/*.dart
-    - '**.g.dart'
+    - "**.g.dart"
 
 dart_code_metrics:
   metrics:

--- a/lib/pages/chat/events/audio_message/audio_player_widget.dart
+++ b/lib/pages/chat/events/audio_message/audio_player_widget.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:async/async.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/pages/chat/events/audio_message/audio_play_extension.dart';
 import 'package:fluffychat/pages/chat/events/audio_message/audio_player_style.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat/seen_by_row.dart';
 import 'package:fluffychat/presentation/mixins/audio_mixin.dart';
+import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -22,11 +25,8 @@ import 'package:intl/intl.dart';
 import 'package:just_audio/just_audio.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
-import 'package:fluffychat/generated/l10n/app_localizations.dart';
-import 'package:path_provider/path_provider.dart';
-
-import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:opus_caf_converter_dart/opus_caf_converter_dart.dart';
+import 'package:path_provider/path_provider.dart';
 
 class AudioPlayerWidget extends StatefulWidget {
   final Color color;
@@ -430,13 +430,11 @@ class AudioPlayerState extends State<AudioPlayerWidget>
                 const SizedBox(width: 4),
                 SeenByRow(
                   timelineOverlayMessage: widget.event.timelineOverlayMessage,
-                  participants: widget.timeline.room.getParticipants(),
                   getSeenByUsers: widget.event.room.getSeenByUsers(
                     widget.timeline,
                     eventId: widget.event.eventId,
                   ),
                   eventStatus: widget.event.status,
-                  event: widget.event,
                 ),
               ],
             ),

--- a/lib/pages/chat/events/message_time.dart
+++ b/lib/pages/chat/events/message_time.dart
@@ -1,16 +1,16 @@
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat/events/message_time_style.dart';
 import 'package:fluffychat/pages/chat/events/text_message_retry_button.dart';
 import 'package:fluffychat/pages/chat/seen_by_row.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
+import 'package:fluffychat/utils/room_status_extension.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
-import 'package:matrix/matrix.dart';
 import 'package:linagora_design_flutter/colors/linagora_state_layer.dart';
-import 'package:fluffychat/utils/room_status_extension.dart';
-import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:matrix/matrix.dart';
 
 class MessageTime extends StatelessWidget {
   const MessageTime({
@@ -90,13 +90,11 @@ class MessageTime extends StatelessWidget {
             SizedBox(width: MessageTimeStyle.paddingTimeAndIcon),
             SeenByRow(
               timelineOverlayMessage: timelineOverlayMessage,
-              participants: timeline.room.getParticipants(),
               getSeenByUsers: room.getSeenByUsers(
                 timeline,
                 eventId: event.eventId,
               ),
               eventStatus: event.status,
-              event: event,
             ),
           ],
         ],

--- a/lib/pages/chat/events/message_time_style.dart
+++ b/lib/pages/chat/events/message_time_style.dart
@@ -1,33 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 
-class MessageTimeStyle {
+final class MessageTimeStyle {
   static Color? timelineColor(bool timelineOverlayMessage) =>
       timelineOverlayMessage
       ? Colors.white
       : LinagoraRefColors.material().neutral[50];
 
   static double get timelineLetterSpacing => 0.4;
-
   static double get paddingTimeAndIcon => 8;
   static double get seenByRowIconSize => 16;
-  static Color seenByRowIconPrimaryColor(
+
+  static Color readReceiptColor(bool seenByOthers) => seenByOthers
+      ? LinagoraSysColors.material().secondary
+      : LinagoraRefColors.material().neutral[50]!;
+
+  static Color seenByRowIconPrimaryColor(bool timelineOverlayMessage) =>
+      timelineOverlayMessage ? Colors.white : readReceiptColor(true);
+
+  static Color seenByRowIconSecondaryColor(
     bool timelineOverlayMessage,
-    BuildContext context,
-  ) => timelineOverlayMessage
-      ? Colors.white
-      : LinagoraSysColors.material().secondary;
-  static Color? seenByRowIconSecondaryColor(
-    bool timelineOverlayMessage,
-    BuildContext context,
-  ) => timelineOverlayMessage
-      ? Theme.of(context).colorScheme.onPrimary
-      : LinagoraRefColors.material().neutral[50];
+    ColorScheme colorScheme,
+  ) => timelineOverlayMessage ? colorScheme.onPrimary : readReceiptColor(false);
 
   static TextStyle? textStyle(
-    BuildContext context,
     bool timelineOverlayMessage,
-  ) => Theme.of(context).textTheme.bodySmall?.merge(
+    TextTheme textTheme,
+  ) => textTheme.bodySmall?.merge(
     TextStyle(color: timelineColor(timelineOverlayMessage), letterSpacing: 0.4),
   );
 }

--- a/lib/pages/chat/seen_by_row.dart
+++ b/lib/pages/chat/seen_by_row.dart
@@ -6,27 +6,23 @@ enum MessageStatus { sending, sent, hasBeenSeen, error }
 
 class SeenByRow extends StatelessWidget {
   final List<User> getSeenByUsers;
-  final List<User> participants;
   final EventStatus? eventStatus;
   final bool timelineOverlayMessage;
-  final Event event;
 
   const SeenByRow({
     this.eventStatus,
     super.key,
     required this.getSeenByUsers,
-    required this.participants,
     required this.timelineOverlayMessage,
-    required this.event,
   });
 
   @override
   Widget build(BuildContext context) {
-    return getEventIcon(context, getSeenByUsers, eventStatus: eventStatus);
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    return getEventIcon(colorScheme, getSeenByUsers, eventStatus: eventStatus);
   }
 
   MessageStatus getMessageStatus(
-    BuildContext context,
     List<User> seenByUsers, {
     EventStatus? eventStatus,
   }) {
@@ -46,13 +42,11 @@ class SeenByRow extends StatelessWidget {
   }
 
   Widget getEventIcon(
-    BuildContext context,
+    ColorScheme colorScheme,
     List<User> seenByUsers, {
-    bool? oldMessageFullyRead,
     EventStatus? eventStatus,
   }) {
     final messageStatus = getMessageStatus(
-      context,
       seenByUsers,
       eventStatus: eventStatus,
     );
@@ -62,7 +56,7 @@ class SeenByRow extends StatelessWidget {
           Icons.schedule,
           color: MessageTimeStyle.seenByRowIconSecondaryColor(
             timelineOverlayMessage,
-            context,
+            colorScheme,
           ),
           size: MessageTimeStyle.seenByRowIconSize,
         );
@@ -71,7 +65,7 @@ class SeenByRow extends StatelessWidget {
           Icons.done_all,
           color: MessageTimeStyle.seenByRowIconSecondaryColor(
             timelineOverlayMessage,
-            context,
+            colorScheme,
           ),
           size: MessageTimeStyle.seenByRowIconSize,
         );
@@ -80,14 +74,13 @@ class SeenByRow extends StatelessWidget {
           Icons.done_all,
           color: MessageTimeStyle.seenByRowIconPrimaryColor(
             timelineOverlayMessage,
-            context,
           ),
           size: MessageTimeStyle.seenByRowIconSize,
         );
       case MessageStatus.error:
         return Icon(
           Icons.error,
-          color: Theme.of(context).colorScheme.error,
+          color: colorScheme.error,
           size: MessageTimeStyle.seenByRowIconSize,
         );
     }

--- a/lib/pages/chat_list/chat_list_item_subtitle.dart
+++ b/lib/pages/chat_list/chat_list_item_subtitle.dart
@@ -2,17 +2,15 @@ import 'dart:async';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:fluffychat/pages/chat/events/message_time_style.dart';
 import 'package:fluffychat/pages/chat/typing_timer_wrapper.dart';
-import 'package:fluffychat/presentation/mixins/chat_list_item_mixin.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_item_style.dart';
+import 'package:fluffychat/presentation/mixins/chat_list_item_mixin.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/room_status_extension.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
-import 'package:fluffychat/generated/l10n/app_localizations.dart';
-import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
-import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
 import 'package:matrix/matrix.dart';
 
 class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
@@ -23,20 +21,25 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
 
   @override
   Widget build(BuildContext context) {
-    final typingText = room.getLocalizedTypingText(L10n.of(context)!);
-    final isGroup = !room.isDirectChat;
-    final unreadBadgeSize = ChatListItemStyle.unreadBadgeSize(
+    final String typingText = room.getLocalizedTypingText(L10n.of(context)!);
+    final bool isGroup = !room.isDirectChat;
+    final double unreadBadgeSize = ChatListItemStyle.unreadBadgeSize(
       room.isUnreadOrInvited,
       room.hasNewMessages,
       room.notificationCount > 0,
     );
-    final lastEvent = this.lastEvent ?? room.lastEvent;
-    final isMediaEvent =
+    final Event? lastEvent = this.lastEvent ?? room.lastEvent;
+    final bool isMediaEvent =
         lastEvent?.messageType == MessageTypes.Image ||
         lastEvent?.messageType == MessageTypes.Video;
+
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+    final TextTheme textScheme = theme.textTheme;
+
     return Row(
-      mainAxisAlignment: MainAxisAlignment.start,
-      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisAlignment: .start,
+      crossAxisAlignment: .start,
       children: <Widget>[
         Expanded(
           child: _buildMainSubtitleContent(
@@ -59,33 +62,31 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
               ) ??
               Future.value(''),
           builder: (context, snapshot) {
-            if (snapshot.data == '' ||
-                snapshot.data == null ||
+            if (snapshot.data == null ||
+                snapshot.data!.isEmpty ||
                 lastEvent == null) {
               return const SizedBox.shrink();
             }
             final isMentioned = lastEvent.isMention == true;
-            return lastEvent.senderId == Matrix.of(context).client.userID
+            return lastEvent.senderId == room.client.userID
                 ? Icon(
                     Icons.done_all,
-                    color: lastEvent.receipts.isEmpty
-                        ? LinagoraRefColors.material().tertiary[30]
-                        : LinagoraSysColors.material().secondary,
+                    color: MessageTimeStyle.readReceiptColor(
+                      room.hasLastEventBeenSeenByOthers,
+                    ),
                     size: 20,
                   )
                 : AnimatedContainer(
                     duration: TwakeThemes.animationDuration,
                     curve: TwakeThemes.animationCurve,
-                    padding: const EdgeInsets.only(bottom: 4),
+                    padding: const .only(bottom: 4),
                     height: ChatListItemStyle.mentionIconWidth,
                     width: isMentioned && room.isUnreadOrInvited
                         ? ChatListItemStyle.mentionIconWidth
                         : 0,
                     decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.primary,
-                      borderRadius: BorderRadius.circular(
-                        AppConfig.borderRadius,
-                      ),
+                      color: colorScheme.primary,
+                      borderRadius: .circular(AppConfig.borderRadius),
                     ),
                     child: Center(
                       child: isMentioned && room.isUnreadOrInvited
@@ -93,16 +94,12 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
                               '@',
                               style: TextStyle(
                                 color: isMentioned
-                                    ? Theme.of(context).colorScheme.onPrimary
-                                    : Theme.of(
-                                        context,
-                                      ).colorScheme.onPrimaryContainer,
-                                fontSize: Theme.of(
-                                  context,
-                                ).textTheme.labelMedium?.fontSize,
+                                    ? colorScheme.onPrimary
+                                    : colorScheme.onPrimaryContainer,
+                                fontSize: textScheme.labelMedium?.fontSize,
                               ),
                             )
-                          : Container(),
+                          : const SizedBox.shrink(),
                     ),
                   );
           },
@@ -111,7 +108,7 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
         AnimatedContainer(
           duration: TwakeThemes.animationDuration,
           curve: TwakeThemes.animationCurve,
-          padding: const EdgeInsets.symmetric(horizontal: 7),
+          padding: const .symmetric(horizontal: 7),
           height: unreadBadgeSize,
           width: ChatListItemStyle.notificationBadgeSize(
             room.isUnreadOrInvited,
@@ -120,18 +117,18 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
           ),
           decoration: BoxDecoration(
             color: notificationColor(context: context, room: room),
-            borderRadius: BorderRadius.circular(AppConfig.borderRadius),
+            borderRadius: .circular(AppConfig.borderRadius),
           ),
           child: Center(
             child: room.notificationCount > 0
                 ? Text(
                     room.notificationCount.toString(),
-                    style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    style: textScheme.labelMedium?.copyWith(
                       letterSpacing: -0.5,
-                      color: Theme.of(context).colorScheme.onPrimary,
+                      color: colorScheme.onPrimary,
                     ),
                   )
-                : Container(),
+                : const SizedBox.shrink(),
           ),
         ),
       ],

--- a/lib/utils/room_status_extension.dart
+++ b/lib/utils/room_status_extension.dart
@@ -1,8 +1,8 @@
+import 'package:collection/collection.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/utils/string_extension.dart';
 import 'package:flutter/widgets.dart';
-
-import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:matrix/matrix.dart';
 
 import '../config/app_config.dart';
@@ -80,9 +80,22 @@ extension RoomStatusExtension on Room {
           break;
         }
       }
+      /* Remove the current user from the receipts list, as we don't want to show that the current user
+      has seen their own message. Because sender always sees their own message.  */
       lastReceipts.removeWhere((user) => user.id == client.userID);
     }
     return lastReceipts.toList();
+  }
+
+  /// Returns true if the last event has been seen by at least one other user.
+  ///
+  /// [receipts] is a getter that reads from [room.receiptState], so it is always
+  /// up to date without requiring the [Timeline] to be loaded.
+  bool get hasLastEventBeenSeenByOthers {
+    return lastEvent?.receipts
+            .whereNot((r) => r.user.id == client.userID)
+            .isNotEmpty ??
+        false;
   }
 
   bool isTypingText(BuildContext context) {

--- a/test/utils/room_status_extension_test.dart
+++ b/test/utils/room_status_extension_test.dart
@@ -1,0 +1,97 @@
+import 'package:fluffychat/utils/room_status_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'room_status_extension_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<Room>(), MockSpec<Event>(), MockSpec<Client>()])
+void main() {
+  group('hasLastEventBeenSeenByOthers', () {
+    late MockRoom mockRoom;
+    late MockEvent mockEvent;
+    late MockClient mockClient;
+
+    const ownUserId = '@me:example.com';
+    const otherUserId = '@other:example.com';
+
+    setUp(() {
+      mockRoom = MockRoom();
+      mockEvent = MockEvent();
+      mockClient = MockClient();
+
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockClient.userID).thenReturn(ownUserId);
+    });
+
+    test('returns false when lastEvent is null', () {
+      when(mockRoom.lastEvent).thenReturn(null);
+
+      expect(mockRoom.hasLastEventBeenSeenByOthers, false);
+    });
+
+    test('returns false when receipts is empty', () {
+      when(mockRoom.lastEvent).thenReturn(mockEvent);
+      when(mockEvent.receipts).thenReturn([]);
+
+      expect(mockRoom.hasLastEventBeenSeenByOthers, false);
+    });
+
+    test('returns false when only receipt is from current user', () {
+      final ownUser = MockUser(ownUserId);
+
+      when(mockRoom.lastEvent).thenReturn(mockEvent);
+      when(mockEvent.receipts).thenReturn([Receipt(ownUser, DateTime.now())]);
+
+      expect(mockRoom.hasLastEventBeenSeenByOthers, false);
+    });
+
+    test('returns true when receipt is from another user', () {
+      final otherUser = MockUser(otherUserId);
+
+      when(mockRoom.lastEvent).thenReturn(mockEvent);
+      when(mockEvent.receipts).thenReturn([Receipt(otherUser, DateTime.now())]);
+
+      expect(mockRoom.hasLastEventBeenSeenByOthers, true);
+    });
+
+    test(
+      'returns true when receipts contain both current user and other user',
+      () {
+        final ownUser = MockUser(ownUserId);
+        final otherUser = MockUser(otherUserId);
+
+        when(mockRoom.lastEvent).thenReturn(mockEvent);
+        when(mockEvent.receipts).thenReturn([
+          Receipt(ownUser, DateTime.now()),
+          Receipt(otherUser, DateTime.now()),
+        ]);
+
+        expect(mockRoom.hasLastEventBeenSeenByOthers, true);
+      },
+    );
+
+    test('returns true when multiple other users have seen the event', () {
+      final otherUser1 = MockUser(otherUserId);
+      final otherUser2 = MockUser('@another:example.com');
+
+      when(mockRoom.lastEvent).thenReturn(mockEvent);
+      when(mockEvent.receipts).thenReturn([
+        Receipt(otherUser1, DateTime.now()),
+        Receipt(otherUser2, DateTime.now()),
+      ]);
+
+      expect(mockRoom.hasLastEventBeenSeenByOthers, true);
+    });
+  });
+}
+
+class MockUser extends Mock implements User {
+  final String _id;
+
+  MockUser(this._id);
+
+  @override
+  String get id => _id;
+}


### PR DESCRIPTION
## Ticket
No issue related

## Root cause
lastEvent.receipts includes the sender's own receipt, and the list does not filter the current user, unlike getSeenByUsers() in the conversation details (cf. RoomStatusExtension.getSeenByUsers).

<img width="215" height="54" alt="Capture d’écran 2026-03-03 à 17 20 10" src="https://github.com/user-attachments/assets/eebfd58a-6e40-4471-926d-58b0fe061352" />
<img width="542" height="297" alt="Capture d’écran 2026-03-03 à 17 16 15" src="https://github.com/user-attachments/assets/8eca743c-689c-4a34-ad7b-bb39ff70de99" />



**‼️ According to the https://spec.matrix.org/v1.13/client-server-api/#receipts, clients SHOULD NOT send read receipts for events sent by their own user. However, the matrix-dart-sdk does not enforce this rule, resulting in the sender's own receipt being stored in receiptState and exposed via lastEvent.receipts.**  

## Solution
lastEvent.receipts includes the sender's own read receipt, causing the chat list to incorrectly display the sent message as read. The fix filters out the current user from lastEvent.receipts using whereNot, aligning the chat list behavior with the conversation detail which already correctly excludes the sender via the method getSeenByUsers() in extension RoomStatusExtension (room_status_extension.dart : line 84).

## Refactoring
  As part of this fix, a few small improvements were made to ChatListItemSubtitle following Dart/Flutter best practices:
  - Matrix.of(context).client.userID replaced with room.client.userID to avoid unnecessary BuildContext usage
  - Read receipt logic extracted into RoomStatusExtension as hasLastEventBeenSeenByOthers to align with the existing pattern of getSeenByUsers()
  - Theme properties (colorScheme, textTheme) grouped at the top of build() to avoid repeated Theme.of(context) calls
  - Strict typing enforced where previously implicit, in line with Dart best practices
  - Shorthand property syntax applied where applicable
  - Container() replaced with const SizedBox.shrink() for semantic clarity and performance

## Test recommendations
Before fix : To test this, you can take account A and send a message to account B. Account B should not read the incoming message, leaving it unopened/unread. Then, on account A, the icon will turn blue after a few seconds. 
After fix: Same test, but the icon will not turn blue.

## Resolved
- Web:
- Android:
- IOS:
 
<img width="904" height="896" alt="Capture d’écran 2026-03-03 à 18 17 18" src="https://github.com/user-attachments/assets/760c2be4-1400-4ec6-b8e6-0a578154aa8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-receipt indicator now reflects when other users have seen the latest message.

* **Bug Fixes**
  * Fixed read-receipt logic to exclude the current user from the "seen by" count.

* **UI**
  * Improved theming, colors, padding, and text styles across message list, mention bubbles, badges, and timestamps; seen-by indicators updated for consistency.

* **Refactor**
  * Simplified seen-by/status rendering to centralize color and style decisions.

* **Tests**
  * Added tests covering multiple seen-by scenarios to verify read-receipt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->