### PR TITLE
perf: fix ChatListSortRooms redundant rebuilds and lifecycle leaks

### DIFF
--- a/lib/pages/chat_list/chat_list_sort_rooms.dart
+++ b/lib/pages/chat_list/chat_list_sort_rooms.dart
@@ -30,6 +30,13 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
   Map<String, Event?> _lastEventByRoomId = {};
   List<Room> _sortCache = [];
   Map<String, StreamSubscription?> _roomSubscriptions = {};
+  Future<List<Room>>? _sortFuture;
+
+  /// Monotonically increasing counter to invalidate stale sort futures.
+  /// Each call to [_triggerSort] increments this value. When a sort future
+  /// completes, it checks whether its generation matches [_sortGeneration].
+  /// If not, the result is discarded (a newer sort has been triggered).
+  int _sortGeneration = 0;
 
   RoomSorter sortRoomsBy(Client client) => (a, b) {
     if (client.pinInvitedRooms &&
@@ -53,17 +60,32 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
         );
   };
 
-  Future<List<Room>> sortRooms() async {
+  Future<List<Room>> _sortRooms(int generation) async {
     await Matrix.of(context).initSettingsCompleter.future;
     for (final room in widget.rooms) {
+      // Bail out early if the widget was disposed or a newer sort was
+      // triggered while we were awaiting.
+      if (!mounted || generation != _sortGeneration) return _sortCache;
+
       if (_lastEventByRoomId[room.id] != null) continue;
 
       final event = await room.lastEventAvailableInPreview();
+
+      if (!mounted || generation != _sortGeneration) return _sortCache;
+
       _lastEventByRoomId[room.id] = event;
     }
+
+    if (!mounted) return _sortCache;
+
     widget.sortingRoomsNotifier.value = false;
     return List.from(widget.rooms)
       ..sort(sortRoomsBy(Matrix.of(context).client));
+  }
+
+  void _triggerSort() {
+    _sortGeneration++;
+    _sortFuture = _sortRooms(_sortGeneration);
   }
 
   @override
@@ -82,6 +104,7 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
         ),
       ),
     );
+    _triggerSort();
   }
 
   @override
@@ -114,12 +137,24 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
         ),
       ),
     );
+    _triggerSort();
+  }
+
+  @override
+  void dispose() {
+    for (final subscription in _roomSubscriptions.values) {
+      subscription?.cancel();
+    }
+    _roomSubscriptions.clear();
+    // Invalidate any in-flight sort future so its callbacks become no-ops.
+    _sortGeneration++;
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: sortRooms(),
+      future: _sortFuture,
       builder: (context, snapshot) {
         if (snapshot.data != null) {
           _sortCache = snapshot.data!;


### PR DESCRIPTION
## Summary

Fix the chat list sort widget that was re-running an expensive async sort on every frame rebuild, and fix pre-existing lifecycle bugs causing memory leaks.

## Problems

1. **Redundant sort on every build()**: `FutureBuilder(future: sortRooms())` was called directly in `build()`, creating a new Future on every rebuild. Since a parent `StreamBuilder` triggers rebuilds ~1x/second (rate-limited sync), this launched a full async sort of all rooms every second.

2. **Memory leak (pre-existing)**: No `dispose()` method — `StreamSubscription` instances (one per room, listening to `room.onUpdate`) were **never cancelled** when the widget was destroyed.

3. **Crash risk (pre-existing)**: `sortRooms()` accesses `context` and `widget` after multiple `await` calls without checking `mounted`. If the widget is disposed mid-sort, this throws `"Looking up a deactivated widget's ancestor"`.

4. **Concurrent stale futures (pre-existing)**: Each `didUpdateWidget` call launched a new sort without invalidating the previous one. Multiple sort futures could run in parallel, mutating shared state and writing to the parent's `ValueNotifier`.

## Solution

- Cache the sort `Future` in `_sortFuture`, computed only in `initState()` and `didUpdateWidget()` — not in `build()`
- Add `dispose()` to cancel all room subscriptions
- Add `mounted` guards after every `await` in `_sortRooms()`
- Add a `_sortGeneration` counter: each new sort increments it, and in-flight sorts bail out early if their generation is stale

## Results

> **Conditions**: Flutter Web `--profile` build, CPU throttling 4×, Chrome DevTools trace, Chrome restarted clean between each run. Navigation ~60 s (DMs, groups, contacts, settings, scroll, members list). Automated via Chrome DevTools MCP on Claude Code.

| Metric | main | PR 2932 | Delta |
|---|---|---|---|
| **Long tasks (>50 ms) count** | 9 | 8 | **−11 %** |
| **Long tasks total blocking** | 1 627 ms | 1 552 ms | −4.6 % |
| Long task max | 403.6 ms | 397.4 ms | −1.5 % |
| **JS Heap avg stable** | 77.9 MB | 73.6 MB | **−5.5 %** |
| JS Heap peak | 95.9 MB | 96.0 MB | ~0 % |
| **GC total time** | 1 390 ms | 1 185 ms | **−14.7 %** |
| Dropped frames | 235 | 225 | −4.3 % |
| Frame P50 | 7.03 ms | 7.17 ms | +2.0 % |

### Key takeaways

- **Memory**: −5.5 % steady-state heap thanks to `dispose()` cancelling per-room `StreamSubscription`s that were previously leaked.
- **GC pressure**: −14.7 % total GC time — direct consequence of reduced memory churn.
- **Long tasks**: modest reduction (−11 % count, −75 ms total). The dominant long tasks (>300 ms) come from `/sync` JSON parsing on the main thread, which is **not** addressed by this PR (see #2931).
- **Frames/jank**: within noise — the sort fix removes redundant async work but doesn't change the rendering pipeline itself.

## Files changed

| File | Change |
|---|---|
| `lib/pages/chat_list/chat_list_sort_rooms.dart` | Fix rebuild + add dispose/mounted/generation |