### PR TITLE
Fix/tw 2236 transfer ownership bricks legacy rooms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ devenv.local.nix
 # pre-commit
 .pre-commit-config.yaml
 
+# Patrol generated
+test_bundle.dart
+
+.fvm

--- a/integration_test/.env
+++ b/integration_test/.env
@@ -31,3 +31,5 @@ SSO_URL=ssoURL
 GroupID=groupID
 Receiver=receiverUser
 ReceiverPass=passOfReceiverUser
+
+MemberMatrixID=matrixIdOfMember

--- a/integration_test/robots/chat/chat_profile_info_robot.dart
+++ b/integration_test/robots/chat/chat_profile_info_robot.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 
+import 'package:fluffychat/presentation/enum/profile_info/profile_info_body_enum.dart';
+
 import '../../base/core_robot.dart';
 
 class ChatProfileInfoRobot extends CoreRobot {
@@ -181,6 +183,79 @@ class ChatProfileInfoRobot extends CoreRobot {
       await $(confirmButtons.first).tap();
     }
     await $.pumpAndSettle(timeout: const Duration(seconds: 5));
+  }
+
+  /// Find a profile action button by its enum value
+  PatrolFinder getProfileActionButton(ProfileInfoActions action) {
+    return $(find.byKey(Key('profile_action_${action.name}')));
+  }
+
+  /// Verify a profile action button is visible
+  Future<void> verifyProfileActionButtonVisible(
+    ProfileInfoActions action, {
+    bool expected = true,
+  }) async {
+    if (expected) {
+      try {
+        await getProfileActionButton(
+          action,
+        ).waitUntilVisible(timeout: const Duration(seconds: 5));
+      } catch (_) {
+        // Fall through to the expect below for a clear error message
+      }
+    } else {
+      await $.pump(const Duration(seconds: 2));
+    }
+    final button = getProfileActionButton(action);
+    expect(
+      button.exists,
+      expected,
+      reason: expected
+          ? '${action.name} button not found'
+          : '${action.name} button should not be visible',
+    );
+  }
+
+  /// Tap on a profile action button
+  Future<void> tapProfileActionButton(ProfileInfoActions action) async {
+    final button = getProfileActionButton(action);
+    await button.waitUntilVisible();
+    await button.tap();
+    await $.pump(const Duration(seconds: 2));
+  }
+
+  /// Confirm the transfer ownership dialog
+  Future<void> confirmTransferOwnership() async {
+    await $.waitUntilVisible(
+      $(find.byKey(TwakeDialog.showConfirmAlertDialogKey)),
+    );
+
+    final dialogFinder = find.byKey(TwakeDialog.showConfirmAlertDialogKey);
+    final confirmButton = find.descendant(
+      of: dialogFinder,
+      matching: find.textContaining('Confirm'),
+    );
+
+    if (confirmButton.evaluate().isNotEmpty) {
+      await $(confirmButton).tap();
+      await $.pump(const Duration(seconds: 3));
+      return;
+    }
+
+    // Fallback: tap the first confirm-style button
+    final buttons = find.descendant(
+      of: dialogFinder,
+      matching: find.byWidgetPredicate(
+        (widget) => widget is TextButton || widget is ElevatedButton,
+      ),
+    );
+
+    if (buttons.evaluate().length >= 2) {
+      await $(buttons.at(1)).tap();
+    } else if (buttons.evaluate().isNotEmpty) {
+      await $(buttons.first).tap();
+    }
+    await $.pump(const Duration(seconds: 3));
   }
 
   /// Navigate back from profile info screen

--- a/integration_test/robots/chat_group_detail_robot.dart
+++ b/integration_test/robots/chat_group_detail_robot.dart
@@ -47,7 +47,7 @@ class ChatGroupDetailRobot extends CoreRobot {
 
   Future<void> tapOnChatBarTitle() async {
     await getChatAppBarTitle().tap();
-    await $.waitUntilVisible($("Group information"));
+    await $.waitUntilVisible($("Group info"));
   }
 
   Future<void> tapOnChatBarTitleForDM() async {

--- a/integration_test/robots/chat_list_robot.dart
+++ b/integration_test/robots/chat_list_robot.dart
@@ -83,11 +83,14 @@ class ChatListRobot extends HomeRobot {
     // Tap on the search TextField in the chat list to open search screen
     await $(TextField).tap();
     await $.pumpAndSettle();
-    // Verify SearchView is opened
-    await $.waitUntilVisible($(SearchView));
 
+    // Handle the contacts permission dialog before waiting for SearchView,
+    // as the dialog overlays SearchView and makes it non-hit-testable
     await confirmShareContactInformation();
     await confirmAccessContact();
+
+    // Verify SearchView is opened
+    await $.waitUntilVisible($(SearchView));
   }
 
   Future<void> openSearchScreenWithoutAcceptPermission() async {

--- a/integration_test/robots/search/search_view_robot.dart
+++ b/integration_test/robots/search/search_view_robot.dart
@@ -25,7 +25,7 @@ class SearchViewRobot extends SearchRobot {
       await $.waitUntilVisible($(CircularProgressIndicator));
       await CoreRobot($).waitUntilAbsent($, $(CircularProgressIndicator));
     }
-    await $.pumpAndSettle();
+    await $.pump(const Duration(seconds: 2));
 
     await enterSearchText(roomName);
 

--- a/integration_test/scenarios/chat_scenario.dart
+++ b/integration_test/scenarios/chat_scenario.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 import 'dart:io';
+
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/pages/chat/chat_app_bar_title.dart';
 import 'package:fluffychat/pages/chat/chat_input_row.dart';
@@ -8,6 +9,7 @@ import 'package:fluffychat/pages/chat/chat_pinned_events/pinned_events_view.dart
 import 'package:fluffychat/pages/chat/chat_pinned_events/pinned_messages_screen.dart';
 import 'package:fluffychat/pages/chat/chat_view.dart';
 import 'package:fluffychat/pages/chat/event_info_dialog.dart';
+import 'package:fluffychat/pages/chat/events/images_builder/sending_image_info_widget.dart';
 import 'package:fluffychat/pages/chat/events/message/multi_platform_message_container.dart';
 import 'package:fluffychat/pages/chat/events/message_content.dart';
 import 'package:fluffychat/pages/chat/events/message_time.dart';
@@ -16,18 +18,18 @@ import 'package:fluffychat/pages/chat_draft/draft_chat_view.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_body_view.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action_item_widget.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
-import 'package:fluffychat/pages/chat/events/images_builder/sending_image_info_widget.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:linagora_design_flutter/images_picker/image_item_widget.dart';
 import 'package:linkfy_text/linkfy_text.dart';
 import 'package:patrol/patrol.dart';
+
 import '../base/core_robot.dart';
 import '../help/soft_assertion_helper.dart';
 import '../robots/add_member_robot.dart';
 import '../robots/chat_group_detail_robot.dart';
 import '../robots/chat_list_robot.dart';
-import 'package:flutter/material.dart';
 import '../robots/group_information_robot.dart';
 import '../robots/menu_robot.dart';
 import '../robots/new_chat_robot.dart';
@@ -39,6 +41,11 @@ enum UserLevel { member, admin, owner, moderator }
 
 class ChatScenario extends CoreRobot {
   ChatScenario(super.$);
+
+  L10n get _l10n {
+    final context = $.tester.element(find.byType(Scaffold));
+    return L10n.of(context)!;
+  }
 
   Future<void> enterSearchText(String searchText) async {
     await SearchRobot($).enterSearchText(searchText);
@@ -66,7 +73,7 @@ class ChatScenario extends CoreRobot {
     }
     await AddMemberRobot($).getNextIcon().tap();
     await AddMemberRobot($).getAgreeInviteMemberBtn().tap();
-    await $.waitUntilVisible($("Group information"));
+    await $.waitUntilVisible($(_l10n.groupInfo));
     return (await GroupInformationRobot($).getListOfMembers()).length;
   }
 
@@ -77,7 +84,7 @@ class ChatScenario extends CoreRobot {
       await GroupInformationRobot($).clickOnRemoveFromGroup();
       await GroupInformationRobot($).clickOnAgreeIRemoveMemberBtn();
     }
-    await $.waitUntilVisible($("Group information"));
+    await $.waitUntilVisible($(_l10n.groupInfo));
     return (await GroupInformationRobot($).getListOfMembers()).length;
   }
 
@@ -149,6 +156,9 @@ class ChatScenario extends CoreRobot {
 
     // 2) Get MaterialLocalizations from the input's own context (NOT WidgetsApp)
     final BuildContext inputCtx = $.tester.element(input.finder);
+    if (inputCtx.mounted == false) {
+      throw StateError('Input context is not mounted');
+    }
     final String pasteLabel = MaterialLocalizations.of(
       inputCtx,
     ).pasteButtonLabel;
@@ -221,7 +231,7 @@ class ChatScenario extends CoreRobot {
   Future<void> deleteMessage(String message) async {
     await ChatGroupDetailRobot($).openPullDownMenu(message);
     await (PullDownMenuRobot($).getDeleteItem()).tap();
-    await $.native.tap(Selector(text: 'Delete'));
+    await $.native.tap(Selector(text: _l10n.delete));
   }
 
   Future<ChatGroupDetailRobot> createANewGroupChat(
@@ -318,11 +328,8 @@ class ChatScenario extends CoreRobot {
     await icon.tap();
     // wait for the pinned UI (a real widget on that screen)
     await $.waitUntilVisible(
-      $(AppBar).containing(find.textContaining('Pinned message')),
+      $(AppBar).containing(find.textContaining(_l10n.pinnedMessagesTooltip)),
     );
-    // await $.waitUntilVisible(
-    //   $(PinnedMessagesScreen).containing(find.text('Unpin all message')),
-    // );
 
     await $.waitUntilVisible(
       $(PinnedMessagesScreen),
@@ -331,7 +338,7 @@ class ChatScenario extends CoreRobot {
     await $.waitUntilVisible(
       $(
         PinnedMessagesScreen,
-      ).containing(find.textContaining('Unpin all message')),
+      ).containing(find.textContaining(_l10n.unpinAllMessages)),
     );
   }
 
@@ -342,13 +349,16 @@ class ChatScenario extends CoreRobot {
     final chatInputRow = $(ChatInputRow);
 
     expect(
-      find.descendant(of: $(AppBar).finder, matching: find.byTooltip('Close')),
+      find.descendant(
+        of: $(AppBar).finder,
+        matching: find.byTooltip(_l10n.close),
+      ),
       findsOneWidget,
     );
     expect(
       find.descendant(
         of: $(ChatAppBarTitle).finder,
-        matching: find.byTooltip('Copy'),
+        matching: find.byTooltip(_l10n.copy),
       ),
       findsOneWidget,
     );
@@ -363,24 +373,30 @@ class ChatScenario extends CoreRobot {
       expect(
         find.descendant(
           of: $(ChatAppBarTitle).finder,
-          matching: find.byTooltip('Pin'),
+          matching: find.byTooltip(_l10n.pin),
         ),
         findsOneWidget,
       );
       expect(
         find.descendant(
           of: $(ChatAppBarTitle).finder,
-          matching: find.byTooltip('More'),
+          matching: find.byTooltip(_l10n.more),
         ),
         findsOneWidget,
       );
       expect(
-        find.descendant(of: chatInputRow.finder, matching: find.text('Reply')),
+        find.descendant(
+          of: chatInputRow.finder,
+          matching: find.text(_l10n.reply),
+        ),
         findsOneWidget,
       );
     }
     expect(
-      find.descendant(of: chatInputRow.finder, matching: find.text('Forward')),
+      find.descendant(
+        of: chatInputRow.finder,
+        matching: find.text(_l10n.forward),
+      ),
       findsOneWidget,
     );
     await expectMessageTickSelected(
@@ -599,9 +615,7 @@ class ChatScenario extends CoreRobot {
       return widget.icon == Icons.add_circle_outline;
     });
     await addIcon.tap();
-    final context = $(addIcon).evaluate().first;
-    final nextLabel = L10n.of(context)!.next;
-    await $(nextLabel).tap();
+    await $(_l10n.next).tap();
 
     // 2. Handle permissions if necessary (though usually handled by CoreRobot or LoginScenario)
     // CoreRobot's confirmAccessContact style

--- a/integration_test/tests/chat/transfer_ownership_test.dart
+++ b/integration_test/tests/chat/transfer_ownership_test.dart
@@ -1,0 +1,61 @@
+import 'package:fluffychat/presentation/enum/profile_info/profile_info_body_enum.dart';
+
+import '../../base/test_base.dart';
+import '../../robots/chat/chat_profile_info_robot.dart';
+import '../../robots/chat_list_robot.dart';
+import '../../robots/group_information_robot.dart';
+import '../../robots/search/search_view_robot.dart';
+import '../../scenarios/chat_scenario.dart';
+
+const searchPhrase = String.fromEnvironment(
+  'SearchByTitle',
+  defaultValue: 'My Default Group',
+);
+
+const memberMatrixID = String.fromEnvironment(
+  'MemberMatrixID',
+  defaultValue: '@member:localhost',
+);
+
+void main() {
+  TestBase().runPatrolTest(
+    tags: ['transfer_ownership_test_01'],
+    description:
+        'Transfer ownership button disappears after successful transfer',
+    test: ($) async {
+      // 1. Open the group chat
+      await ChatListRobot($).openSearchScreen();
+      final room = await SearchViewRobot($).searchRoom(searchPhrase);
+      if (room == null) {
+        throw Exception('Test failed: Room "$searchPhrase" was not found.');
+      }
+      await SearchViewRobot($).openRoom(room);
+
+      // 2. Open group info and navigate to a member's profile
+      await ChatScenario($).openGroupChatInfo();
+      await GroupInformationRobot($).openMemberDetail(matrixID: memberMatrixID);
+
+      // 3. Verify transfer ownership button is visible (current user is owner)
+      await ChatProfileInfoRobot(
+        $,
+      ).verifyProfileActionButtonVisible(ProfileInfoActions.transferOwnership);
+
+      // 4. Tap transfer ownership and confirm
+      await ChatProfileInfoRobot(
+        $,
+      ).tapProfileActionButton(ProfileInfoActions.transferOwnership);
+      await ChatProfileInfoRobot($).confirmTransferOwnership();
+
+      // 5. Wait for the operation to complete and profile page to pop
+      await $.pump(const Duration(seconds: 3));
+
+      // 6. After transfer, the profile page pops back to Group Info.
+      //    Re-open the same member's profile to verify the button is gone.
+      await GroupInformationRobot($).openMemberDetail(matrixID: memberMatrixID);
+      await ChatProfileInfoRobot($).verifyProfileActionButtonVisible(
+        ProfileInfoActions.transferOwnership,
+        expected: false,
+      );
+    },
+  );
+}

--- a/lib/domain/model/room/room_extension.dart
+++ b/lib/domain/model/room/room_extension.dart
@@ -355,11 +355,15 @@ extension RoomExtension on Room {
                 false)),
   );
 
+  /// Get the default power level for users in the room
+  ///
   int getUserDefaultLevel() {
+    const usersDefaultKey = 'users_default';
+
     return getState(
           EventTypes.RoomPowerLevels,
-        )!.content.tryGet<int>('users_default') ??
-        0;
+        )?.content.tryGet<int>(usersDefaultKey) ??
+        DefaultPowerLevelMember.guest.powerLevel;
   }
 
   bool get canTransferOwnership {

--- a/lib/domain/usecase/room/set_permission_level_interactor.dart
+++ b/lib/domain/usecase/room/set_permission_level_interactor.dart
@@ -5,6 +5,10 @@ import 'package:fluffychat/domain/app_state/room/set_permission_level_state.dart
 import 'package:matrix/matrix.dart';
 
 class SetPermissionLevelInteractor {
+  /// Set the permission level for a list of users in a room
+  /// [room] The room in which to set the permission levels
+  /// [userPermissionLevels] A map of users and their corresponding permission levels to set
+  ///
   Stream<Either<Failure, Success>> execute({
     required Room room,
     required Map<User, int> userPermissionLevels,
@@ -12,13 +16,16 @@ class SetPermissionLevelInteractor {
     try {
       yield Right(SetPermissionLevelLoading());
 
-      var powerMap = room.getState(EventTypes.RoomPowerLevels)?.content;
-      if (powerMap is! Map<String, dynamic>) {
-        powerMap = <String, dynamic>{};
-      }
-      final usersMap = powerMap['users'] ??= {};
+      final powerMap = Map<String, dynamic>.from(
+        room.getState(EventTypes.RoomPowerLevels)?.content ??
+            const <String, dynamic>{},
+      );
+      final usersMap = Map<String, dynamic>.from(
+        powerMap['users'] as Map? ?? const <String, dynamic>{},
+      );
+      powerMap['users'] = usersMap;
 
-      userPermissionLevels.forEach((user, level) {
+      userPermissionLevels.forEach((User user, int level) {
         usersMap[user.id] = level;
       });
 
@@ -33,6 +40,8 @@ class SetPermissionLevelInteractor {
     } on MatrixException catch (e) {
       if (e.error == MatrixError.M_FORBIDDEN) {
         yield const Left(NoPermissionFailure());
+      } else {
+        yield Left(SetPermissionLevelFailure(exception: e));
       }
     } catch (error) {
       yield Left(SetPermissionLevelFailure(exception: error));

--- a/lib/pages/chat_details/chat_details_page_view/chat_details_members_page.dart
+++ b/lib/pages/chat_details/chat_details_page_view/chat_details_members_page.dart
@@ -95,7 +95,8 @@ class ChatDetailsMembersPage extends StatelessWidget {
                       listenable: selectedUsersMapChangeNotifier,
                       builder: (context, child) {
                         return ParticipantListItem(
-                          members![index],
+                          key: ValueKey(members![index].id),
+                          members[index],
                           onUpdatedMembers: onUpdatedMembers,
                           selectionMode: selectedUsersMapChangeNotifier
                               .getSelectionModeForUser(members[index]),

--- a/lib/pages/profile_info/profile_info_body/profile_info_body.dart
+++ b/lib/pages/profile_info/profile_info_body/profile_info_body.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/domain/app_state/user_info/get_user_info_state.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/domain/usecase/room/set_permission_level_interactor.dart';
 import 'package:fluffychat/domain/usecase/user_info/get_user_info_interactor.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/pages/profile_info/profile_info_body/profile_info_body_view.dart';
 import 'package:fluffychat/pages/profile_info/profile_info_body/profile_info_body_view_style.dart';
 import 'package:fluffychat/presentation/enum/profile_info/profile_info_body_enum.dart';
@@ -26,7 +27,6 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
-import 'package:fluffychat/generated/l10n/app_localizations.dart';
 
 class ProfileInfoBody extends StatefulWidget {
   const ProfileInfoBody({
@@ -51,12 +51,9 @@ class ProfileInfoBody extends StatefulWidget {
 
 class ProfileInfoBodyController extends State<ProfileInfoBody>
     with SingleTickerProviderStateMixin {
-  final _getUserInfoInteractor = getIt.get<GetUserInfoInteractor>();
+  static const int _animationDuration = 100;
 
-  final _setPermissionLevelInteractor = getIt
-      .get<SetPermissionLevelInteractor>();
-
-  final responsive = getIt.get<ResponsiveUtils>();
+  final ResponsiveUtils responsive = getIt.get<ResponsiveUtils>();
 
   StreamSubscription? _setPermissionLevelSubscription;
 
@@ -71,15 +68,35 @@ class ProfileInfoBodyController extends State<ProfileInfoBody>
 
   Timer? _avatarToggleTimer;
 
-  static const int _animationDuration = 100;
-
   User? get user => widget.user;
 
   bool get isOwnProfile => user?.id == user?.room.client.userID;
 
+  @override
+  void initState() {
+    super.initState();
+    animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: _animationDuration),
+    );
+    getUserInfoAction();
+  }
+
+  @override
+  void dispose() {
+    userInfoNotifierSub?.cancel();
+    _setPermissionLevelSubscription?.cancel();
+    _avatarToggleTimer?.cancel();
+    animationController.dispose();
+    isExpandedAvatar.dispose();
+    userInfoNotifier.dispose();
+    super.dispose();
+  }
+
   void getUserInfoAction() {
     if (user == null) return;
-    userInfoNotifierSub = _getUserInfoInteractor
+    userInfoNotifierSub = getIt
+        .get<GetUserInfoInteractor>()
         .execute(userId: user!.id)
         .listen((event) => userInfoNotifier.value = event);
   }
@@ -116,33 +133,36 @@ class ProfileInfoBodyController extends State<ProfileInfoBody>
     required String path,
     required ContactPresentationSearch contactPresentationSearch,
   }) {
-    if (contactPresentationSearch.matrixId !=
+    if (contactPresentationSearch.matrixId ==
         Matrix.of(context).client.userID) {
-      Router.neglect(
-        context,
-        () => context.go(
-          '/$path/draftChat',
-          extra: {
-            PresentationContactConstant.receiverId:
-                contactPresentationSearch.matrixId ?? '',
-            PresentationContactConstant.displayName:
-                contactPresentationSearch.displayName ?? '',
-            PresentationContactConstant.status: '',
-          },
-        ),
-      );
+      return;
     }
+
+    Router.neglect(
+      context,
+      () => context.go(
+        '/$path/draftChat',
+        extra: {
+          PresentationContactConstant.receiverId:
+              contactPresentationSearch.matrixId ?? '',
+          PresentationContactConstant.displayName:
+              contactPresentationSearch.displayName ?? '',
+          PresentationContactConstant.status: '',
+        },
+      ),
+    );
   }
 
   Future<void> removeFromGroupChat() async {
     if (user == null) return;
+
     WarningDialog.hideWarningDialog(context);
     final result = await TwakeDialog.showFutureLoadingDialogFullScreen(
       future: () => user!.ban(),
     );
     if (result.error != null) {
-      TwakeSnackBar.show(context, result.error!.message);
-      return;
+      if (!mounted) return;
+      return TwakeSnackBar.show(context, result.error!.message);
     }
     widget.onUpdatedMembers?.call();
   }
@@ -187,6 +207,7 @@ class ProfileInfoBodyController extends State<ProfileInfoBody>
               children: [
                 if (action.divider(context) != null) action.divider(context)!,
                 InkWell(
+                  key: Key('profile_action_${action.name}'),
                   highlightColor: Colors.transparent,
                   splashColor: Colors.transparent,
                   focusColor: Colors.transparent,
@@ -230,60 +251,74 @@ class ProfileInfoBodyController extends State<ProfileInfoBody>
     );
   }
 
+  /// Transfer ownership of the room to the user
+  ///
+  /// Related to:
+  ///   [SetPermissionLevelInteractor] to set the user's power level to owner and the current user's power level to admin
+  ///   [DefaultPowerLevelMember] to get the power level of owner and admin
+  ///
   Future<void> transferOwnership() async {
-    if (user == null) return;
-    if (user?.room == null) return;
+    if (user == null || user?.room == null) return;
+
+    final L10n? translations = L10n.of(context);
+
     await showConfirmAlertDialog(
       context: context,
-      title: L10n.of(
-        context,
-      )?.confirmTransferOwnership(user?.displayName ?? ''),
-      message: L10n.of(context)?.transferOwnershipDescription,
-      okLabel: L10n.of(context)?.confirm,
-      cancelLabel: L10n.of(context)?.cancel,
+      title: translations?.confirmTransferOwnership(user?.displayName ?? ''),
+      message: translations?.transferOwnershipDescription,
+      okLabel: translations?.confirm,
+      cancelLabel: translations?.cancel,
     ).then((result) {
-      if (result == ConfirmResult.ok) {
-        _setPermissionLevelSubscription = _setPermissionLevelInteractor
-            .execute(
-              room: user!.room,
-              userPermissionLevels: {
-                user!: DefaultPowerLevelMember.owner.powerLevel,
-                user!.room.ownUser: DefaultPowerLevelMember.admin.powerLevel,
-              },
-            )
-            .listen((state) => _handleSetPermissionState(state));
-      }
+      if (result == ConfirmResult.cancel) return;
+
+      final Room room = user!.room;
+      _setPermissionLevelSubscription = getIt
+          .get<SetPermissionLevelInteractor>()
+          .execute(
+            room: room,
+            userPermissionLevels: {
+              user!: room.ownUser.powerLevel,
+              room.ownUser: room.getUserDefaultLevel(),
+            },
+          )
+          .listen(_handleSetPermissionState);
     });
   }
 
+  /// Handles the result state of a permission level change operation.
+  ///
   void _handleSetPermissionState(Either<Failure, Success> state) {
     state.fold(
-      (failure) {
-        if (failure is SetPermissionLevelFailure) {
-          TwakeDialog.hideLoadingDialog(context);
-          TwakeSnackBar.show(context, failure.exception.toString());
-          return;
-        }
+      (Failure failure) {
+        _setPermissionLevelSubscription?.cancel();
+        if (!mounted) return;
+        switch (failure) {
+          case SetPermissionLevelFailure():
+            TwakeDialog.hideLoadingDialog(context);
+            TwakeSnackBar.show(context, failure.exception.toString());
 
-        if (failure is NoPermissionFailure) {
-          TwakeDialog.hideLoadingDialog(context);
-          TwakeSnackBar.show(
-            context,
-            L10n.of(context)!.permissionErrorChangeRole,
-          );
-          return;
+          case NoPermissionFailure():
+            TwakeDialog.hideLoadingDialog(context);
+            TwakeSnackBar.show(
+              context,
+              L10n.of(context)!.permissionErrorChangeRole,
+            );
+          default:
+            break;
         }
       },
-      (success) {
-        if (success is SetPermissionLevelLoading) {
-          TwakeDialog.showLoadingDialog(context);
-          return;
-        }
+      (Success success) {
+        switch (success) {
+          case SetPermissionLevelLoading():
+            TwakeDialog.showLoadingDialog(context);
 
-        if (success is SetPermissionLevelSuccess) {
-          TwakeDialog.hideLoadingDialog(context);
-          widget.onTransferOwnershipSuccess?.call();
-          return;
+          case SetPermissionLevelSuccess():
+            _setPermissionLevelSubscription?.cancel();
+            if (!mounted) return;
+            TwakeDialog.hideLoadingDialog(context);
+            widget.onTransferOwnershipSuccess?.call();
+          default:
+            break;
         }
       },
     );
@@ -321,27 +356,6 @@ class ProfileInfoBodyController extends State<ProfileInfoBody>
         },
       );
     }
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    animationController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: _animationDuration),
-    );
-    getUserInfoAction();
-  }
-
-  @override
-  void dispose() {
-    animationController.dispose();
-    isExpandedAvatar.dispose();
-    userInfoNotifier.dispose();
-    userInfoNotifierSub?.cancel();
-    _setPermissionLevelSubscription?.cancel();
-    _avatarToggleTimer?.cancel();
-    super.dispose();
   }
 
   @override

--- a/lib/presentation/enum/profile_info/profile_info_body_enum.dart
+++ b/lib/presentation/enum/profile_info/profile_info_body_enum.dart
@@ -1,6 +1,6 @@
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/pages/profile_info/profile_info_body/profile_info_body_view_style.dart';
 import 'package:flutter/material.dart';
-import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 
 enum ProfileInfoActions {
@@ -10,34 +10,33 @@ enum ProfileInfoActions {
   transferOwnership;
 
   String label(BuildContext context) {
+    final L10n l10n = L10n.of(context)!;
     switch (this) {
       case ProfileInfoActions.sendMessage:
-        return L10n.of(context)!.sendMessage;
+        return l10n.sendMessage;
       case ProfileInfoActions.removeFromGroup:
-        return L10n.of(context)!.removeFromGroup;
+        return l10n.removeFromGroup;
       case ProfileInfoActions.downgradeToReadOnly:
-        return L10n.of(context)!.downgradeToReadOnly;
+        return l10n.downgradeToReadOnly;
       case ProfileInfoActions.transferOwnership:
-        return L10n.of(context)!.transferOwnership;
+        return l10n.transferOwnership;
     }
   }
 
   TextStyle textStyle(BuildContext context) {
+    final TextTheme textTheme = Theme.of(context).textTheme;
     switch (this) {
       case ProfileInfoActions.sendMessage:
-        return Theme.of(context).textTheme.labelLarge!.copyWith(
+        return textTheme.labelLarge!.copyWith(
           color: LinagoraSysColors.material().onPrimary,
         );
       case ProfileInfoActions.removeFromGroup:
-        return Theme.of(context).textTheme.labelLarge!.copyWith(
+        return textTheme.labelLarge!.copyWith(
           color: LinagoraSysColors.material().error,
         );
       case ProfileInfoActions.downgradeToReadOnly:
-        return Theme.of(context).textTheme.labelLarge!.copyWith(
-          color: LinagoraSysColors.material().primary,
-        );
       case ProfileInfoActions.transferOwnership:
-        return Theme.of(context).textTheme.labelLarge!.copyWith(
+        return textTheme.labelLarge!.copyWith(
           color: LinagoraSysColors.material().primary,
         );
     }


### PR DESCRIPTION
## Ticket
TW-2236: Transfer Ownership button bricks legacy rooms

## Root cause
Hardcoded power levels in transferOwnership() :
The old implementation used hardcoded power levels (DefaultPowerLevelMember.owner.powerLevel = 90 and DefaultPowerLevelMember.admin.powerLevel = 80) instead of the room's actual power levels. In legacy rooms where the owner had a different power level (e.g., 100), this would:                                                                            
  - Set the target user to level 90 instead of the actual owner level — they never truly became owner
  - Demote the original owner to 80 (admin) instead of the room's users_default

## Solution
1. Use dynamic room power levels instead of hardcoded values
transferOwnership() now reads the actual owner's power level (room.ownUser.powerLevel) to assign to the target user, and demotes the current owner to the room's users_default level via room.getUserDefaultLevel(). This ensures correct behavior regardless of the room's power level configuration.

2. Fix getUserDefaultLevel() fallback
Changed the fallback from 0 to DefaultPowerLevelMember.guest.powerLevel to ensure consistency with the app's power level definitions.

3. Add E2E integration test
Added a Patrol integration test that verifies the full transfer ownership flow: opens a group chat, navigates to a member's profile, transfers ownership, then verifies the transfer button is no longer visible (confirming the current user lost owner privileges).

## Test recommendations
1. Manual pre-condition setup
This test is not idempotent — after a successful run, ownership has been transferred. Before re-running, the owner must be manually restored to the original user.

## Refactoring & code hygiene:

- Widget lifecycle & member ordering: Reordered ProfileInfoBodyController members following the [doc](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#order-other-class-members-in-a-way-that-makes-sense).
- Strict typing on class attributes: Added explicit types to class fields (e.g., final ResponsiveUtils responsive instead of implicit final responsive)
- Inverted condition fix in _goToDraftChat(): The guard clause used != instead of ==, preventing draft chats from opening for other users. Replaced with an early return pattern.
- Switch expressions: Replaced if/return chains in _handleSetPermissionState() with switch pattern matching for exhaustive state handling.
- .gitignore updates: Added test_bundle.dart (Patrol auto-generated, marked DO NOT COMMIT) and .fvm/ (Flutter Version Management local config).

## Resolved
- Web:
<img width="521" height="170" alt="image" src="https://github.com/user-attachments/assets/27b6e674-916c-4443-b215-03101a4762ce" />
<img width="1035" height="404" alt="image" src="https://github.com/user-attachments/assets/cbcb8dd8-e7a2-4d40-931b-87eedd6fc141" />
<img width="526" height="191" alt="image" src="https://github.com/user-attachments/assets/ecc3efee-3f3b-4053-9fbb-fbd694bcdbfc" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer group ownership UI flow added and covered by a new integration test
  * New profile action controls exposed for test automation

* **Improvements**
  * Expanded localization across chat scenarios and UI text
  * Lifecycle, animation and reliability improvements in profile UI
  * Better contact-permission handling in search flow
  * Member list stability improved via identity keys
  * Minor UI text tweak ("Group info")

* **Bug Fixes**
  * More reliable waits for progress indicators and dialogs

* **Chores**
  * Updated ignore rules and test environment variables
<!-- end of auto-generated comment: release notes by coderabbit.ai -->