### PR TITLE
TW-2942: Refactor connection status handling in chat components

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3194,6 +3194,5 @@
   "selectYourServer": "Select your server",
   "welcomeBack": "Welcome back",
   "matrixIdOrUsername": "Matrix Id or username",
-  "updating": "Updating...",
   "waitingForResponse": "Waiting for response"
 }

--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3193,5 +3193,7 @@
   "@cacheIsScanning": {},
   "selectYourServer": "Select your server",
   "welcomeBack": "Welcome back",
-  "matrixIdOrUsername": "Matrix Id or username"
+  "matrixIdOrUsername": "Matrix Id or username",
+  "updating": "Updating...",
+  "waitingForResponse": "Waiting for response"
 }

--- a/lib/pages/chat/chat_app_bar_title.dart
+++ b/lib/pages/chat/chat_app_bar_title.dart
@@ -16,6 +16,7 @@ import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/common_helper.dart';
 import 'package:fluffychat/utils/room_status_extension.dart';
 import 'package:fluffychat/utils/string_extension.dart';
+import 'package:fluffychat/widgets/connection_status_header.dart';
 import 'package:flutter/material.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -143,17 +144,25 @@ class ChatAppBarTitle extends StatelessWidget {
                             style: ChatAppBarTitleStyle.appBarTitleStyle(
                               context,
                             ),
-                          ),
-                        ),
-                      ],
+                          );
+                        },
+                      ),
                     ),
-                    statusContent!,
                   ],
                 ),
-              ),
-            ],
-          );
-        },
+                ConnectionStatusHeader(
+                  connectedWidget: _ChatAppBarStatusContent(
+                    connectivityResultStream: connectivityResultStream,
+                    room: room!,
+                    cachedPresenceNotifier: cachedPresenceNotifier,
+                    cachedPresenceStreamController:
+                        cachedPresenceStreamController,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/chat/chat_app_bar_title.dart
+++ b/lib/pages/chat/chat_app_bar_title.dart
@@ -91,11 +91,13 @@ class ChatAppBarTitle extends StatelessWidget {
       // when the contacts notifier emits.
       child: ValueListenableBuilder(
         valueListenable: getIt.get<ContactsManager>().getContactsNotifier(),
-        child: _ChatAppBarStatusContent(
-          connectivityResultStream: connectivityResultStream,
-          room: room!,
-          cachedPresenceNotifier: cachedPresenceNotifier,
-          cachedPresenceStreamController: cachedPresenceStreamController,
+        child: ConnectionStatusHeader(
+          connectedWidget: _ChatAppBarStatusContent(
+            connectivityResultStream: connectivityResultStream,
+            room: room!,
+            cachedPresenceNotifier: cachedPresenceNotifier,
+            cachedPresenceStreamController: cachedPresenceStreamController,
+          ),
         ),
         builder: (context, state, statusContent) {
           final resolvedRoomName = _getRoomName(context, state);
@@ -144,25 +146,17 @@ class ChatAppBarTitle extends StatelessWidget {
                             style: ChatAppBarTitleStyle.appBarTitleStyle(
                               context,
                             ),
-                          );
-                        },
-                      ),
+                          ),
+                        ),
+                      ],
                     ),
+                    statusContent!,
                   ],
                 ),
-                ConnectionStatusHeader(
-                  connectedWidget: _ChatAppBarStatusContent(
-                    connectivityResultStream: connectivityResultStream,
-                    room: room!,
-                    cachedPresenceNotifier: cachedPresenceNotifier,
-                    cachedPresenceStreamController:
-                        cachedPresenceStreamController,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ],
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/pages/chat/chat_view_body.dart
+++ b/lib/pages/chat/chat_view_body.dart
@@ -21,7 +21,6 @@ import 'package:fluffychat/pages/contacts_tab/widgets/add_contact/add_contact_di
 import 'package:fluffychat/presentation/model/chat/view_event_list_ui_state.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
-import 'package:fluffychat/widgets/connection_status_header.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_emoji_mart/flutter_emoji_mart.dart';
@@ -343,7 +342,6 @@ class ChatViewBody extends StatelessWidget with MessageContentMixin {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const ConnectionStatusHeader(),
           ValueListenableBuilder(
             valueListenable: controller.editEventNotifier,
             builder: (context, editEvent, _) {

--- a/lib/pages/chat_list/chat_list_body_view.dart
+++ b/lib/pages/chat_list/chat_list_body_view.dart
@@ -8,7 +8,6 @@ import 'package:fluffychat/pages/chat_list/space_view.dart';
 import 'package:fluffychat/presentation/enum/chat_list/chat_list_enum.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
-import 'package:fluffychat/widgets/connection_status_header.dart';
 import 'package:flutter/material.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
@@ -115,9 +114,6 @@ class ChatListBodyView extends StatelessWidget {
                 return CustomScrollView(
                   controller: controller.scrollController,
                   slivers: [
-                    SliverToBoxAdapter(
-                      child: ConnectionStatusHeader(controller: controller),
-                    ),
                     SliverToBoxAdapter(
                       child: AnimatedContainer(
                         height: ChatListBodyViewStyle.heightIsTorBrowser(

--- a/lib/pages/chat_list/chat_list_header.dart
+++ b/lib/pages/chat_list/chat_list_header.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/pages/chat_list/chat_list.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_header_style.dart';
 import 'package:fluffychat/pages/search/search.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/widgets/connection_status_header.dart';
 import 'package:fluffychat/widgets/context_menu_builder_ios_paste_without_permission.dart';
 import 'package:fluffychat/widgets/swipe_to_dismiss_wrap.dart';
 import 'package:fluffychat/widgets/twake_components/twake_header.dart';
@@ -31,6 +32,7 @@ class ChatListHeader extends StatelessWidget {
           conversationSelectionNotifier:
               controller.conversationSelectionNotifier,
           onClickAvatar: controller.onClickAvatar,
+          connectionStatusHeaderWidget: const ConnectionStatusHeader(),
         ),
         Container(
           color: ChatListHeaderStyle.responsive.isMobile(context)

--- a/lib/utils/localized_exception_extension.dart
+++ b/lib/utils/localized_exception_extension.dart
@@ -45,6 +45,6 @@ extension LocalizedExceptionExtension on Object {
     if (this is String) return toString();
     if (this is UiaException) return toString();
     Logs().w('Something went wrong: ', this);
-    return L10n.of(context)!.oopsSomethingWentWrong;
+    return L10n.of(context)!.waitingForResponse;
   }
 }

--- a/lib/utils/localized_exception_extension.dart
+++ b/lib/utils/localized_exception_extension.dart
@@ -45,6 +45,6 @@ extension LocalizedExceptionExtension on Object {
     if (this is String) return toString();
     if (this is UiaException) return toString();
     Logs().w('Something went wrong: ', this);
-    return L10n.of(context)!.waitingForResponse;
+    return L10n.of(context)!.oopsSomethingWentWrong;
   }
 }

--- a/lib/widgets/app_bars/twake_app_bar.dart
+++ b/lib/widgets/app_bars/twake_app_bar.dart
@@ -16,6 +16,7 @@ class TwakeAppBar extends StatelessWidget implements PreferredSizeWidget {
   final double? leadingWidth;
   final bool enableLeftTitle;
   final bool isDialog;
+  final Widget? connectionStatusHeaderWidget;
 
   const TwakeAppBar({
     super.key,
@@ -29,6 +30,7 @@ class TwakeAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.leadingWidth,
     this.enableLeftTitle = false,
     this.isDialog = false,
+    this.connectionStatusHeaderWidget,
   });
 
   @override
@@ -57,6 +59,8 @@ class TwakeAppBar extends StatelessWidget implements PreferredSizeWidget {
                     ),
                   ),
                 ),
+                if (connectionStatusHeaderWidget != null)
+                  connectionStatusHeaderWidget!,
               ],
             )
           : Row(
@@ -65,12 +69,19 @@ class TwakeAppBar extends StatelessWidget implements PreferredSizeWidget {
                   padding: enableLeftTitle
                       ? EdgeInsets.zero
                       : const EdgeInsets.only(left: 16),
-                  child: Text(
-                    title,
-                    style: TwakeAppBarStyle.titleTextStyle(
-                      context,
-                      isDialog: isDialog,
-                    ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: TwakeAppBarStyle.titleTextStyle(
+                          context,
+                          isDialog: isDialog,
+                        ),
+                      ),
+                      if (connectionStatusHeaderWidget != null)
+                        connectionStatusHeaderWidget!,
+                    ],
                   ),
                 ),
               ],

--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -1,19 +1,17 @@
 import 'dart:async';
-
-import 'package:fluffychat/pages/chat_list/chat_list.dart';
-import 'package:fluffychat/widgets/chat_sort_loading.dart';
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
 
 import '../utils/localized_exception_extension.dart';
 import 'matrix.dart';
 
 class ConnectionStatusHeader extends StatefulWidget {
-  const ConnectionStatusHeader({super.key, this.controller});
+  const ConnectionStatusHeader({super.key, this.connectedWidget});
 
-  final ChatListController? controller;
+  final Widget? connectedWidget;
 
   @override
   ConnectionStatusHeaderState createState() => ConnectionStatusHeaderState();
@@ -21,17 +19,41 @@ class ConnectionStatusHeader extends StatefulWidget {
 
 class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
   late final StreamSubscription _onSyncSub;
+  SyncStatus? _lastStatus;
+  bool _lastHideState = true;
+  Timer? _debounceTimer;
 
   @override
   void initState() {
+    super.initState();
     _onSyncSub = Matrix.of(
       context,
-    ).client.onSyncStatus.stream.listen((_) => setState(() {}));
-    super.initState();
+    ).client.onSyncStatus.stream.listen(_onStatusUpdate);
+  }
+
+  void _onStatusUpdate(SyncStatusUpdate update) {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(const Duration(milliseconds: 100), () {
+      if (!mounted) return;
+
+      final client = Matrix.of(context).client;
+      final hide =
+          client.onSync.value != null &&
+          update.status != SyncStatus.error &&
+          client.prevBatch != null;
+
+      if (_lastStatus != update.status || _lastHideState != hide) {
+        setState(() {
+          _lastStatus = update.status;
+          _lastHideState = hide;
+        });
+      }
+    });
   }
 
   @override
   void dispose() {
+    _debounceTimer?.cancel();
     _onSyncSub.cancel();
     super.dispose();
   }
@@ -47,42 +69,34 @@ class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
         status.status != SyncStatus.error &&
         client.prevBatch != null;
 
-    if (hide) return ChatSortLoading(controller: widget.controller);
-
-    return Container(
-      height: 36,
-      clipBehavior: Clip.hardEdge,
-      decoration: BoxDecoration(color: Theme.of(context).colorScheme.surface),
-      padding: const EdgeInsets.symmetric(horizontal: 12),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          SizedBox(
-            width: 24,
-            height: 24,
-            child: CircularProgressIndicator.adaptive(
-              strokeWidth: 2,
-              value: hide ? 1.0 : status.progress,
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 200),
+      transitionBuilder: (child, animation) {
+        return FadeTransition(opacity: animation, child: child);
+      },
+      child: hide
+          ? (widget.connectedWidget != null
+                ? widget.connectedWidget!
+                : const SizedBox.shrink())
+          : Text(
+              status.toLocalizedString(context),
+              key: ValueKey(status.status),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: LinagoraSysColors.material().secondary,
+              ),
             ),
-          ),
-          const SizedBox(width: 12),
-          Text(
-            status.toLocalizedString(context),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
-          ),
-        ],
-      ),
     );
   }
 }
 
 extension on SyncStatusUpdate {
   String toLocalizedString(BuildContext context) {
+    final l10n = L10n.of(context);
     switch (status) {
       case SyncStatus.waitingForResponse:
-        return L10n.of(context)!.loadingPleaseWait;
+        return l10n!.waitingForResponse;
       case SyncStatus.error:
         return ((error?.exception ?? Object()) as Object).toLocalizedString(
           context,
@@ -90,7 +104,7 @@ extension on SyncStatusUpdate {
       case SyncStatus.processing:
       case SyncStatus.cleaningUp:
       case SyncStatus.finished:
-        return L10n.of(context)!.synchronizingPleaseWait;
+        return l10n!.synchronizingPleaseWait;
     }
   }
 }

--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -75,9 +75,7 @@ class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
         return FadeTransition(opacity: animation, child: child);
       },
       child: hide
-          ? (widget.connectedWidget != null
-                ? widget.connectedWidget!
-                : const SizedBox.shrink())
+          ? widget.connectedWidget ?? const SizedBox.shrink()
           : Text(
               status.toLocalizedString(context),
               key: ValueKey(status.status),

--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -17,7 +17,7 @@ class ConnectionStatusHeader extends StatefulWidget {
 
 class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
   late final StreamSubscription _onSyncSub;
-  SyncStatus? _lastStatus;
+  SyncStatusUpdate? _lastStatus;
   bool _lastHideState = true;
   Timer? _debounceTimer;
 
@@ -40,9 +40,9 @@ class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
           update.status != SyncStatus.error &&
           client.prevBatch != null;
 
-      if (_lastStatus != update.status || _lastHideState != hide) {
+      if (_lastStatus?.status != update.status || _lastHideState != hide) {
         setState(() {
-          _lastStatus = update.status;
+          _lastStatus = update;
           _lastHideState = hide;
         });
       }
@@ -60,6 +60,7 @@ class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
   Widget build(BuildContext context) {
     final client = Matrix.of(context).client;
     final status =
+        _lastStatus ??
         client.onSyncStatus.value ??
         const SyncStatusUpdate(SyncStatus.waitingForResponse);
     final hide =

--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -94,7 +94,7 @@ extension on SyncStatusUpdate {
       case SyncStatus.waitingForResponse:
         return l10n!.waitingForResponse;
       case SyncStatus.error:
-        return L10n.of(context)!.waitingForResponse;
+        return l10n!.waitingForResponse;
       case SyncStatus.processing:
       case SyncStatus.cleaningUp:
       case SyncStatus.finished:

--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -4,8 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
-
-import '../utils/localized_exception_extension.dart';
 import 'matrix.dart';
 
 class ConnectionStatusHeader extends StatefulWidget {
@@ -96,9 +94,7 @@ extension on SyncStatusUpdate {
       case SyncStatus.waitingForResponse:
         return l10n!.waitingForResponse;
       case SyncStatus.error:
-        return ((error?.exception ?? Object()) as Object).toLocalizedString(
-          context,
-        );
+        return L10n.of(context)!.waitingForResponse;
       case SyncStatus.processing:
       case SyncStatus.cleaningUp:
       case SyncStatus.finished:

--- a/lib/widgets/twake_components/twake_header.dart
+++ b/lib/widgets/twake_components/twake_header.dart
@@ -19,6 +19,7 @@ class TwakeHeader extends StatefulWidget implements PreferredSizeWidget {
   conversationSelectionNotifier;
   final VoidCallback onClickAvatar;
   final Client client;
+  final Widget? connectionStatusHeaderWidget;
 
   const TwakeHeader({
     super.key,
@@ -27,6 +28,7 @@ class TwakeHeader extends StatefulWidget implements PreferredSizeWidget {
     required this.selectModeNotifier,
     required this.conversationSelectionNotifier,
     required this.onClickAvatar,
+    this.connectionStatusHeaderWidget,
   });
 
   @override
@@ -100,7 +102,12 @@ class _TwakeHeaderState extends State<TwakeHeader>
       valueListenable: widget.selectModeNotifier,
       builder: (context, selectMode, _) {
         return selectMode == SelectMode.normal
-            ? TwakeAppBar(title: L10n.of(context)!.chats, context: context)
+            ? TwakeAppBar(
+                title: L10n.of(context)!.chats,
+                context: context,
+                connectionStatusHeaderWidget:
+                    widget.connectionStatusHeaderWidget,
+              )
             : AppBar(
                 backgroundColor: responsive.isMobile(context)
                     ? LinagoraSysColors.material().background


### PR DESCRIPTION
## Ticket
**Related issue**

- #2942 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-19 at 12 30 31" src="https://github.com/user-attachments/assets/7ce7b11d-5ed0-4d99-b214-7b7e29414cda" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-03-19 at 12 30 34" src="https://github.com/user-attachments/assets/9369860d-e93f-4903-b17e-b9d0c017ffd9" />


<img width="1262" height="627" alt="Screenshot 2026-03-26 at 09 43 55" src="https://github.com/user-attachments/assets/44825aae-58f9-47ec-a490-7c9981abba7e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two status messages: "Updating..." and "Waiting for response"

* **Improvements**
  * Connection status is now shown in the app header (no longer duplicated in the chat input or chat list)
  * Status indicator uses smoother transitions and more stable update timing for less flicker and clearer messaging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->