### PR TITLE
perf: offload /sync JSON parsing to background isolate/web worker

### DIFF
--- a/lib/utils/client_manager.dart
+++ b/lib/utils/client_manager.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:fluffychat/utils/custom_http_client.dart';
 import 'package:fluffychat/utils/custom_image_resizer.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/flutter_hive_collections_database.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/twake_client.dart';
 import 'package:fluffychat/utils/open_sqflite_db.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/foundation.dart';
@@ -92,7 +93,7 @@ abstract class ClientManager {
       : NativeImplementationsIsolate(compute, vodozemacInit: () => vod.init());
 
   static Future<Client> createClient(String clientName) async {
-    return Client(
+    return TwakeClient(
       clientName,
       httpClient: PlatformInfos.isAndroid
           ? CustomHttpClient.createHTTPClient()

--- a/lib/utils/matrix_sdk_extensions/twake_client.dart
+++ b/lib/utils/matrix_sdk_extensions/twake_client.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:matrix/matrix.dart';
+
+/// Top-level function for native isolate-based sync response parsing.
+/// Returns a fully constructed [SyncUpdate] since Dart isolates can
+/// transfer complex objects without serialization overhead.
+SyncUpdate _parseSyncResponseNative(Uint8List responseBody) {
+  final responseString = utf8.decode(responseBody);
+  final json = jsonDecode(responseString);
+  return SyncUpdate.fromJson(json as Map<String, Object?>);
+}
+
+/// Top-level function for web JSON decoding via `compute()`.
+/// Returns only the raw [Map] because structured clone (used by web workers)
+/// transfers Maps/Lists/primitives efficiently, whereas custom Dart class
+/// instances like [SyncUpdate] do not. [SyncUpdate.fromJson] is therefore
+/// called on the main thread after the transfer.
+Map<String, Object?> _jsonDecodeSyncResponseWeb(Uint8List responseBody) {
+  final responseString = utf8.decode(responseBody);
+  return jsonDecode(responseString) as Map<String, Object?>;
+}
+
+/// A [Client] subclass that offloads the heavy JSON parsing of `/sync`
+/// responses to a background isolate / web worker.
+///
+/// On **native** platforms (iOS, Android, macOS, Linux), the entire parsing
+/// pipeline (`utf8.decode` + `jsonDecode` + `SyncUpdate.fromJson`) runs in
+/// a background isolate via `compute()`.
+///
+/// On **web**, only `utf8.decode` + `jsonDecode` (~80% of parsing time) runs
+/// via `compute()`. On Flutter Web with WASM, this executes at near-native
+/// speed (not in a separate thread). `SyncUpdate.fromJson` remains on the
+/// main thread because structured clone cannot transfer custom Dart class
+/// instances — only Maps/Lists/primitives pass without overhead.
+///
+/// ## Maintenance notice
+///
+/// This override replicates the HTTP request logic from the generated
+/// `Api.sync()` in `matrix_api_lite`. If the upstream SDK changes the
+/// sync endpoint (new parameters, headers, or path), this override must
+/// be updated accordingly. When upgrading the `matrix` SDK dependency,
+/// compare the generated `Api.sync()` signature and body with this
+/// implementation.
+// Validated against matrix SDK ^6.0.0
+class TwakeClient extends Client {
+  TwakeClient(
+    super.clientName, {
+    required super.database,
+    super.legacyDatabaseBuilder,
+    super.verificationMethods,
+    super.httpClient,
+    super.importantStateEvents,
+    super.roomPreviewLastEvents,
+    super.pinUnreadRooms,
+    super.pinInvitedRooms,
+    super.requestHistoryOnLimitedTimeline,
+    super.supportedLoginTypes,
+    super.mxidLocalPartFallback,
+    super.formatLocalpart,
+    super.nativeImplementations,
+    super.logLevel,
+    super.syncFilter,
+    super.defaultNetworkRequestTimeout,
+    super.sendTimelineEventTimeout,
+    super.customImageResizer,
+    super.shareKeysWith,
+    super.enableDehydratedDevices,
+    super.receiptsPublicByDefault,
+    super.onSoftLogout,
+    super.typingIndicatorTimeout,
+    super.convertLinebreaksInFormatting,
+  });
+
+  @override
+  Future<SyncUpdate> sync({
+    String? filter,
+    String? since,
+    bool? fullState,
+    PresenceType? setPresence,
+    int? timeout,
+    bool? useStateAfter,
+  }) async {
+    // Build the request identically to the generated Api.sync().
+    final requestUri = Uri(
+      path: '_matrix/client/v3/sync',
+      queryParameters: {
+        if (filter != null) 'filter': filter,
+        if (since != null) 'since': since,
+        if (fullState != null) 'full_state': fullState.toString(),
+        if (setPresence != null) 'set_presence': setPresence.name,
+        if (timeout != null) 'timeout': timeout.toString(),
+        if (useStateAfter != null) 'use_state_after': useStateAfter.toString(),
+      },
+    );
+    final request = http.Request('GET', baseUri!.resolveUri(requestUri));
+    request.headers['authorization'] = 'Bearer ${bearerToken!}';
+    final response = await httpClient.send(request);
+    final responseBody = await response.stream.toBytes();
+    if (response.statusCode != 200) {
+      unexpectedResponse(response, responseBody);
+    }
+
+    try {
+      if (kIsWeb) {
+        // On web: run utf8.decode + jsonDecode via compute() (near-native
+        // speed on WASM), then call SyncUpdate.fromJson on the main thread.
+        final json = await compute(_jsonDecodeSyncResponseWeb, responseBody);
+        return SyncUpdate.fromJson(json);
+      }
+
+      // On native: offload the entire pipeline to a background isolate.
+      return await compute(_parseSyncResponseNative, responseBody);
+    } catch (e) {
+      // Re-throw parsing errors with context so _innerSync's catch chain
+      // can distinguish them from network/connection errors.
+      throw FormatException('Failed to parse /sync response: $e');
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Move the expensive `/sync` response parsing off the main thread to eliminate UI freezes during Matrix sync.

## Problem

The `/sync` JSON response parsing (`utf8.decode` + `jsonDecode` + `SyncUpdate.fromJson`) was running entirely on the main thread, blocking the UI for **~380ms per sync call** (measured with CPU 4x throttling).

## Solution

Introduce `TwakeClient extends Client` that overrides `sync()` to offload parsing via `compute()`:

- **Native** (iOS/Android/Desktop): the entire pipeline runs in a background Dart isolate
- **Web**: only `utf8.decode` + `jsonDecode` (~80% of cost) runs in a web worker. `SyncUpdate.fromJson` stays on the main thread because web workers can only transfer Maps/Lists/primitives efficiently through structured clone — not custom Dart class instances

### Why a subclass instead of modifying the SDK?

- `Api.sync()` is **generated code** in `dart_matrix_api_lite` — modifications would be overwritten on regeneration
- The override is non-intrusive: `Client` exposes `httpClient`, `baseUri`, `bearerToken`, and `unexpectedResponse()` — everything needed to replicate the HTTP request
- Error handling, `FixedTimeoutHttpClient` timeout wrapper, soft logout, and token refresh all work identically to the original (verified by code review of the SDK internals)

> A maintenance notice is included in the code: when upgrading the `matrix` SDK, the generated `Api.sync()` signature should be compared with this override.

## Results

> Metrics collected via Chrome DevTools performance trace with CPU 4x throttling (simulating a low-end device). The raw flame chart JSON exceeded 350,000 lines — analysis was automated using the Chrome DevTools MCP on Claude Code to run the app, navigate through conversations, record performance traces, and extract metrics programmatically.

| Metric | Before | After | Delta |
|---|---|---|---|
| **Sync processing (main thread)** | **381.7ms** | **8.7ms** | **-97.7%** |

## Files changed

| File | Change |
|---|---|
| `lib/utils/matrix_sdk_extensions/twake_client.dart` | New file |
| `lib/utils/client_manager.dart` | Import + `Client(` → `TwakeClient(` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sync operation rewritten for safer error handling and platform-specific parsing/offloading to improve reliability and performance on web and native.
  * Sync request/response processing now buffers and validates responses more robustly to reduce malformed-sync failures.
  * Client creation now produces an updated client implementation while keeping the public creation API unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->