### PR TITLE
[APRIL SPRINT] TW-2893 Add multi account noti

### DIFF
--- a/ios/NSE/KeychainController.swift
+++ b/ios/NSE/KeychainController.swift
@@ -20,7 +20,6 @@ import MatrixRustSDK
 
 enum KeychainControllerService: String {
     case sessions
-    case ssss
     case tests
 
     var identifier: String {
@@ -30,16 +29,11 @@ enum KeychainControllerService: String {
 
 class KeychainController: KeychainControllerProtocol {
     private let keychain: Keychain
-    private let ssssKeychain: Keychain
 
     init(service: KeychainControllerService,
          accessGroup: String) {
         keychain = Keychain(service: service.identifier,
                             accessGroup: accessGroup)
-        ssssKeychain = Keychain(
-            service: KeychainControllerService.ssss.identifier,
-            accessGroup: accessGroup
-        )
     }
 
     func setRestorationToken(_ restorationToken: RestorationToken, forUsername username: String) {
@@ -99,7 +93,7 @@ class KeychainController: KeychainControllerProtocol {
     func recoveryKey(forUsername username: String) -> String? {
         let keychainKey = "ssss_recovery_\(username)"
         do {
-            return try ssssKeychain.getString(keychainKey)
+            return try keychain.getString(keychainKey)
         } catch {
             MXLog.error("Failed retrieving SSSS recovery key: \(error)")
             return nil

--- a/ios/NSE/Logging/MXLog.swift
+++ b/ios/NSE/Logging/MXLog.swift
@@ -59,7 +59,7 @@ enum MXLog {
                                logFileSizeLimit: logFileSizeLimit)
             return
         }
-        
+
         if let target {
             self.target = target
             MXLogger.setSubLogName(target)
@@ -193,6 +193,6 @@ enum MXLog {
         
         let messageString = "\(message)"
         logEvent(file: (file as NSString).lastPathComponent, line: UInt32(line), level: level, target: target, message: messageString)
-        os_log("MXLog: %{private}@", messageString)
+        os_log("MXLog: %{public}@", messageString)
     }
 }

--- a/ios/NSE/Sources/Other/NSEUserSession.swift
+++ b/ios/NSE/Sources/Other/NSEUserSession.swift
@@ -61,18 +61,28 @@ final class NSEUserSession {
             .notificationClient(processSetup: .multipleProcesses)
     }
     
+    // Retry delays in milliseconds; kept as ms for readability, converted to ns at call site.
+    private static let retryDelaysMs: [UInt64] = [300, 800]
+
     func notificationItemProxy(roomID: String, eventID: String) async -> NotificationItemProxyProtocol? {
         var proxy = await fetchNotificationItem(roomID: roomID, eventID: eventID)
         guard proxy?.isEncrypted == true else { return proxy }
 
         // Recovery key is registered in init, but decryption may not have settled yet.
         // Two bounded retries give the Rust SDK time to decrypt without blocking indefinitely.
-        let retryDelaysNs: [UInt64] = [300_000_000, 800_000_000]
-        for (attempt, delayNs) in retryDelaysNs.enumerated() {
-            MXLog.info("NSE: Notification still encrypted, retrying after \(delayNs / 1_000_000)ms (attempt \(attempt + 1)) - roomID: \(roomID)")
-            try? await Task.sleep(nanoseconds: delayNs)
-            proxy = await fetchNotificationItem(roomID: roomID, eventID: eventID)
+        for (attempt, delayMs) in Self.retryDelaysMs.enumerated() {
+            MXLog.info("NSE: Notification still encrypted, retrying after \(delayMs)ms (attempt \(attempt + 1)) - roomID: \(roomID)")
+            try? await Task.sleep(nanoseconds: delayMs * 1_000_000)
+            // Only overwrite proxy when the retry returns a value, to avoid losing
+            // the encrypted fallback if the SDK transiently returns nil.
+            if let retried = await fetchNotificationItem(roomID: roomID, eventID: eventID) {
+                proxy = retried
+            }
             if proxy?.isEncrypted != true { break }
+        }
+
+        if proxy?.isEncrypted == true {
+            MXLog.warning("NSE: Notification remains encrypted after \(Self.retryDelaysMs.count) retries - roomID: \(roomID)")
         }
 
         return proxy

--- a/ios/NSE/Sources/Other/NSEUserSession.swift
+++ b/ios/NSE/Sources/Other/NSEUserSession.swift
@@ -62,22 +62,6 @@ final class NSEUserSession {
     }
     
     func notificationItemProxy(roomID: String, eventID: String) async -> NotificationItemProxyProtocol? {
-        var proxy: NotificationItemProxyProtocol? = await fetchNotificationItem(roomID: roomID, eventID: eventID)
-        if let proxy, !proxy.isEncrypted { return proxy }
-
-        for attempt in 0..<3 {
-            let delaySeconds = 1 << attempt
-            MXLog.info("NSE: Notification is \(proxy == nil ? "nil" : "encrypted"), retrying in \(delaySeconds)s (attempt \(attempt)) - roomID: \(roomID)")
-            try? await Task.sleep(nanoseconds: UInt64(delaySeconds) * 1_000_000_000)
-
-            proxy = await fetchNotificationItem(roomID: roomID, eventID: eventID)
-            if let proxy, !proxy.isEncrypted { return proxy }
-        }
-
-        return proxy
-    }
-
-    private func fetchNotificationItem(roomID: String, eventID: String) async -> NotificationItemProxyProtocol? {
         do {
             let status = try await notificationClient.getNotification(roomId: roomID, eventId: eventID)
             switch status {

--- a/ios/NSE/Sources/Other/NSEUserSession.swift
+++ b/ios/NSE/Sources/Other/NSEUserSession.swift
@@ -62,6 +62,23 @@ final class NSEUserSession {
     }
     
     func notificationItemProxy(roomID: String, eventID: String) async -> NotificationItemProxyProtocol? {
+        var proxy = await fetchNotificationItem(roomID: roomID, eventID: eventID)
+        guard proxy?.isEncrypted == true else { return proxy }
+
+        // Recovery key is registered in init, but decryption may not have settled yet.
+        // Two bounded retries give the Rust SDK time to decrypt without blocking indefinitely.
+        let retryDelaysNs: [UInt64] = [300_000_000, 800_000_000]
+        for (attempt, delayNs) in retryDelaysNs.enumerated() {
+            MXLog.info("NSE: Notification still encrypted, retrying after \(delayNs / 1_000_000)ms (attempt \(attempt + 1)) - roomID: \(roomID)")
+            try? await Task.sleep(nanoseconds: delayNs)
+            proxy = await fetchNotificationItem(roomID: roomID, eventID: eventID)
+            if proxy?.isEncrypted != true { break }
+        }
+
+        return proxy
+    }
+
+    private func fetchNotificationItem(roomID: String, eventID: String) async -> NotificationItemProxyProtocol? {
         do {
             let status = try await notificationClient.getNotification(roomId: roomID, eventId: eventID)
             switch status {

--- a/lib/data/model/push/twake_local_notification_payload.dart
+++ b/lib/data/model/push/twake_local_notification_payload.dart
@@ -1,0 +1,31 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'twake_local_notification_payload.g.dart';
+
+/// Payload attached to local notifications for routing on tap.
+@JsonSerializable()
+class TwakeLocalNotificationPayload {
+  @JsonKey(name: 'room_id')
+  final String? roomId;
+
+  @JsonKey(name: 'receiver_id')
+  final String? receiverId;
+
+  @JsonKey(name: 'event_id')
+  final String? eventId;
+
+  const TwakeLocalNotificationPayload({
+    this.roomId,
+    this.receiverId,
+    this.eventId,
+  });
+
+  factory TwakeLocalNotificationPayload.fromJson(Map<String, dynamic> json) =>
+      _$TwakeLocalNotificationPayloadFromJson(json);
+
+  Map<String, dynamic> toJson() => _$TwakeLocalNotificationPayloadToJson(this);
+
+  /// Returns an empty payload used as a safe fallback.
+  factory TwakeLocalNotificationPayload.empty() =>
+      const TwakeLocalNotificationPayload();
+}

--- a/lib/domain/keychain_sharing/keychain_sharing_manager.dart
+++ b/lib/domain/keychain_sharing/keychain_sharing_manager.dart
@@ -17,16 +17,6 @@ class KeychainSharingManager {
     ),
   );
 
-  static FlutterSecureStorage get _recoveryStorage =>
-      const FlutterSecureStorage(
-        iOptions: IOSOptions(
-          groupId: AppConfig.iOSKeychainSharingId,
-          accountName: AppConfig.iOSKeychainSharingSsssAccount,
-          synchronizable: false,
-          accessibility: KeychainAccessibility.first_unlock_this_device,
-        ),
-      );
-
   static const String _ssssRecoveryKeyPrefix = 'ssss_recovery_';
 
   static Future<void> saveRecoveryKey({
@@ -35,7 +25,7 @@ class KeychainSharingManager {
   }) async {
     if (!PlatformInfos.isIOS || userId == null) return;
     try {
-      await _recoveryStorage.write(
+      await _secureStorage.write(
         key: '$_ssssRecoveryKeyPrefix$userId',
         value: recoveryKey,
       );
@@ -48,7 +38,7 @@ class KeychainSharingManager {
   static Future<void> deleteRecoveryKey({required String? userId}) async {
     if (!PlatformInfos.isIOS || userId == null) return;
     try {
-      await _recoveryStorage.delete(key: '$_ssssRecoveryKeyPrefix$userId');
+      await _secureStorage.delete(key: '$_ssssRecoveryKeyPrefix$userId');
       Logs().d('[KeychainSharing] Deleted SSSS recovery key for $userId');
     } catch (e, s) {
       Logs().wtf('[KeychainSharing] Unable to delete SSSS recovery key', e, s);

--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -21,6 +21,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:fcm_shared_isolate/fcm_shared_isolate.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/keychain_sharing/keychain_sharing_manager.dart';
@@ -108,56 +109,199 @@ class BackgroundPush {
         if (call.method == 'willPresent') {
           onReceiveNotification(call.arguments);
         } else if (call.method == 'didReceive') {
-          iOSUserSelectedNoti(call.arguments);
+          await iOSUserSelectedNoti(call.arguments);
         }
       });
       getIosInitialNoti();
-      _setupKeychainSyncListener();
+      _setupKeychainSyncForClient(client);
     }
   }
 
-  String? _lastKeychainAccessToken;
-  bool _didSyncRecoveryKey = false;
+  final Map<String, StreamSubscription> _keychainSyncSubs = {};
 
-  void _setupKeychainSyncListener() {
-    client.onSync.stream.listen((_) async {
-      final accessToken = client.accessToken;
-      if (accessToken == null || !client.isLogged()) return;
+  bool _isActiveClient(Client targetClient) =>
+      _matrixState?.client.userID == targetClient.userID;
 
-      if (accessToken != _lastKeychainAccessToken) {
-        _lastKeychainAccessToken = accessToken;
-        final userId = client.userID;
-        final homeserver = client.homeserver?.toString();
-        if (userId != null && homeserver != null) {
-          await KeychainSharingManager.saveSession(
-            accessToken: accessToken,
-            userId: userId,
-            deviceId: client.deviceID ?? '',
-            homeserverUrl: homeserver,
-          );
-        }
-      }
-
-      if (!_didSyncRecoveryKey) {
-        _didSyncRecoveryKey = true;
-        await _syncRecoveryKeyToKeychain();
-      }
-    });
-  }
-
-  Future<void> _syncRecoveryKeyToKeychain() async {
-    final userId = client.userID;
-    if (userId == null) return;
+  Future<void> _syncRecoveryKeyForUserId(String userId) async {
     final result = await getIt.get<GetRecoveryWordsInteractor>().execute();
     await result.fold(
       (failure) async => Logs().d(
-        '[KeychainSharing] No recovery words found to sync: $failure',
+        '[KeychainSharing] No recovery words found to sync for $userId: $failure',
       ),
       (success) => KeychainSharingManager.saveRecoveryKey(
         userId: userId,
         recoveryKey: success.words.words,
       ),
     );
+  }
+
+  void _setupKeychainSyncForClient(Client targetClient) {
+    String? lastAccessToken;
+    bool didSyncRecoveryKey = false;
+
+    final sub = targetClient.onSync.stream.listen((_) async {
+      final accessToken = targetClient.accessToken;
+      if (accessToken == null || !targetClient.isLogged()) return;
+
+      if (accessToken != lastAccessToken) {
+        lastAccessToken = accessToken;
+        final userId = targetClient.userID;
+        final homeserver = targetClient.homeserver?.toString();
+        if (userId != null && homeserver != null) {
+          await KeychainSharingManager.saveSession(
+            accessToken: accessToken,
+            userId: userId,
+            deviceId: targetClient.deviceID ?? '',
+            homeserverUrl: homeserver,
+          );
+        }
+      }
+
+      if (!didSyncRecoveryKey && _isActiveClient(targetClient)) {
+        final userId = targetClient.userID;
+        if (userId != null) await _syncRecoveryKeyForUserId(userId);
+        didSyncRecoveryKey = true;
+      }
+    });
+
+    final userId = targetClient.userID;
+    if (userId != null) {
+      _keychainSyncSubs[userId]?.cancel();
+      _keychainSyncSubs[userId] = sub;
+    }
+  }
+
+  void cancelKeychainSyncForClient(Client targetClient) {
+    final userId = targetClient.userID;
+    if (userId == null) return;
+    _keychainSyncSubs[userId]?.cancel();
+    _keychainSyncSubs.remove(userId);
+  }
+
+  Future<void> syncRecoveryKeyForClient(Client targetClient) async {
+    if (!PlatformInfos.isIOS) return;
+    final userId = targetClient.userID;
+    if (userId == null) return;
+    await _syncRecoveryKeyForUserId(userId);
+  }
+
+  Future<void> _setupPusherForClient({
+    required Client targetClient,
+    required String gatewayUrl,
+    required String token,
+  }) async {
+    final clientName = PlatformInfos.clientName;
+    final appId = AppConfig.pushNotificationsAppId;
+
+    final pushers =
+        await targetClient.getPushers().catchError((e) {
+          Logs().w(
+            '[Push] Unable to request pushers for ${targetClient.userID}',
+            e,
+          );
+          return <Pusher>[];
+        }) ??
+        [];
+
+    final currentPushers = pushers.where((p) => p.pushkey == token);
+    if (currentPushers.length == 1 &&
+        currentPushers.first.kind == 'http' &&
+        currentPushers.first.appId == appId &&
+        currentPushers.first.appDisplayName == clientName &&
+        currentPushers.first.deviceDisplayName == targetClient.deviceName &&
+        currentPushers.first.lang == 'en' &&
+        currentPushers.first.data.url.toString() == gatewayUrl &&
+        currentPushers.first.data.format ==
+            AppConfig.pushNotificationsPusherFormat) {
+      Logs().i('[Push] Pusher already set for ${targetClient.userID}');
+      return;
+    }
+
+    try {
+      await targetClient.postPusher(
+        Pusher(
+          pushkey: token,
+          appId: appId,
+          appDisplayName: clientName,
+          deviceDisplayName: targetClient.deviceName!,
+          lang: 'en',
+          data: PusherData(
+            url: Uri.parse(gatewayUrl),
+            format: AppConfig.pushNotificationsPusherFormat,
+            additionalProperties: {
+              "default_payload": {
+                "aps": {
+                  "mutable-content": 1,
+                  "content-available": 1,
+                  "badge": 1,
+                  "sound": "default",
+                  "alert": {"loc-key": "newMessageInTwake", "loc-args": []},
+                },
+                "pusher_notification_client_identifier":
+                    targetClient.pusherNotificationClientIdentifier,
+              },
+            },
+          ),
+          kind: 'http',
+        ),
+        append: false,
+      );
+      Logs().i(
+        '[Push] Pusher registered for additional account ${targetClient.userID}',
+      );
+    } catch (e, s) {
+      Logs().e('[Push] Unable to set pusher for ${targetClient.userID}', e, s);
+    }
+  }
+
+  Future<void> setupPushForAdditionalClient(Client additionalClient) async {
+    if (!PlatformInfos.isIOS) return;
+
+    _setupKeychainSyncForClient(additionalClient);
+
+    final token = _pushToken;
+    if (token == null) {
+      Logs().w(
+        '[Push] setupPushForAdditionalClient: no APN token cached yet for ${additionalClient.userID}',
+      );
+      return;
+    }
+    await _setupPusherForClient(
+      targetClient: additionalClient,
+      gatewayUrl: AppConfig.pushNotificationsGatewayUrl,
+      token: token,
+    );
+  }
+
+  Future<void> removePusherForClient(Client targetClient) async {
+    if (!PlatformInfos.isIOS) return;
+    final token = _pushToken;
+    if (token == null) return;
+
+    try {
+      final pushers =
+          await targetClient.getPushers().catchError((e) {
+            Logs().w(
+              '[Push] Unable to get pushers for ${targetClient.userID}',
+              e,
+            );
+            return <Pusher>[];
+          }) ??
+          [];
+
+      for (final pusher in pushers) {
+        if (pusher.pushkey == token) {
+          await targetClient.deletePusher(pusher);
+          Logs().i('[Push] Removed pusher for ${targetClient.userID}');
+        }
+      }
+    } catch (e, s) {
+      Logs().e(
+        '[Push] Failed to remove pusher for ${targetClient.userID}',
+        e,
+        s,
+      );
+    }
   }
 
   factory BackgroundPush.clientOnly(Client client) {
@@ -380,6 +524,14 @@ class BackgroundPush {
       gatewayUrl: AppConfig.pushNotificationsGatewayUrl,
       token: _pushToken,
     );
+
+    if (PlatformInfos.isIOS && _matrixState != null) {
+      for (final additionalClient in _matrixState!.widget.clients) {
+        if (additionalClient == client) continue;
+        if (!additionalClient.isLogged()) continue;
+        await setupPushForAdditionalClient(additionalClient);
+      }
+    }
   }
 
   Future<void> getIosInitialNoti() async {
@@ -387,18 +539,47 @@ class BackgroundPush {
       final noti = await apnChannel.invokeMethod('getInitialNoti');
       Logs().v('[Push] Got initial notification: $noti');
       if (noti != null) {
-        iOSUserSelectedNoti(noti);
+        await iOSUserSelectedNoti(noti);
       }
     } catch (e, s) {
       Logs().e('[Push] Failed to get initial notification', e, s);
     }
   }
 
-  void iOSUserSelectedNoti(dynamic noti) {
+  Future<void> iOSUserSelectedNoti(dynamic noti) async {
     // roomId is payload if noti is local
-    final roomId = noti['room_id'] ?? noti['payload'];
+    String? roomId = noti['room_id'];
     final eventId = noti['event_id'];
-    goToRoom(roomId, eventId: eventId);
+    String? receiverId = noti['receiver_id'] as String?;
+    final payload = noti['payload'] != null
+        ? jsonDecode(noti['payload'])
+        : null;
+    if (payload is Map) {
+      payload['room_id'] is String ? roomId = payload['room_id'] : null;
+      payload['receiver_id'] is String
+          ? receiverId = payload['receiver_id']
+          : null;
+    }
+    await _switchAccount(receiverId);
+    await goToRoom(roomId, eventId: eventId);
+  }
+
+  Future<void> _switchAccount(String? receiverId) async {
+    Client? targetClient;
+    if (receiverId != null && _matrixState != null) {
+      targetClient = _matrixState!.widget.clients.firstWhereOrNull(
+        (c) => c.userID == receiverId,
+      );
+      if (targetClient != null &&
+          targetClient.userID != _matrixState!.client.userID) {
+        Logs().d(
+          '[Push] Switching to account ${targetClient.userID} for notification',
+        );
+        await _matrixState!.setActiveClient(targetClient);
+        await _matrixState!.cancelListenSynchronizeContacts();
+        await _matrixState!.reSyncContacts();
+      }
+    }
   }
 
   void onReceiveNotification(dynamic message) {
@@ -418,11 +599,19 @@ class BackgroundPush {
   Future<void> onSelectNotification(
     NotificationResponse? response, {
     String? eventId,
-  }) {
+  }) async {
+    final payload = jsonDecode(response?.payload ?? '{}');
+    final roomId = payload['room_id'];
+    final receiverId = payload['receiver_id'];
     Logs().d(
-      'BackgroundPush::onSelectNotification() roomId - ${response?.payload} ||eventId - $eventId',
+      'BackgroundPush::onSelectNotification() roomId - $roomId ||eventId - $eventId',
     );
-    return goToRoom(response?.payload, eventId: eventId);
+    if (receiverId is String?) {
+      await _switchAccount(receiverId);
+    }
+    if (roomId is String?) {
+      await goToRoom(roomId, eventId: eventId);
+    }
   }
 
   Future<void> goToRoom(String? roomId, {String? eventId}) async {

--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -23,6 +23,7 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:fcm_shared_isolate/fcm_shared_isolate.dart';
+import 'package:fluffychat/data/model/push/twake_local_notification_payload.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/keychain_sharing/keychain_sharing_manager.dart';
 import 'package:fluffychat/domain/model/extensions/push/push_notification_extension.dart';
@@ -48,6 +49,24 @@ import '../config/app_config.dart';
 import '../config/setting_keys.dart';
 import 'famedlysdk_store.dart';
 import 'platform_infos.dart';
+
+/// APN method names sent from the native iOS layer via [MethodChannel].
+enum _ApnMethod {
+  willPresent,
+  didReceive;
+
+  String get value {
+    switch (this) {
+      case _ApnMethod.willPresent:
+        return 'willPresent';
+      case _ApnMethod.didReceive:
+        return 'didReceive';
+    }
+  }
+}
+
+/// Language tag sent in Matrix pusher registration (RFC 5646 / Matrix spec).
+const _pusherLang = 'en';
 
 class NoTokenException implements Exception {
   String get cause => 'Cannot get push token';
@@ -106,9 +125,9 @@ class BackgroundPush {
     } else if (Platform.isIOS) {
       apnChannel.setMethodCallHandler((call) async {
         Logs().v('[Push] Received APN call: $call');
-        if (call.method == 'willPresent') {
+        if (call.method == _ApnMethod.willPresent.value) {
           onReceiveNotification(call.arguments);
-        } else if (call.method == 'didReceive') {
+        } else if (call.method == _ApnMethod.didReceive.value) {
           await iOSUserSelectedNoti(call.arguments);
         }
       });
@@ -209,7 +228,7 @@ class BackgroundPush {
         currentPushers.first.appId == appId &&
         currentPushers.first.appDisplayName == clientName &&
         currentPushers.first.deviceDisplayName == targetClient.deviceName &&
-        currentPushers.first.lang == 'en' &&
+        currentPushers.first.lang == _pusherLang &&
         currentPushers.first.data.url.toString() == gatewayUrl &&
         currentPushers.first.data.format ==
             AppConfig.pushNotificationsPusherFormat) {
@@ -223,8 +242,9 @@ class BackgroundPush {
           pushkey: token,
           appId: appId,
           appDisplayName: clientName,
-          deviceDisplayName: targetClient.deviceName!,
-          lang: 'en',
+          deviceDisplayName:
+              targetClient.deviceName ?? PlatformInfos.clientName,
+          lang: _pusherLang,
           data: PusherData(
             url: Uri.parse(gatewayUrl),
             format: AppConfig.pushNotificationsPusherFormat,
@@ -370,7 +390,7 @@ class BackgroundPush {
           currentPushers.first.appId == thisAppId &&
           currentPushers.first.appDisplayName == clientName &&
           currentPushers.first.deviceDisplayName == client.deviceName &&
-          currentPushers.first.lang == 'en' &&
+          currentPushers.first.lang == _pusherLang &&
           currentPushers.first.data.url.toString() == gatewayUrl &&
           currentPushers.first.data.format ==
               AppConfig.pushNotificationsPusherFormat) {
@@ -405,8 +425,8 @@ class BackgroundPush {
             pushkey: token!,
             appId: thisAppId,
             appDisplayName: clientName,
-            deviceDisplayName: client.deviceName!,
-            lang: 'en',
+            deviceDisplayName: client.deviceName ?? clientName,
+            lang: _pusherLang,
             data: PusherData(
               url: Uri.parse(gatewayUrl!),
               format: AppConfig.pushNotificationsPusherFormat,
@@ -551,15 +571,21 @@ class BackgroundPush {
     String? roomId = noti['room_id'];
     final eventId = noti['event_id'];
     String? receiverId = noti['receiver_id'] as String?;
-    final payload = noti['payload'] != null
-        ? jsonDecode(noti['payload'])
-        : null;
-    if (payload is Map) {
-      payload['room_id'] is String ? roomId = payload['room_id'] : null;
-      payload['receiver_id'] is String
-          ? receiverId = payload['receiver_id']
-          : null;
+
+    // Remote APN notifications nest the routing data inside 'payload'.
+    if (noti['payload'] != null) {
+      try {
+        final rawPayload = jsonDecode(noti['payload'] as String);
+        if (rawPayload is Map<String, dynamic>) {
+          final parsed = TwakeLocalNotificationPayload.fromJson(rawPayload);
+          if (parsed.roomId != null) roomId = parsed.roomId;
+          if (parsed.receiverId != null) receiverId = parsed.receiverId;
+        }
+      } catch (e) {
+        Logs().w('[Push] iOSUserSelectedNoti: failed to parse payload', e);
+      }
     }
+
     await _switchAccount(receiverId);
     await goToRoom(roomId, eventId: eventId);
   }
@@ -600,18 +626,19 @@ class BackgroundPush {
     NotificationResponse? response, {
     String? eventId,
   }) async {
-    final payload = jsonDecode(response?.payload ?? '{}');
-    final roomId = payload['room_id'];
-    final receiverId = payload['receiver_id'];
+    TwakeLocalNotificationPayload payload;
+    try {
+      final raw = jsonDecode(response?.payload ?? '{}') as Map<String, dynamic>;
+      payload = TwakeLocalNotificationPayload.fromJson(raw);
+    } catch (e) {
+      Logs().w('[Push] onSelectNotification: failed to parse payload', e);
+      payload = TwakeLocalNotificationPayload.empty();
+    }
     Logs().d(
-      'BackgroundPush::onSelectNotification() roomId - $roomId ||eventId - $eventId',
+      'BackgroundPush::onSelectNotification() roomId - ${payload.roomId} ||eventId - $eventId',
     );
-    if (receiverId is String?) {
-      await _switchAccount(receiverId);
-    }
-    if (roomId is String?) {
-      await goToRoom(roomId, eventId: eventId);
-    }
+    await _switchAccount(payload.receiverId);
+    await goToRoom(payload.roomId, eventId: eventId);
   }
 
   Future<void> goToRoom(String? roomId, {String? eventId}) async {

--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -220,12 +220,14 @@ Future<void> _tryPushHelper(
     iOS: iOSPlatformChannelSpecifics,
   );
 
+  final receiverId = event.room.client.userID;
+
   await flutterLocalNotificationsPlugin.show(
     id,
     event.room.getLocalizedDisplayname(MatrixLocals(l10n)),
     body,
     platformChannelSpecifics,
-    payload: event.roomId,
+    payload: jsonEncode({'room_id': event.roomId, 'receiver_id': receiverId}),
   );
   Logs().v('Push helper has been completed!');
 }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -576,6 +576,12 @@ class MatrixState extends State<Matrix>
     Client currentClient,
   ) async {
     waitForFirstSync = false;
+
+    if (PlatformInfos.isIOS) {
+      backgroundPush?.cancelKeychainSyncForClient(currentClient);
+      await backgroundPush?.removePusherForClient(currentClient);
+    }
+
     await _cancelSubs(currentClient.clientName);
     widget.clients.remove(currentClient);
     await ClientManager.removeClientNameFromStore(currentClient.clientName);
@@ -635,7 +641,17 @@ class MatrixState extends State<Matrix>
     waitForFirstSync = false;
     await setUpToMServicesInLogin(activeClient);
     await setUpFederationServicesInLogin(activeClient);
+
+    if (PlatformInfos.isIOS) {
+      await backgroundPush?.syncRecoveryKeyForClient(activeClient);
+    }
+
     final result = await setActiveClient(activeClient);
+
+    if (PlatformInfos.isIOS) {
+      await backgroundPush?.setupPushForAdditionalClient(activeClient);
+    }
+
     await matrixState.cancelListenSynchronizeContacts();
     matrixState.reSyncContacts();
     if (result.isSuccess) {


### PR DESCRIPTION
## Ticket
- #2893 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-account iOS push support: notifications, navigation and account switching handled for multiple logged-in accounts.

* **Improvements**
  * Recovery keys unified into the primary secure storage for consistent sync and restore.
  * Notification payloads include receiver and event identifiers for accurate routing.
  * Logging updated so message content is recorded as public in system logs.

* **Bug Fixes**
  * Reduced, bounded retries when processing encrypted notification items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->