### PR TITLE
perf: prevent iOS OOM kill with download concurrency limiter

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -757,12 +757,22 @@ class ChatListController extends State<ChatList>
 
   @override
   void didUpdateWidget(covariant ChatList oldWidget) {
+    final newArgs = widget.adaptiveScaffoldBodyArgs;
+    final oldArgs = oldWidget.adaptiveScaffoldBodyArgs;
+
+    // Skip work if args haven't changed — avoids unnecessary logging
+    // and processing on every parent rebuild.
+    if (identical(newArgs, oldArgs)) {
+      super.didUpdateWidget(oldWidget);
+      return;
+    }
+
     Logs().d(
-      "ChatList::didUpdateWidget(): Old Args ${oldWidget.adaptiveScaffoldBodyArgs} - UserId ${oldWidget.adaptiveScaffoldBodyArgs?.newActiveClient?.userID}",
+      "ChatList::didUpdateWidget(): Old Args $oldArgs - UserId ${oldArgs?.newActiveClient?.userID}",
     );
-    final newActiveClient = widget.adaptiveScaffoldBodyArgs?.newActiveClient;
+    final newActiveClient = newArgs?.newActiveClient;
     Logs().d(
-      "ChatList::didUpdateWidget(): New Args ${widget.adaptiveScaffoldBodyArgs} - UserId ${newActiveClient?.userID}",
+      "ChatList::didUpdateWidget(): New Args $newArgs - UserId ${newActiveClient?.userID}",
     );
     if (newActiveClient != null && newActiveClient.userID != null) {
       setState(() {

--- a/lib/utils/image_download_queue.dart
+++ b/lib/utils/image_download_queue.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+import 'dart:collection';
+
+/// Limits the number of concurrent image download/decode operations
+/// to prevent memory spikes that cause iOS OOM kills.
+///
+/// Each [MxcImage] acquires a slot before starting its load and
+/// releases it when done (or when disposed). If all slots are taken,
+/// the request is queued and processed in FIFO order.
+class ImageDownloadQueue {
+  static final ImageDownloadQueue _instance = ImageDownloadQueue._();
+  static ImageDownloadQueue get instance => _instance;
+
+  ImageDownloadQueue._();
+
+  /// Maximum number of image loads running simultaneously.
+  /// 4 is a good balance: enough parallelism for fast scrolling,
+  /// low enough to avoid memory pressure on iOS.
+  static const int maxConcurrent = 4;
+
+  int _running = 0;
+  final Queue<_QueueEntry> _queue = Queue<_QueueEntry>();
+
+  /// Acquires a slot in the download queue.
+  ///
+  /// Returns a [Future] that completes when a slot is available.
+  /// The returned [ImageDownloadTicket] must be released by calling
+  /// [release] when the download/decode is finished or cancelled.
+  ///
+  /// If [cancel] is called on the ticket before the slot is acquired,
+  /// the future completes with `false` (meaning: don't start the work).
+  ImageDownloadTicket acquire() {
+    final ticket = ImageDownloadTicket._();
+
+    if (_running < maxConcurrent) {
+      _running++;
+      ticket._granted = true;
+      ticket._completer.complete(true);
+    } else {
+      final entry = _QueueEntry(ticket);
+      _queue.add(entry);
+      ticket._queueEntry = entry;
+    }
+
+    return ticket;
+  }
+
+  /// Releases a slot, allowing the next queued request to proceed.
+  void release(ImageDownloadTicket ticket) {
+    if (!ticket._granted) {
+      // Was still queued — just remove from queue
+      if (ticket._queueEntry != null) {
+        _queue.remove(ticket._queueEntry);
+        ticket._queueEntry = null;
+      }
+      if (!ticket._completer.isCompleted) {
+        ticket._completer.complete(false);
+      }
+      return;
+    }
+
+    ticket._granted = false;
+    _running--;
+
+    _drainQueue();
+  }
+
+  void _drainQueue() {
+    while (_running < maxConcurrent && _queue.isNotEmpty) {
+      final next = _queue.removeFirst();
+      if (next.ticket._cancelled) {
+        // Skip cancelled entries
+        if (!next.ticket._completer.isCompleted) {
+          next.ticket._completer.complete(false);
+        }
+        continue;
+      }
+      _running++;
+      next.ticket._granted = true;
+      next.ticket._queueEntry = null;
+      if (!next.ticket._completer.isCompleted) {
+        next.ticket._completer.complete(true);
+      }
+    }
+  }
+
+  /// Current number of active downloads (for debugging).
+  int get activeCount => _running;
+
+  /// Current number of queued downloads (for debugging).
+  int get queuedCount => _queue.length;
+}
+
+/// A ticket representing a pending or active slot in the download queue.
+class ImageDownloadTicket {
+  ImageDownloadTicket._();
+
+  final Completer<bool> _completer = Completer<bool>();
+  bool _granted = false;
+  bool _cancelled = false;
+  _QueueEntry? _queueEntry;
+
+  /// Resolves to `true` when a slot is available and work should start,
+  /// or `false` if the ticket was cancelled before being granted.
+  Future<bool> get ready => _completer.future;
+
+  /// Whether this ticket currently holds an active slot.
+  bool get isActive => _granted;
+
+  /// Cancel this ticket. If still queued, it will be removed.
+  /// If already active, call [ImageDownloadQueue.release] instead.
+  void cancel() {
+    _cancelled = true;
+    if (!_granted && !_completer.isCompleted) {
+      _completer.complete(false);
+    }
+  }
+}
+
+class _QueueEntry {
+  final ImageDownloadTicket ticket;
+  const _QueueEntry(this.ticket);
+}

--- a/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body.dart
+++ b/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body.dart
@@ -177,29 +177,26 @@ class AppAdaptiveScaffoldBodyController extends State<AppAdaptiveScaffoldBody>
   @override
   void didUpdateWidget(covariant AppAdaptiveScaffoldBody oldWidget) {
     activeRoomIdNotifier.value = widget.activeRoomId;
-    Logs().d(
-      'AppAdaptiveScaffoldBodyController::didUpdateWidget():oldWidget - ${oldWidget.args}',
-    );
-    Logs().d(
-      'AppAdaptiveScaffoldBodyController::didUpdateWidget():newWidget - ${widget.args}',
-    );
-    if (oldWidget.args != widget.args && widget.args is LogoutBodyArgs) {
-      _handleLogout(oldWidget);
-    }
 
-    if (oldWidget.args != widget.args &&
-        widget.args is LoggedInOtherAccountBodyArgs) {
-      getCurrentProfile();
-      _handleProfileDataChange();
-    }
-
-    if (oldWidget.args != widget.args &&
-        widget.args is SwitchActiveAccountBodyArgs) {
-      _handleSwitchAccount(oldWidget);
-    }
-
-    if (oldWidget.args != widget.args && widget.args is ReceiveContentArgs) {
-      _handleReceiveContent(widget.args as ReceiveContentArgs);
+    // Skip expensive checks and logging when args haven't changed,
+    // which is the common case during parent rebuilds.
+    if (oldWidget.args != widget.args) {
+      Logs().d(
+        'AppAdaptiveScaffoldBodyController::didUpdateWidget():oldWidget - ${oldWidget.args}',
+      );
+      Logs().d(
+        'AppAdaptiveScaffoldBodyController::didUpdateWidget():newWidget - ${widget.args}',
+      );
+      if (widget.args is LogoutBodyArgs) {
+        _handleLogout(oldWidget);
+      } else if (widget.args is LoggedInOtherAccountBodyArgs) {
+        getCurrentProfile();
+        _handleProfileDataChange();
+      } else if (widget.args is SwitchActiveAccountBodyArgs) {
+        _handleSwitchAccount(oldWidget);
+      } else if (widget.args is ReceiveContentArgs) {
+        _handleReceiveContent(widget.args as ReceiveContentArgs);
+      }
     }
     super.didUpdateWidget(oldWidget);
   }

--- a/lib/widgets/mixins/get_preview_url_mixin.dart
+++ b/lib/widgets/mixins/get_preview_url_mixin.dart
@@ -6,6 +6,7 @@ import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/preview_url/get_preview_url_success.dart';
 import 'package:fluffychat/domain/usecase/preview_url/get_preview_url_interactor.dart';
+import 'package:fluffychat/utils/image_download_queue.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
 
@@ -21,6 +22,9 @@ mixin GetPreviewUrlMixin {
 
   StreamSubscription<Either<Failure, Success>>? _previewUrlSubscription;
 
+  /// Ticket from the shared download queue to limit concurrent HTTP requests.
+  ImageDownloadTicket? _previewTicket;
+
   abstract String debugLabel;
 
   void getPreviewUrl({
@@ -28,18 +32,52 @@ mixin GetPreviewUrlMixin {
     int preferredPreviewTime = _defaultPreferredPreviewTimeInMilliseconds,
   }) {
     _previewUrlSubscription?.cancel();
-    _previewUrlSubscription = _getPreviewURLInteractor
-        .execute(uri: uri, preferredPreviewTime: preferredPreviewTime)
-        .listen(
-          _handleGetPreviewUrlOnData,
-          onError: _handleGetPreviewUrlOnError,
-          onDone: _handleGetPreviewUrlOnDone,
-        );
+
+    // Acquire a slot from the shared download queue to prevent
+    // dozens of preview_url HTTP requests from firing simultaneously.
+    final ticket = ImageDownloadQueue.instance.acquire();
+    _previewTicket = ticket;
+
+    ticket.ready.then((shouldProceed) {
+      if (!shouldProceed) return;
+
+      _previewUrlSubscription = _getPreviewURLInteractor
+          .execute(uri: uri, preferredPreviewTime: preferredPreviewTime)
+          .listen(
+            _handleGetPreviewUrlOnData,
+            onError: _handleGetPreviewUrlOnError,
+            onDone: () {
+              _handleGetPreviewUrlOnDone();
+              _releasePreviewTicket();
+            },
+          );
+    });
+  }
+
+  void _releasePreviewTicket() {
+    final ticket = _previewTicket;
+    if (ticket != null) {
+      if (ticket.isActive) {
+        ImageDownloadQueue.instance.release(ticket);
+      }
+      _previewTicket = null;
+    }
   }
 
   void disposeGetPreviewUrlMixin() {
     _previewUrlSubscription?.cancel();
     _previewUrlSubscription = null;
+
+    final ticket = _previewTicket;
+    if (ticket != null) {
+      if (ticket.isActive) {
+        ImageDownloadQueue.instance.release(ticket);
+      } else {
+        ticket.cancel();
+      }
+      _previewTicket = null;
+    }
+
     getPreviewUrlStateNotifier.dispose();
   }
 
@@ -56,5 +94,6 @@ mixin GetPreviewUrlMixin {
     Logs().e(
       '$debugLabel::_handleGetPreviewUrlOnError() - error: $error | stackTrace: $stackTrace',
     );
+    _releasePreviewTicket();
   }
 }

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'dart:typed_data';
+import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/data/memory/mxc_image_cache_manager.dart';
 import 'package:fluffychat/pages/image_viewer/image_viewer.dart';
 import 'package:fluffychat/pages/media_viewer/media_viewer.dart';
@@ -7,19 +8,19 @@ import 'package:fluffychat/presentation/enum/chat/media_viewer_popup_result_enum
 import 'package:fluffychat/presentation/extensions/media_thumbnail_extension.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/utils/extension/mime_type_extension.dart';
+import 'package:fluffychat/utils/image_download_queue.dart';
 import 'package:fluffychat/utils/interactive_viewer_gallery.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/hero_page_route.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_avif/flutter_avif.dart';
 import 'package:http/http.dart' as http;
 import 'package:matrix/matrix.dart';
-import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 
 typedef EventId = String;
 typedef ImageData = Uint8List;
@@ -98,6 +99,10 @@ class _MxcImageState extends State<MxcImage>
   ImageData? _imageDataNoCache;
   bool isLoadDone = false;
   String? filePath;
+
+  /// Ticket from [ImageDownloadQueue] — held while a download is in-flight
+  /// so it can be cancelled when the widget is disposed (scrolled off-screen).
+  ImageDownloadTicket? _downloadTicket;
 
   ImageData? get _imageData {
     final cacheKey = widget.cacheKey;
@@ -222,20 +227,46 @@ class _MxcImageState extends State<MxcImage>
         isLoadDone = true;
         filePath = null;
       });
+      return;
     }
+
+    // Acquire a slot from the download queue.
+    // This limits the number of concurrent image loads to avoid
+    // memory spikes that cause iOS OOM kills.
+    final ticket = ImageDownloadQueue.instance.acquire();
+    _downloadTicket = ticket;
+
+    final shouldProceed = await ticket.ready;
+    if (!shouldProceed || !mounted) {
+      // Widget was disposed while waiting — release the slot.
+      ImageDownloadQueue.instance.release(ticket);
+      _downloadTicket = null;
+      return;
+    }
+
     try {
       final loadResult = await _load(context);
-      setState(() {
-        isLoadDone = true;
-        _imageData = loadResult.imageData;
-        filePath = loadResult.filePath;
-      });
+      if (mounted) {
+        setState(() {
+          isLoadDone = true;
+          _imageData = loadResult.imageData;
+          filePath = loadResult.filePath;
+        });
+      }
     } catch (e) {
       if (mounted && !isLoadDone) {
         isLoadDone = true;
+        // Don't retry immediately — release first, then re-enqueue.
+        ImageDownloadQueue.instance.release(ticket);
+        _downloadTicket = null;
         _tryLoad(context);
+        return;
       }
     }
+
+    // Release the slot for the next queued image.
+    ImageDownloadQueue.instance.release(ticket);
+    _downloadTicket = null;
   }
 
   void _onTap(BuildContext context) async {
@@ -283,6 +314,17 @@ class _MxcImageState extends State<MxcImage>
 
   @override
   void dispose() {
+    // Cancel any pending or active download — releases the queue slot
+    // so other images can proceed.
+    final ticket = _downloadTicket;
+    if (ticket != null) {
+      if (ticket.isActive) {
+        ImageDownloadQueue.instance.release(ticket);
+      } else {
+        ticket.cancel();
+      }
+      _downloadTicket = null;
+    }
     _imageDataNoCache = null;
     super.dispose();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -405,10 +405,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "802bd084fb82e55df091ec8ad1553a7331b61c08251eef19a508b6f3f3a9858d"
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.1"
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -662,10 +662,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: f2d9f173c2c14635cc0e9b14c143c49ef30b4934e8d1d274d6206fcb0086a06f
+      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.3"
+    version: "10.3.10"
   file_saver:
     dependency: "direct main"
     description:
@@ -3331,10 +3331,10 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
   dart: ">=3.10.4 <4.0.0"
   flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ dependencies:
     git:
       url: https://github.com/famedly/fcm_shared_isolate.git
       ref: main
-  file_picker: ^10.1.7
+  file_picker: ^10.3.10
   flutter:
     sdk: flutter
   # TODO: remove this after this PR is merged https://github.com/g123k/flutter_app_badger/pull/92

--- a/test/utils/image_download_queue_test.dart
+++ b/test/utils/image_download_queue_test.dart
@@ -1,0 +1,170 @@
+import 'package:fluffychat/utils/image_download_queue.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late ImageDownloadQueue queue;
+
+  setUp(() {
+    // Create a fresh instance for each test via the public constructor-like
+    // pattern. Since the class is a singleton, we test through the singleton.
+    // Reset by releasing all tickets between tests.
+    queue = ImageDownloadQueue.instance;
+  });
+
+  test('acquire grants immediately when under maxConcurrent', () async {
+    final tickets = <ImageDownloadTicket>[];
+    for (var i = 0; i < ImageDownloadQueue.maxConcurrent; i++) {
+      final ticket = queue.acquire();
+      tickets.add(ticket);
+      final result = await ticket.ready;
+      expect(result, isTrue);
+      expect(ticket.isActive, isTrue);
+    }
+
+    // Clean up
+    for (final t in tickets) {
+      queue.release(t);
+    }
+    expect(queue.activeCount, 0);
+  });
+
+  test('acquire queues when at maxConcurrent', () async {
+    final tickets = <ImageDownloadTicket>[];
+    // Fill up all slots
+    for (var i = 0; i < ImageDownloadQueue.maxConcurrent; i++) {
+      final ticket = queue.acquire();
+      tickets.add(ticket);
+      await ticket.ready;
+    }
+
+    // This one should be queued
+    final queuedTicket = queue.acquire();
+    expect(queue.queuedCount, 1);
+
+    // Should not resolve yet
+    var resolved = false;
+    queuedTicket.ready.then((_) => resolved = true);
+
+    // Give it a microtask turn
+    await Future.delayed(Duration.zero);
+    expect(resolved, isFalse);
+
+    // Release one slot
+    queue.release(tickets.first);
+
+    // Now the queued ticket should resolve
+    final result = await queuedTicket.ready;
+    expect(result, isTrue);
+    expect(queuedTicket.isActive, isTrue);
+
+    // Clean up
+    queue.release(queuedTicket);
+    for (var i = 1; i < tickets.length; i++) {
+      queue.release(tickets[i]);
+    }
+    expect(queue.activeCount, 0);
+  });
+
+  test('cancel removes ticket from queue', () async {
+    final tickets = <ImageDownloadTicket>[];
+    // Fill up all slots
+    for (var i = 0; i < ImageDownloadQueue.maxConcurrent; i++) {
+      final ticket = queue.acquire();
+      tickets.add(ticket);
+      await ticket.ready;
+    }
+
+    // Queue two more
+    final queued1 = queue.acquire();
+    final queued2 = queue.acquire();
+    expect(queue.queuedCount, 2);
+
+    // Cancel the first queued one
+    queued1.cancel();
+    final result1 = await queued1.ready;
+    expect(result1, isFalse);
+
+    // Release a slot — queued2 should get it, not queued1
+    queue.release(tickets.first);
+    final result2 = await queued2.ready;
+    expect(result2, isTrue);
+
+    // Clean up
+    queue.release(queued2);
+    for (var i = 1; i < tickets.length; i++) {
+      queue.release(tickets[i]);
+    }
+    expect(queue.activeCount, 0);
+  });
+
+  test('release on active ticket decrements count', () async {
+    final ticket = queue.acquire();
+    await ticket.ready;
+    expect(queue.activeCount, 1);
+
+    queue.release(ticket);
+    expect(queue.activeCount, 0);
+  });
+
+  test('release on queued ticket removes from queue', () async {
+    final tickets = <ImageDownloadTicket>[];
+    for (var i = 0; i < ImageDownloadQueue.maxConcurrent; i++) {
+      final ticket = queue.acquire();
+      tickets.add(ticket);
+      await ticket.ready;
+    }
+
+    final queuedTicket = queue.acquire();
+    expect(queue.queuedCount, 1);
+
+    // Release the queued ticket (simulating dispose before grant)
+    queue.release(queuedTicket);
+    expect(queue.queuedCount, 0);
+
+    final result = await queuedTicket.ready;
+    expect(result, isFalse);
+
+    // Clean up
+    for (final t in tickets) {
+      queue.release(t);
+    }
+    expect(queue.activeCount, 0);
+  });
+
+  test('FIFO order is respected', () async {
+    final tickets = <ImageDownloadTicket>[];
+    // Fill up all slots
+    for (var i = 0; i < ImageDownloadQueue.maxConcurrent; i++) {
+      final ticket = queue.acquire();
+      tickets.add(ticket);
+      await ticket.ready;
+    }
+
+    final order = <int>[];
+    final queued1 = queue.acquire();
+    final queued2 = queue.acquire();
+    final queued3 = queue.acquire();
+
+    queued1.ready.then((_) => order.add(1));
+    queued2.ready.then((_) => order.add(2));
+    queued3.ready.then((_) => order.add(3));
+
+    // Release slots one by one
+    queue.release(tickets[0]);
+    await Future.delayed(Duration.zero);
+    queue.release(tickets[1]);
+    await Future.delayed(Duration.zero);
+    queue.release(tickets[2]);
+    await Future.delayed(Duration.zero);
+
+    expect(order, [1, 2, 3]);
+
+    // Clean up
+    queue.release(queued1);
+    queue.release(queued2);
+    queue.release(queued3);
+    for (var i = 3; i < tickets.length; i++) {
+      queue.release(tickets[i]);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Add `ImageDownloadQueue` (FIFO semaphore, max 4 concurrent) to throttle simultaneous image downloads and URL preview fetches, preventing memory spikes that cause iOS OOM kills
- Cancel pending downloads when `MxcImage` is disposed (scrolled off-screen) so HTTP requests are never wasted
- Integrate the same queue into `GetPreviewUrlMixin` so `preview_url` requests share the concurrency limit
- Skip redundant `didUpdateWidget` processing in `ChatList` and `AppAdaptiveScaffoldBody` when args haven't changed
- Bump `file_picker` 10.1.7 → 10.3.10 to fix ObjC `FileUtils` class collision with `OSAnalytics` that caused random native crashes

## Context
In profile mode on iOS, the app crashes (`Lost connection to device`) after scrolling through rooms with many images/links. The root cause is an iOS OOM kill: dozens of image downloads + URL preview fetches fire simultaneously, each allocating memory for HTTP responses and decoded bitmaps. Combined with timeline data accumulation across multiple rooms, iOS kills the process when memory exceeds its limit.

These changes reduce peak concurrent HTTP requests from unbounded to max 4, and ensure widgets scrolled off-screen release their queue slot immediately.

> **Note:** The underlying memory accumulation from Matrix timeline data across rooms remains a deeper architectural issue. These changes significantly reduce the crash frequency but don't eliminate it entirely under extreme scrolling patterns.

## Changes
| File | Change |
|---|---|
| `lib/utils/image_download_queue.dart` | **New** — FIFO semaphore with max 4 concurrent slots |
| `lib/widgets/mxc_image.dart` | Acquire/release queue ticket around `_tryLoad`, cancel on dispose |
| `lib/widgets/mixins/get_preview_url_mixin.dart` | Acquire/release queue ticket around preview URL fetch, cancel on dispose |
| `lib/pages/chat_list/chat_list.dart` | Early return in `didUpdateWidget` when args are identical |
| `lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body.dart` | Early return in `didUpdateWidget` when args unchanged |
| `pubspec.yaml` | `file_picker` ^10.1.7 → ^10.3.10 |
| `test/utils/image_download_queue_test.dart` | **New** — 6 unit tests (acquire, queue, cancel, release, FIFO order) |

## Tests
- 6/6 `ImageDownloadQueue` tests pass
- 14/14 `MxcImageCacheManager` tests pass
- `flutter analyze` clean (0 errors)