### PR TITLE
feat(search): validate mxid profile via API before displaying external contact

### DIFF
--- a/integration_test/tests/chat/search_external_mxid_test.dart
+++ b/integration_test/tests/chat/search_external_mxid_test.dart
@@ -1,0 +1,81 @@
+import 'package:fluffychat/pages/new_private_chat/widget/expansion_contact_list_tile.dart';
+import 'package:fluffychat/pages/new_private_chat/widget/no_contacts_found.dart';
+import '../../base/core_robot.dart';
+import '../../base/test_base.dart';
+import '../../help/soft_assertion_helper.dart';
+import '../../robots/contact_list_robot.dart';
+import '../../robots/home_robot.dart';
+import '../../robots/search_robot.dart';
+import '../../scenarios/contact_scenario.dart';
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Search external contact by Matrix ID validates profile',
+    test: ($) async {
+      final s = SoftAssertHelper();
+
+      const currentAccount = String.fromEnvironment('CurrentAccount');
+
+      // Navigate to Contacts tab
+      await HomeRobot($).gotoContactListScreen();
+
+      // --- Case 1: search a non-existent mxid ---
+      const nonExistentMxid =
+          '@nonexistent_test_user_xyz_000:fake.server.invalid';
+      await ContactScenario($).enterSearchText(nonExistentMxid);
+
+      // Wait for the profile lookup to finish (loading → result)
+      await CoreRobot($).waitForEitherVisible(
+        $: $,
+        first: $(NoContactsFound),
+        second: $(ExpansionContactListTile),
+        timeout: const Duration(seconds: 30),
+      );
+      await $.pumpAndTrySettle();
+
+      // "No Results" should be shown for a non-existent mxid
+      s.softAssertEquals(
+        $(NoContactsFound).exists || (SearchRobot($).getNoResultIcon()).exists,
+        true,
+        'Expected "No Results" to be shown for non-existent mxid, but it was not',
+      );
+
+      // No contact tile should be displayed
+      s.softAssertEquals(
+        $(ExpansionContactListTile).exists,
+        false,
+        'Expected no contact tile for non-existent mxid, but one was found',
+      );
+
+      // --- Case 2: search a valid mxid (current account) ---
+      await SearchRobot($).deleteSearchPhrase();
+      await ContactScenario($).enterSearchText(currentAccount);
+
+      // Wait for the profile lookup to finish
+      await CoreRobot($).waitForEitherVisible(
+        $: $,
+        first: $(NoContactsFound),
+        second: $(ExpansionContactListTile),
+        timeout: const Duration(seconds: 30),
+      );
+      await $.pumpAndTrySettle();
+
+      // "No Results" should NOT be shown — a contact tile should be displayed
+      s.softAssertEquals(
+        $(NoContactsFound).exists,
+        false,
+        'Expected profile info to be shown for valid mxid, but got "No Results"',
+      );
+
+      // A contact list item should be visible (external contact tile)
+      final contacts = await ContactListRobot($).getListOfContact();
+      s.softAssertEquals(
+        contacts.isNotEmpty || $(ExpansionContactListTile).exists,
+        true,
+        'Expected a contact tile to be rendered for valid mxid',
+      );
+
+      s.verifyAll();
+    },
+  );
+}

--- a/lib/pages/contacts_tab/contacts_tab_body_view.dart
+++ b/lib/pages/contacts_tab/contacts_tab_body_view.dart
@@ -18,6 +18,7 @@ import 'package:fluffychat/widgets/contacts_warning_banner/contacts_warning_bann
 import 'package:fluffychat/widgets/sliver_expandable_list.dart';
 import 'package:flutter/material.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:matrix/matrix.dart';
 
 class ContactsTabBodyView extends StatelessWidget {
   final ContactsTabController controller;
@@ -268,7 +269,7 @@ class _SliverContactsList extends StatelessWidget {
   }
 }
 
-class _SilverExternalContact extends StatelessWidget {
+class _SilverExternalContact extends StatefulWidget {
   final ContactsTabController controller;
   final PresentationContact externalContact;
 
@@ -278,23 +279,92 @@ class _SilverExternalContact extends StatelessWidget {
   });
 
   @override
+  State<_SilverExternalContact> createState() => _SilverExternalContactState();
+}
+
+class _SilverExternalContactState extends State<_SilverExternalContact> {
+  Future<CachedProfileInformation>? _profileFuture;
+  String? _currentMatrixId;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _fetchProfileIfNeeded();
+  }
+
+  @override
+  void didUpdateWidget(covariant _SilverExternalContact oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.externalContact.matrixId != widget.externalContact.matrixId) {
+      _fetchProfileIfNeeded();
+    }
+  }
+
+  void _fetchProfileIfNeeded() {
+    final matrixId = widget.externalContact.matrixId;
+    if (matrixId == null) {
+      _currentMatrixId = null;
+      _profileFuture = null;
+      return;
+    }
+    if (_currentMatrixId != matrixId) {
+      _currentMatrixId = matrixId;
+      _profileFuture = widget.controller.client.getUserProfile(
+        matrixId,
+        maxCacheAge: Duration.zero,
+      );
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return SliverToBoxAdapter(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: ContactsTabViewStyle.padding,
-        ),
-        child: ExpansionContactListTile(
-          contact: externalContact,
-          highlightKeyword: controller.textEditingController.text,
-          enableInvitation: controller.supportInvitation(),
-          onContactTap: () => controller.onContactTap(
-            context: context,
-            path: 'rooms',
-            contact: externalContact,
+    return FutureBuilder<CachedProfileInformation>(
+      future: _profileFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const SliverToBoxAdapter(child: LoadingContactWidget());
+        }
+
+        if (snapshot.hasError || !snapshot.hasData) {
+          return SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.only(
+                left: ContactsTabViewStyle.padding,
+                top: ContactsTabViewStyle.padding,
+              ),
+              child: NoContactsFound(
+                keyword: widget.controller.textEditingController.text,
+              ),
+            ),
+          );
+        }
+
+        final profile = snapshot.data!;
+        final validatedContact = PresentationContact(
+          matrixId: widget.externalContact.matrixId,
+          displayName:
+              profile.displayname ?? widget.externalContact.displayName,
+          type: widget.externalContact.type,
+        );
+
+        return SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: ContactsTabViewStyle.padding,
+            ),
+            child: ExpansionContactListTile(
+              contact: validatedContact,
+              highlightKeyword: widget.controller.textEditingController.text,
+              enableInvitation: widget.controller.supportInvitation(),
+              onContactTap: () => widget.controller.onContactTap(
+                context: context,
+                path: 'rooms',
+                contact: validatedContact,
+              ),
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/pages/search/search_external_contact.dart
+++ b/lib/pages/search/search_external_contact.dart
@@ -4,43 +4,102 @@ import 'package:fluffychat/pages/search/search.dart';
 import 'package:fluffychat/pages/search/search_external_contact_style.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/search/empty_search_widget.dart';
+import 'package:fluffychat/widgets/twake_components/twake_loading/center_loading_indicator.dart';
 import 'package:flutter/material.dart' hide SearchController;
+import 'package:matrix/matrix.dart';
 
-class SearchExternalContactWidget extends StatelessWidget {
+class SearchExternalContactWidget extends StatefulWidget {
   const SearchExternalContactWidget({
     super.key,
     required this.keyword,
     required this.searchController,
+    @visibleForTesting this.clientForTesting,
   });
 
   final String keyword;
   final SearchController searchController;
+  final Client? clientForTesting;
+
+  @override
+  State<SearchExternalContactWidget> createState() =>
+      _SearchExternalContactWidgetState();
+}
+
+class _SearchExternalContactWidgetState
+    extends State<SearchExternalContactWidget> {
+  Future<CachedProfileInformation>? _profileFuture;
+  String? _currentKeyword;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _fetchProfileIfNeeded();
+  }
+
+  @override
+  void didUpdateWidget(covariant SearchExternalContactWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.keyword != widget.keyword) {
+      _fetchProfileIfNeeded();
+    }
+  }
+
+  void _fetchProfileIfNeeded() {
+    if (_currentKeyword != widget.keyword) {
+      _currentKeyword = widget.keyword;
+      final client = widget.clientForTesting ?? Matrix.of(context).client;
+      _profileFuture = client.getUserProfile(
+        widget.keyword,
+        maxCacheAge: Duration.zero,
+      );
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    final newContact = PresentationContact(
-      matrixId: keyword,
-      displayName: keyword.substring(1),
-      type: ContactType.external,
-    );
-
-    return Padding(
-      padding: SearchExternalContactStyle.contentPadding,
-      child: InkWell(
-        onTap: () {
-          searchController.onSearchItemTap(
-            ContactPresentationSearch(
-              matrixId: newContact.matrixId,
-              displayName: newContact.displayName,
-            ),
+    return FutureBuilder<CachedProfileInformation>(
+      future: _profileFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Padding(
+            padding: EdgeInsets.only(top: 48),
+            child: CenterLoadingIndicator(),
           );
-        },
-        borderRadius: SearchExternalContactStyle.borderRadius,
-        child: ExpansionContactListTile(
-          contact: newContact,
-          highlightKeyword: searchController.textEditingController.text,
-        ),
-      ),
+        }
+
+        if (snapshot.hasError || !snapshot.hasData) {
+          return const EmptySearchWidget();
+        }
+
+        final profile = snapshot.data!;
+        final newContact = PresentationContact(
+          matrixId: widget.keyword,
+          displayName: profile.displayname ?? widget.keyword.substring(1),
+          type: ContactType.external,
+        );
+
+        return Padding(
+          padding: SearchExternalContactStyle.contentPadding,
+          child: InkWell(
+            onTap: () {
+              widget.searchController.onSearchItemTap(
+                ContactPresentationSearch(
+                  matrixId: newContact.matrixId,
+                  displayName: newContact.displayName,
+                ),
+              );
+            },
+            borderRadius: SearchExternalContactStyle.borderRadius,
+            child: ExpansionContactListTile(
+              contact: newContact,
+              highlightKeyword:
+                  widget.searchController.textEditingController.text,
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/test/pages/search/search_external_contact_test.dart
+++ b/test/pages/search/search_external_contact_test.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+
+import 'package:fluffychat/config/localizations/localization_service.dart';
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/domain/usecase/contacts/delete_third_party_contact_box_interactor.dart';
+import 'package:fluffychat/domain/usecase/contacts/post_address_book_interactor.dart';
+import 'package:fluffychat/domain/usecase/invitation/get_invitation_status_interactor.dart';
+import 'package:fluffychat/domain/usecase/invitation/hive_delete_invitation_status_interactor.dart';
+import 'package:fluffychat/domain/usecase/invitation/hive_get_invitation_status_interactor.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:fluffychat/pages/new_private_chat/widget/expansion_contact_list_tile.dart';
+import 'package:fluffychat/pages/search/search.dart';
+import 'package:fluffychat/pages/search/search_external_contact.dart';
+import 'package:fluffychat/utils/custom_scroll_behaviour.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/search/empty_search_widget.dart';
+import 'package:fluffychat/widgets/theme_builder.dart';
+import 'package:fluffychat/widgets/twake_components/twake_loading/center_loading_indicator.dart';
+import 'package:flutter/material.dart' hide SearchController;
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localized_locales/flutter_localized_locales.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+import 'search_external_contact_test.mocks.dart';
+
+/// Lightweight stand-in for [MatrixState] that only exposes [client].
+/// We avoid mocking [MatrixState] directly because it references dart:html
+/// types that are unavailable in VM tests.
+class FakeMatrixState extends Fake implements MatrixState {
+  FakeMatrixState(this._client);
+  final Client _client;
+
+  @override
+  Client get client => _client;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      'FakeMatrixState';
+}
+
+@GenerateNiceMocks([
+  MockSpec<Client>(),
+  MockSpec<SearchController>(),
+  MockSpec<TextEditingController>(),
+  MockSpec<HiveGetInvitationStatusInteractor>(),
+  MockSpec<GetInvitationStatusInteractor>(),
+  MockSpec<PostAddressBookInteractor>(),
+  MockSpec<HiveDeleteInvitationStatusInteractor>(),
+  MockSpec<DeleteThirdPartyContactBoxInteractor>(),
+])
+void main() {
+  late MockClient mockClient;
+  late MockSearchController mockSearchController;
+  late MockTextEditingController mockTextEditingController;
+
+  setUpAll(() {
+    final getIt = GetIt.instance;
+    getIt.registerSingleton(ResponsiveUtils());
+  });
+
+  setUp(() {
+    final getIt = GetIt.instance;
+
+    mockClient = MockClient();
+    mockSearchController = MockSearchController();
+    mockTextEditingController = MockTextEditingController();
+
+    when(mockClient.userID).thenReturn('@me:server.com');
+    when(
+      mockSearchController.textEditingController,
+    ).thenReturn(mockTextEditingController);
+    when(mockTextEditingController.text).thenReturn('@test:server.com');
+
+    // Register InvitationStatusMixin dependencies required by
+    // ExpansionContactListTile (resolved at field-init time via getIt).
+    if (!getIt.isRegistered<HiveGetInvitationStatusInteractor>()) {
+      getIt.registerSingleton<HiveGetInvitationStatusInteractor>(
+        MockHiveGetInvitationStatusInteractor(),
+      );
+    }
+    if (!getIt.isRegistered<GetInvitationStatusInteractor>()) {
+      getIt.registerSingleton<GetInvitationStatusInteractor>(
+        MockGetInvitationStatusInteractor(),
+      );
+    }
+    if (!getIt.isRegistered<PostAddressBookInteractor>()) {
+      getIt.registerSingleton<PostAddressBookInteractor>(
+        MockPostAddressBookInteractor(),
+      );
+    }
+    if (!getIt.isRegistered<HiveDeleteInvitationStatusInteractor>()) {
+      getIt.registerSingleton<HiveDeleteInvitationStatusInteractor>(
+        MockHiveDeleteInvitationStatusInteractor(),
+      );
+    }
+    if (!getIt.isRegistered<DeleteThirdPartyContactBoxInteractor>()) {
+      getIt.registerSingleton<DeleteThirdPartyContactBoxInteractor>(
+        MockDeleteThirdPartyContactBoxInteractor(),
+      );
+    }
+  });
+
+  Future<void> buildWidget(
+    WidgetTester tester, {
+    required String keyword,
+  }) async {
+    await tester.pumpWidget(
+      ThemeBuilder(
+        builder: (context, themeMode, primaryColor) => MaterialApp(
+          locale: const Locale('en'),
+          scrollBehavior: CustomScrollBehavior(),
+          localizationsDelegates: const [
+            LocaleNamesLocalizationsDelegate(),
+            L10n.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          supportedLocales: LocalizationService.supportedLocales,
+          theme: TwakeThemes.buildTheme(
+            context,
+            Brightness.light,
+            primaryColor,
+          ),
+          home: Provider<MatrixState>.value(
+            value: FakeMatrixState(mockClient),
+            child: Scaffold(
+              backgroundColor: LinagoraSysColors.material().onPrimary,
+              body: SearchExternalContactWidget(
+                keyword: keyword,
+                searchController: mockSearchController,
+                clientForTesting: mockClient,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('[SearchExternalContactWidget] TEST', () {
+    testWidgets('GIVEN getUserProfile is still loading\n'
+        'THEN should display CenterLoadingIndicator', (
+      WidgetTester tester,
+    ) async {
+      // getUserProfile returns a Future that never completes → loading state
+      final completer = Completer<CachedProfileInformation>();
+      when(
+        mockClient.getUserProfile(any, maxCacheAge: anyNamed('maxCacheAge')),
+      ).thenAnswer((_) => completer.future);
+
+      await buildWidget(tester, keyword: '@test:server.com');
+      // Only pump once — do NOT pumpAndSettle, the future is still pending
+      await tester.pump();
+
+      expect(find.byType(CenterLoadingIndicator), findsOneWidget);
+      expect(find.byType(EmptySearchWidget), findsNothing);
+    });
+
+    testWidgets('GIVEN getUserProfile throws an error\n'
+        'WHEN searching for @nonexistent:server.com\n'
+        'THEN should display EmptySearchWidget (No Results)', (
+      WidgetTester tester,
+    ) async {
+      // thenAnswer with an async error so the exception lands in the Future,
+      // not thrown synchronously during _fetchProfileIfNeeded.
+      when(
+        mockClient.getUserProfile(any, maxCacheAge: anyNamed('maxCacheAge')),
+      ).thenAnswer(
+        (_) => Future<CachedProfileInformation>.error(
+          MatrixException.fromJson({
+            'errcode': 'M_NOT_FOUND',
+            'error': 'Profile not found',
+          }),
+        ),
+      );
+
+      await buildWidget(tester, keyword: '@nonexistent:server.com');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EmptySearchWidget), findsOneWidget);
+      expect(find.byType(CenterLoadingIndicator), findsNothing);
+    });
+
+    testWidgets('GIVEN getUserProfile returns a valid profile\n'
+        'WHEN searching for @validuser:server.com\n'
+        'THEN should display the contact tile with profile info', (
+      WidgetTester tester,
+    ) async {
+      when(
+        mockClient.getUserProfile(any, maxCacheAge: anyNamed('maxCacheAge')),
+      ).thenAnswer(
+        (_) async => CachedProfileInformation.fromProfile(
+          ProfileInformation(avatarUrl: null, displayname: 'Valid User'),
+          outdated: false,
+          updated: DateTime.now(),
+        ),
+      );
+
+      await buildWidget(tester, keyword: '@validuser:server.com');
+      await tester.pumpAndSettle();
+
+      expect(find.byType(EmptySearchWidget), findsNothing);
+      expect(find.byType(CenterLoadingIndicator), findsNothing);
+      // Should render the ExpansionContactListTile with the fetched profile
+      expect(find.byType(ExpansionContactListTile), findsOneWidget);
+      // Should show the displayName from the server profile
+      expect(find.textContaining('Valid User'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Ticket
TID-2474 - Improve searching by the non-exist matrix address

## Root cause
`SearchExternalContactWidget` displayed any syntactically valid mxid as a contact result without verifying it exists on the server. The check was purely format-based (`isValidMatrixId`), so typing `@noexist:server.com` showed a fake profile instead of "No Results".

## Solution
Converted `SearchExternalContactWidget` from `StatelessWidget` to `StatefulWidget` with a `FutureBuilder` that calls `client.getProfileFromUserId()` before rendering:
- **200** → display the contact with real profile data
- **404/403/5xx** → display `EmptySearchWidget` ("No Results")
- **Loading** → display a spinner

## Impact description
N/A (bug fix)

## Test recommendations
1. Search `@validuser:your-server.com` → should show profile info
2. Search `@nonexistent:your-server.com` → should show "No Results" mascot

## Pre-merge
No

## Resolved
- Web:
<img width="402" height="298" alt="image" src="https://github.com/user-attachments/assets/7222a1f9-15bf-4d86-ae06-5645fa7b7d1b" />

- Android:
- IOS:

https://github.com/user-attachments/assets/c9907079-b9ad-425b-ba80-7fb7a0078300




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External contact search now fetches remote profile data, shows a loading indicator, and accepts an optional test client for testing.
* **Bug Fixes**
  * Shows an explicit empty/no-results state when profile lookup fails or returns no data.
* **Improvements**
  * UI updates responsively when query/ID changes and displays validated contact details; taps use fetched profile info.
* **Tests**
  * Added widget and integration tests covering loading, no-result, and successful profile fetch flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->