### PR TITLE
TW-2940 Widen ios navigation

### DIFF
--- a/lib/config/go_routes/app_routes.dart
+++ b/lib/config/go_routes/app_routes.dart
@@ -65,6 +65,8 @@ part 'app_routes.g.dart';
 
 ResponsiveUtils get _responsive => getIt.get<ResponsiveUtils>();
 
+const double _kWideBackGestureWidth = 100;
+
 FutureOr<String?> _loggedInRedirect(
   BuildContext context,
   GoRouterState state,
@@ -513,7 +515,7 @@ class DraftChatRoute extends GoRouteData with $DraftChatRoute {
   @override
   Page<void> buildPage(BuildContext context, GoRouterState state) =>
       TwakeCupertinoPage(
-        backGestureWidth: 100,
+        backGestureWidth: _kWideBackGestureWidth,
         child: DraftChatAdaptiveScaffold(
           key: Key($extra?['receiverId'] ?? ''),
           state: state,
@@ -831,7 +833,7 @@ class RoomRoute extends GoRouteData with $RoomRoute {
         name: name,
         restorationId: state.pageKey.value,
         child: child,
-        backGestureWidth: 100,
+        backGestureWidth: _kWideBackGestureWidth,
       );
     }
 
@@ -892,7 +894,7 @@ class PinnedMessagesRoute extends GoRouteData with $PinnedMessagesRoute {
       );
     }
     return const TwakeCupertinoPage(
-      backGestureWidth: 100,
+      backGestureWidth: _kWideBackGestureWidth,
       child: PinnedMessages(pinnedEvents: []),
     );
   }

--- a/lib/config/go_routes/app_routes.dart
+++ b/lib/config/go_routes/app_routes.dart
@@ -51,6 +51,7 @@ import 'package:fluffychat/widgets/layouts/adaptive_layout/app_adaptive_scaffold
 import 'package:fluffychat/widgets/layouts/agruments/app_adaptive_scaffold_body_args.dart';
 import 'package:fluffychat/widgets/log_view.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/twake_cupertino_page.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -130,6 +131,7 @@ class RootRoute extends GoRouteData with $RootRoute {
 )
 class HomeRoute extends GoRouteData with $HomeRoute {
   const HomeRoute({this.$extra});
+
   final bool? $extra;
 
   @override
@@ -236,6 +238,7 @@ class ErrorRoute extends GoRouteData with $ErrorRoute {
 @TypedGoRoute<InvitationLinkWebRoute>(path: '/chat/:matrixid')
 class InvitationLinkWebRoute extends GoRouteData with $InvitationLinkWebRoute {
   const InvitationLinkWebRoute({required this.matrixid});
+
   final String matrixid;
 
   @override
@@ -388,6 +391,7 @@ class StoriesCreateRoute extends GoRouteData with $StoriesCreateRoute {
 
 class StoryRoute extends GoRouteData with $StoryRoute {
   const StoryRoute({required this.roomid});
+
   final String roomid;
 
   @override
@@ -401,6 +405,7 @@ class StoryRoute extends GoRouteData with $StoryRoute {
 
 class StoryShareRoute extends GoRouteData with $StoryShareRoute {
   const StoryShareRoute({required this.roomid});
+
   final String roomid;
 
   @override
@@ -428,6 +433,7 @@ class ArchiveRoute extends GoRouteData with $ArchiveRoute {
 
 class ArchiveRoomRoute extends GoRouteData with $ArchiveRoomRoute {
   const ArchiveRoomRoute({required this.roomid});
+
   final String roomid;
 
   @override
@@ -469,6 +475,7 @@ class NewPrivateChatNewGroupRoute extends GoRouteData
 class NewPrivateChatNewGroupInfoRoute extends GoRouteData
     with $NewPrivateChatNewGroupInfoRoute {
   const NewPrivateChatNewGroupInfoRoute({this.$extra});
+
   final Set<PresentationContact>? $extra;
 
   @override
@@ -492,6 +499,7 @@ class NewGroupRoute extends GoRouteData with $NewGroupRoute {
 
 class DraftChatRoute extends GoRouteData with $DraftChatRoute {
   const DraftChatRoute({this.$extra});
+
   final Map<String, String>? $extra;
 
   @override
@@ -504,7 +512,8 @@ class DraftChatRoute extends GoRouteData with $DraftChatRoute {
 
   @override
   Page<void> buildPage(BuildContext context, GoRouterState state) =>
-      CupertinoPage(
+      TwakeCupertinoPage(
+        backGestureWidth: 100,
         child: DraftChatAdaptiveScaffold(
           key: Key($extra?['receiverId'] ?? ''),
           state: state,
@@ -516,6 +525,7 @@ class DraftChatRoute extends GoRouteData with $DraftChatRoute {
 
 class ForwardRoute extends GoRouteData with $ForwardRoute {
   const ForwardRoute({this.$extra});
+
   final ForwardArgument? $extra;
 
   @override
@@ -657,6 +667,7 @@ class EmotesRoute extends GoRouteData with $EmotesRoute {
 
 class AddAccountRoute extends GoRouteData with $AddAccountRoute {
   const AddAccountRoute({this.$extra});
+
   final TwakeWelcomeArg? $extra;
 
   @override
@@ -764,6 +775,7 @@ class SecurityContactsVisibilityRoute extends GoRouteData
 
 class RoomRoute extends GoRouteData with $RoomRoute {
   const RoomRoute({required this.roomid, this.event, this.$extra});
+
   final String roomid;
   final String? event; // query param: ?event=xxx
   final ChatRouterInputArgument? $extra;
@@ -814,11 +826,12 @@ class RoomRoute extends GoRouteData with $RoomRoute {
     );
 
     if (_responsive.isMobile(context)) {
-      return CupertinoPage(
+      return TwakeCupertinoPage(
         key: state.pageKey,
         name: name,
         restorationId: state.pageKey.value,
         child: child,
+        backGestureWidth: 100,
       );
     }
 
@@ -835,6 +848,7 @@ class RoomRoute extends GoRouteData with $RoomRoute {
 
 class EncryptionRoute extends GoRouteData with $EncryptionRoute {
   const EncryptionRoute({required this.roomid});
+
   final String roomid;
 
   @override
@@ -848,6 +862,7 @@ class EncryptionRoute extends GoRouteData with $EncryptionRoute {
 
 class InviteRoute extends GoRouteData with $InviteRoute {
   const InviteRoute({required this.roomid});
+
   final String roomid;
 
   @override
@@ -861,6 +876,7 @@ class InviteRoute extends GoRouteData with $InviteRoute {
 
 class PinnedMessagesRoute extends GoRouteData with $PinnedMessagesRoute {
   const PinnedMessagesRoute({required this.roomid, this.$extra});
+
   final String roomid;
   final PinnedEventsArgument? $extra;
 
@@ -875,6 +891,9 @@ class PinnedMessagesRoute extends GoRouteData with $PinnedMessagesRoute {
         ),
       );
     }
-    return const CupertinoPage(child: PinnedMessages(pinnedEvents: []));
+    return const TwakeCupertinoPage(
+      backGestureWidth: 100,
+      child: PinnedMessages(pinnedEvents: []),
+    );
   }
 }

--- a/lib/widgets/twake_cupertino_page.dart
+++ b/lib/widgets/twake_cupertino_page.dart
@@ -1,0 +1,332 @@
+import 'dart:math';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart';
+
+// Copied from flutter/src/cupertino/route.dart (private constants).
+const double _kMinFlingVelocity = 1.0;
+const Duration _kDroppedSwipePageAnimationDuration = Duration(
+  milliseconds: 350,
+);
+
+/// A [Page] that creates an iOS-style [PageRoute] with a configurable
+/// back-gesture hit-test width.
+///
+/// Identical to [CupertinoPage] but exposes [backGestureWidth] so callers can
+/// widen the swipe-back target area beyond the default 20 logical pixels.
+class TwakeCupertinoPage<T> extends Page<T> {
+  const TwakeCupertinoPage({
+    required this.child,
+    this.maintainState = true,
+    this.title,
+    this.fullscreenDialog = false,
+    this.allowSnapshotting = true,
+    this.backGestureWidth = 20.0,
+    super.canPop,
+    super.onPopInvoked,
+    super.key,
+    super.name,
+    super.arguments,
+    super.restorationId,
+  });
+
+  /// The content to be shown in the [Route] created by this page.
+  final Widget child;
+
+  /// {@macro flutter.cupertino.CupertinoRouteTransitionMixin.title}
+  final String? title;
+
+  /// {@macro flutter.widgets.ModalRoute.maintainState}
+  final bool maintainState;
+
+  /// {@macro flutter.widgets.PageRoute.fullscreenDialog}
+  final bool fullscreenDialog;
+
+  /// {@macro flutter.widgets.TransitionRoute.allowSnapshotting}
+  final bool allowSnapshotting;
+
+  /// Width of the interactive pop gesture hit area in logical pixels.
+  ///
+  /// The system default ([CupertinoPage]) uses 20 px. Increase this value to
+  /// make the edge swipe easier to trigger on devices with minimal bezel or
+  /// with a screen protector.
+  final double backGestureWidth;
+
+  @override
+  Route<T> createRoute(BuildContext context) {
+    return _TwakePageBasedCupertinoPageRoute<T>(
+      page: this,
+      allowSnapshotting: allowSnapshotting,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Route
+// ---------------------------------------------------------------------------
+
+class _TwakePageBasedCupertinoPageRoute<T> extends PageRoute<T>
+    with CupertinoRouteTransitionMixin<T> {
+  _TwakePageBasedCupertinoPageRoute({
+    required TwakeCupertinoPage<T> page,
+    super.allowSnapshotting = true,
+  }) : super(settings: page) {
+    assert(opaque);
+  }
+
+  @override
+  DelegatedTransitionBuilder? get delegatedTransition =>
+      fullscreenDialog ? null : CupertinoPageTransition.delegatedTransition;
+
+  TwakeCupertinoPage<T> get _page => settings as TwakeCupertinoPage<T>;
+
+  @override
+  Widget buildContent(BuildContext context) => _page.child;
+
+  @override
+  String? get title => _page.title;
+
+  @override
+  bool get maintainState => _page.maintainState;
+
+  @override
+  bool get fullscreenDialog => _page.fullscreenDialog;
+
+  @override
+  String get debugLabel => '${super.debugLabel}(${_page.name})';
+
+  /// Starts the pop gesture and returns the controller.
+  _TwakeCupertinoBackGestureController<T> _startPopGesture() {
+    assert(popGestureEnabled);
+    return _TwakeCupertinoBackGestureController<T>(
+      navigator: navigator!,
+      getIsCurrent: () => isCurrent,
+      getIsActive: () => isActive,
+      controller: controller!,
+    );
+  }
+
+  /// Replaces [CupertinoRouteTransitionMixin.buildTransitions] so we can
+  /// inject [_TwakeCupertinoBackGestureDetector] with the custom width.
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    final bool linearTransition = popGestureInProgress;
+    if (fullscreenDialog) {
+      return CupertinoFullscreenDialogTransition(
+        primaryRouteAnimation: animation,
+        secondaryRouteAnimation: secondaryAnimation,
+        linearTransition: linearTransition,
+        child: child,
+      );
+    }
+    return CupertinoPageTransition(
+      primaryRouteAnimation: animation,
+      secondaryRouteAnimation: secondaryAnimation,
+      linearTransition: linearTransition,
+      child: _TwakeCupertinoBackGestureDetector<T>(
+        backGestureWidth: _page.backGestureWidth,
+        enabledCallback: () => popGestureEnabled,
+        onStartPopGesture: _startPopGesture,
+        child: child,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gesture detector — copy of _CupertinoBackGestureDetector with configurable
+// backGestureWidth instead of the hardcoded _kBackGestureWidth = 20.0.
+// ---------------------------------------------------------------------------
+
+class _TwakeCupertinoBackGestureDetector<T> extends StatefulWidget {
+  const _TwakeCupertinoBackGestureDetector({
+    super.key,
+    required this.backGestureWidth,
+    required this.enabledCallback,
+    required this.onStartPopGesture,
+    required this.child,
+  });
+
+  final double backGestureWidth;
+  final Widget child;
+  final ValueGetter<bool> enabledCallback;
+  final ValueGetter<_TwakeCupertinoBackGestureController<T>> onStartPopGesture;
+
+  @override
+  _TwakeCupertinoBackGestureDetectorState<T> createState() =>
+      _TwakeCupertinoBackGestureDetectorState<T>();
+}
+
+class _TwakeCupertinoBackGestureDetectorState<T>
+    extends State<_TwakeCupertinoBackGestureDetector<T>> {
+  _TwakeCupertinoBackGestureController<T>? _backGestureController;
+
+  late HorizontalDragGestureRecognizer _recognizer;
+
+  @override
+  void initState() {
+    super.initState();
+    _recognizer = HorizontalDragGestureRecognizer(debugOwner: this)
+      ..onStart = _handleDragStart
+      ..onUpdate = _handleDragUpdate
+      ..onEnd = _handleDragEnd
+      ..onCancel = _handleDragCancel;
+  }
+
+  @override
+  void dispose() {
+    _recognizer.dispose();
+    if (_backGestureController != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_backGestureController?.navigator.mounted ?? false) {
+          _backGestureController?.navigator.didStopUserGesture();
+        }
+        _backGestureController = null;
+      });
+    }
+    super.dispose();
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    assert(mounted);
+    assert(_backGestureController == null);
+    _backGestureController = widget.onStartPopGesture();
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    assert(mounted);
+    assert(_backGestureController != null);
+    _backGestureController!.dragUpdate(
+      _convertToLogical(details.primaryDelta! / context.size!.width),
+    );
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    assert(mounted);
+    assert(_backGestureController != null);
+    _backGestureController!.dragEnd(
+      _convertToLogical(
+        details.velocity.pixelsPerSecond.dx / context.size!.width,
+      ),
+    );
+    _backGestureController = null;
+  }
+
+  void _handleDragCancel() {
+    assert(mounted);
+    _backGestureController?.dragEnd(0.0);
+    _backGestureController = null;
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    if (widget.enabledCallback()) {
+      _recognizer.addPointer(event);
+    }
+  }
+
+  double _convertToLogical(double value) {
+    return switch (Directionality.of(context)) {
+      TextDirection.rtl => -value,
+      TextDirection.ltr => value,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    assert(debugCheckHasDirectionality(context));
+    final double dragAreaWidth = switch (Directionality.of(context)) {
+      TextDirection.rtl => MediaQuery.paddingOf(context).right,
+      TextDirection.ltr => MediaQuery.paddingOf(context).left,
+    };
+    return Stack(
+      fit: StackFit.passthrough,
+      children: <Widget>[
+        widget.child,
+        PositionedDirectional(
+          start: 0.0,
+          width: max(dragAreaWidth, widget.backGestureWidth),
+          top: 0.0,
+          bottom: 0.0,
+          child: Listener(
+            onPointerDown: _handlePointerDown,
+            behavior: HitTestBehavior.translucent,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Gesture controller — identical copy of _CupertinoBackGestureController.
+// Must be copied because it's private in the Flutter SDK.
+// ---------------------------------------------------------------------------
+
+class _TwakeCupertinoBackGestureController<T> {
+  _TwakeCupertinoBackGestureController({
+    required this.navigator,
+    required this.controller,
+    required this.getIsActive,
+    required this.getIsCurrent,
+  }) {
+    navigator.didStartUserGesture();
+  }
+
+  final AnimationController controller;
+  final NavigatorState navigator;
+  final ValueGetter<bool> getIsActive;
+  final ValueGetter<bool> getIsCurrent;
+
+  void dragUpdate(double delta) {
+    controller.value -= delta;
+  }
+
+  void dragEnd(double velocity) {
+    const Curve animationCurve = Curves.fastEaseInToSlowEaseOut;
+    final bool isCurrent = getIsCurrent();
+    final bool animateForward;
+
+    if (!isCurrent) {
+      animateForward = getIsActive();
+    } else if (velocity.abs() >= _kMinFlingVelocity) {
+      animateForward = velocity <= 0;
+    } else {
+      animateForward = controller.value > 0.5;
+    }
+
+    if (animateForward) {
+      controller.animateTo(
+        1.0,
+        duration: _kDroppedSwipePageAnimationDuration,
+        curve: animationCurve,
+      );
+    } else {
+      if (isCurrent) {
+        navigator.pop();
+      }
+      if (controller.isAnimating) {
+        controller.animateBack(
+          0.0,
+          duration: _kDroppedSwipePageAnimationDuration,
+          curve: animationCurve,
+        );
+      }
+    }
+
+    if (controller.isAnimating) {
+      late AnimationStatusListener animationStatusCallback;
+      animationStatusCallback = (AnimationStatus status) {
+        navigator.didStopUserGesture();
+        controller.removeStatusListener(animationStatusCallback);
+      };
+      controller.addStatusListener(animationStatusCallback);
+    } else {
+      navigator.didStopUserGesture();
+    }
+  }
+}

--- a/lib/widgets/twake_cupertino_page.dart
+++ b/lib/widgets/twake_cupertino_page.dart
@@ -144,6 +144,8 @@ class _TwakePageBasedCupertinoPageRoute<T> extends PageRoute<T>
 // ---------------------------------------------------------------------------
 // Gesture detector — copy of _CupertinoBackGestureDetector with configurable
 // backGestureWidth instead of the hardcoded _kBackGestureWidth = 20.0.
+// Sourced from Flutter 3.38.9 (flutter/lib/src/cupertino/route.dart).
+// Keep in sync when upgrading Flutter.
 // ---------------------------------------------------------------------------
 
 class _TwakeCupertinoBackGestureDetector<T> extends StatefulWidget {

--- a/lib/widgets/twake_cupertino_page.dart
+++ b/lib/widgets/twake_cupertino_page.dart
@@ -202,18 +202,24 @@ class _TwakeCupertinoBackGestureDetectorState<T>
   void _handleDragUpdate(DragUpdateDetails details) {
     assert(mounted);
     assert(_backGestureController != null);
+    final size = context.size;
+    if (size == null) return;
     _backGestureController!.dragUpdate(
-      _convertToLogical(details.primaryDelta! / context.size!.width),
+      _convertToLogical(details.primaryDelta! / size.width),
     );
   }
 
   void _handleDragEnd(DragEndDetails details) {
     assert(mounted);
     assert(_backGestureController != null);
+    final size = context.size;
+    if (size == null) {
+      _backGestureController?.dragEnd(0.0);
+      _backGestureController = null;
+      return;
+    }
     _backGestureController!.dragEnd(
-      _convertToLogical(
-        details.velocity.pixelsPerSecond.dx / context.size!.width,
-      ),
+      _convertToLogical(details.velocity.pixelsPerSecond.dx / size.width),
     );
     _backGestureController = null;
   }

--- a/lib/widgets/twake_cupertino_page.dart
+++ b/lib/widgets/twake_cupertino_page.dart
@@ -181,12 +181,13 @@ class _TwakeCupertinoBackGestureDetectorState<T>
   @override
   void dispose() {
     _recognizer.dispose();
-    if (_backGestureController != null) {
+    final controller = _backGestureController;
+    _backGestureController = null;
+    if (controller != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (_backGestureController?.navigator.mounted ?? false) {
-          _backGestureController?.navigator.didStopUserGesture();
+        if (controller.navigator.mounted) {
+          controller.navigator.didStopUserGesture();
         }
-        _backGestureController = null;
       });
     }
     super.dispose();

--- a/lib/widgets/twake_cupertino_page.dart
+++ b/lib/widgets/twake_cupertino_page.dart
@@ -28,7 +28,10 @@ class TwakeCupertinoPage<T> extends Page<T> {
     super.name,
     super.arguments,
     super.restorationId,
-  });
+  }) : assert(
+         backGestureWidth >= 0 && backGestureWidth < double.infinity,
+         'backGestureWidth must be a finite, non-negative value',
+       );
 
   /// The content to be shown in the [Route] created by this page.
   final Widget child;


### PR DESCRIPTION
## Ticket
- #2940 

## Resolved


https://github.com/user-attachments/assets/4c46ecf5-d683-43d5-8cb6-b7e7dfc59775




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable back-swipe navigation for iOS-style pages with adjustable gesture detection width (default 20.0).
* **Improvements**
  * Applied wider gesture region on mobile routes for easier back-swipe (uses larger default in mobile contexts).
  * Improved fullscreen-dialog snapshot behavior and smoother interactive back-swipe animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->