### PR TITLE
TW-2895: Remove top and bottom padding from chat scroll view

### DIFF
--- a/lib/pages/chat/chat_scroll_view.dart
+++ b/lib/pages/chat/chat_scroll_view.dart
@@ -107,8 +107,6 @@ class _ChatScrollViewState extends State<ChatScrollView> {
 
     return Padding(
       padding: EdgeInsets.only(
-        top: 16,
-        bottom: 8.0,
         left: horizontalPadding,
         right: horizontalPadding,
       ),


### PR DESCRIPTION
## Ticket
**Related issue**

- #2895

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

https://github.com/user-attachments/assets/fb8872fb-0851-4ed5-ade7-aed2e1b832c3


https://github.com/user-attachments/assets/a814be61-0dd7-4069-a77a-7a89c3cd00e0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined vertical spacing in the chat interface by adjusting padding around chat content for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->