### PR TITLE
perf: prevent iOS OOM kills with image download queue and decode resize

### DIFF
--- a/lib/pages/chat/events/images_builder/image_bubble.dart
+++ b/lib/pages/chat/events/images_builder/image_bubble.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/pages/chat/events/images_builder/image_builder_web.dart';
 import 'package:fluffychat/pages/chat/events/images_builder/image_placeholder.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
@@ -108,6 +109,8 @@ class ImageBubble extends StatelessWidget {
                     event: event,
                     width: width,
                     height: height,
+                    cacheWidth: context.getCacheSize(width),
+                    cacheHeight: context.getCacheSize(height),
                     fit: fit,
                     animated: animated,
                     isThumbnail: thumbnailOnly,

--- a/lib/utils/image_download_queue.dart
+++ b/lib/utils/image_download_queue.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:flutter/foundation.dart';
+
+/// Limits the number of concurrent image download/decode operations
+/// to prevent memory spikes that cause iOS OOM kills.
+///
+/// Each [MxcImage] acquires a slot before starting its load and
+/// releases it when done (or when disposed). If all slots are taken,
+/// the request is queued and processed in FIFO order.
+class ImageDownloadQueue {
+  static ImageDownloadQueue _instance = ImageDownloadQueue._internal();
+  static ImageDownloadQueue get instance => _instance;
+
+  @visibleForTesting
+  static set instance(ImageDownloadQueue queue) => _instance = queue;
+
+  @visibleForTesting
+  static void resetInstance() {
+    _instance = ImageDownloadQueue._internal();
+  }
+
+  ImageDownloadQueue._internal({this.maxConcurrent = 4});
+
+  @visibleForTesting
+  factory ImageDownloadQueue.forTesting({int maxConcurrent = 4}) =>
+      ImageDownloadQueue._internal(maxConcurrent: maxConcurrent);
+
+  /// Maximum number of image loads running simultaneously.
+  /// 4 is a good balance: enough parallelism for fast scrolling,
+  /// low enough to avoid memory pressure on iOS.
+  final int maxConcurrent;
+
+  int _running = 0;
+  final Queue<_QueueEntry> _queue = Queue<_QueueEntry>();
+
+  /// Acquires a slot in the download queue.
+  ///
+  /// Returns an [ImageDownloadTicket] whose [ready] future completes
+  /// with `true` when a slot is available, or `false` if cancelled.
+  ///
+  /// The ticket must be released via [release] when work is finished,
+  /// or cancelled via [ImageDownloadTicket.cancel] if no longer needed.
+  ImageDownloadTicket acquire() {
+    final ticket = ImageDownloadTicket._();
+
+    if (_running < maxConcurrent) {
+      _running++;
+      ticket._granted = true;
+      ticket._completer.complete(true);
+    } else {
+      final entry = _QueueEntry(ticket);
+      _queue.add(entry);
+      // Entry held in queue; ticket uses cancel() to skip when drained.
+    }
+
+    return ticket;
+  }
+
+  /// Releases a slot, allowing the next queued request to proceed.
+  void release(ImageDownloadTicket ticket) {
+    if (!ticket._granted) {
+      // Was still queued — mark as cancelled and let _drainQueue skip it.
+      // This is O(1) instead of O(n) queue.remove().
+      ticket.cancel();
+      return;
+    }
+
+    ticket._granted = false;
+    _running--;
+
+    _drainQueue();
+  }
+
+  void _drainQueue() {
+    while (_running < maxConcurrent && _queue.isNotEmpty) {
+      final next = _queue.removeFirst();
+      if (next.ticket._cancelled) {
+        if (!next.ticket._completer.isCompleted) {
+          next.ticket._completer.complete(false);
+        }
+        continue;
+      }
+      _running++;
+      next.ticket._granted = true;
+      // Ticket granted; no longer in queue.
+      if (!next.ticket._completer.isCompleted) {
+        next.ticket._completer.complete(true);
+      }
+    }
+  }
+
+  /// Current number of active downloads (for debugging/testing).
+  int get activeCount => _running;
+
+  /// Current number of queued downloads (for debugging/testing).
+  /// Note: may include cancelled entries not yet drained.
+  int get queuedCount => _queue.length;
+}
+
+/// A ticket representing a pending or active slot in the download queue.
+class ImageDownloadTicket {
+  ImageDownloadTicket._();
+
+  final Completer<bool> _completer = Completer<bool>();
+  bool _granted = false;
+  bool _cancelled = false;
+
+  /// Resolves to `true` when a slot is available and work should start,
+  /// or `false` if the ticket was cancelled before being granted.
+  Future<bool> get ready => _completer.future;
+
+  /// Whether this ticket currently holds an active slot.
+  bool get isActive => _granted;
+
+  /// Cancel this ticket. If still queued, it will be skipped by drainQueue.
+  /// If already active, call [ImageDownloadQueue.release] instead.
+  void cancel() {
+    _cancelled = true;
+    if (!_granted && !_completer.isCompleted) {
+      _completer.complete(false);
+    }
+  }
+}
+
+class _QueueEntry {
+  final ImageDownloadTicket ticket;
+  const _QueueEntry(this.ticket);
+}

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -226,39 +226,41 @@ class _MxcImageState extends State<MxcImage>
       return;
     }
 
-    // Acquire a slot from the shared download queue to prevent
-    // dozens of image downloads/decodes from running simultaneously,
-    // which causes OOM kills on iOS during fast scrolling.
-    _releaseDownloadTicket();
-    final ticket = ImageDownloadQueue.instance.acquire();
-    _downloadTicket = ticket;
+    var shouldRetry = false;
+    do {
+      shouldRetry = false;
 
-    final shouldProceed = await ticket.ready;
-    if (!shouldProceed || !mounted) {
-      if (shouldProceed) {
-        ImageDownloadQueue.instance.release(ticket);
-        _downloadTicket = null;
-      }
-      return;
-    }
+      // Acquire a slot from the shared download queue to prevent
+      // dozens of image downloads/decodes from running simultaneously,
+      // which causes OOM kills on iOS during fast scrolling.
+      _releaseDownloadTicket();
+      final ticket = ImageDownloadQueue.instance.acquire();
+      _downloadTicket = ticket;
 
-    try {
-      final loadResult = await _load(context);
-      isLoadDone = true;
-      _imageData = loadResult.imageData;
-      filePath = loadResult.filePath;
-      if (mounted) setState(() {});
-    } catch (e) {
-      if (mounted && !isLoadDone) {
-        isLoadDone = true;
-        // Release before retry so the retry can acquire its own slot.
-        _releaseDownloadTicket();
-        _tryLoad(context);
+      final shouldProceed = await ticket.ready;
+      if (!shouldProceed || !mounted) {
+        if (shouldProceed) {
+          ImageDownloadQueue.instance.release(ticket);
+          _downloadTicket = null;
+        }
         return;
       }
-    } finally {
-      _releaseDownloadTicket();
-    }
+
+      try {
+        final loadResult = await _load(context);
+        isLoadDone = true;
+        _imageData = loadResult.imageData;
+        filePath = loadResult.filePath;
+        if (mounted) setState(() {});
+      } catch (e) {
+        if (mounted && !isLoadDone) {
+          isLoadDone = true;
+          shouldRetry = true;
+        }
+      } finally {
+        _releaseDownloadTicket();
+      }
+    } while (shouldRetry);
   }
 
   void _releaseDownloadTicket() {

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -11,6 +11,7 @@ import 'package:fluffychat/utils/interactive_viewer_gallery.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
+import 'package:fluffychat/utils/image_download_queue.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/hero_page_route.dart';
 import 'package:flutter/cupertino.dart';
@@ -98,6 +99,7 @@ class _MxcImageState extends State<MxcImage>
   ImageData? _imageDataNoCache;
   bool isLoadDone = false;
   String? filePath;
+  ImageDownloadTicket? _downloadTicket;
 
   ImageData? get _imageData {
     final cacheKey = widget.cacheKey;
@@ -221,19 +223,53 @@ class _MxcImageState extends State<MxcImage>
       isLoadDone = true;
       filePath = null;
       setState(() {});
+      return;
     }
+
+    // Acquire a slot from the shared download queue to prevent
+    // dozens of image downloads/decodes from running simultaneously,
+    // which causes OOM kills on iOS during fast scrolling.
+    _releaseDownloadTicket();
+    final ticket = ImageDownloadQueue.instance.acquire();
+    _downloadTicket = ticket;
+
+    final shouldProceed = await ticket.ready;
+    if (!shouldProceed || !mounted) {
+      if (shouldProceed) {
+        ImageDownloadQueue.instance.release(ticket);
+        _downloadTicket = null;
+      }
+      return;
+    }
+
     try {
       final loadResult = await _load(context);
       isLoadDone = true;
       _imageData = loadResult.imageData;
       filePath = loadResult.filePath;
-      setState(() {});
+      if (mounted) setState(() {});
     } catch (e) {
       if (mounted && !isLoadDone) {
         isLoadDone = true;
+        // Release before retry so the retry can acquire its own slot.
+        _releaseDownloadTicket();
         _tryLoad(context);
+        return;
       }
     }
+
+    _releaseDownloadTicket();
+  }
+
+  void _releaseDownloadTicket() {
+    final ticket = _downloadTicket;
+    if (ticket == null) return;
+    if (ticket.isActive) {
+      ImageDownloadQueue.instance.release(ticket);
+    } else {
+      ticket.cancel();
+    }
+    _downloadTicket = null;
   }
 
   void _onTap(BuildContext context) async {
@@ -281,6 +317,7 @@ class _MxcImageState extends State<MxcImage>
 
   @override
   void dispose() {
+    _releaseDownloadTicket();
     _imageDataNoCache = null;
     super.dispose();
   }

--- a/lib/widgets/mxc_image.dart
+++ b/lib/widgets/mxc_image.dart
@@ -256,9 +256,9 @@ class _MxcImageState extends State<MxcImage>
         _tryLoad(context);
         return;
       }
+    } finally {
+      _releaseDownloadTicket();
     }
-
-    _releaseDownloadTicket();
   }
 
   void _releaseDownloadTicket() {

--- a/test/utils/image_download_queue_test.dart
+++ b/test/utils/image_download_queue_test.dart
@@ -215,49 +215,43 @@ void main() {
   });
 
   group('stress test', () {
-    test(
-      'rapid acquire/cancel cycles leave queue in clean state',
-      () async {
-        final queue = ImageDownloadQueue.forTesting(maxConcurrent: 3);
+    test('rapid acquire/cancel cycles leave queue in clean state', () async {
+      final queue = ImageDownloadQueue.forTesting(maxConcurrent: 3);
 
-        final holders = <ImageDownloadTicket>[];
-        for (var i = 0; i < queue.maxConcurrent; i++) {
-          final t = queue.acquire();
-          await t.ready;
-          holders.add(t);
-        }
+      final holders = <ImageDownloadTicket>[];
+      for (var i = 0; i < queue.maxConcurrent; i++) {
+        final t = queue.acquire();
+        await t.ready;
+        holders.add(t);
+      }
 
-        for (var i = 0; i < 50; i++) {
-          final ticket = queue.acquire();
-          ticket.cancel();
-          await ticket.ready;
-        }
+      for (var i = 0; i < 50; i++) {
+        final ticket = queue.acquire();
+        ticket.cancel();
+        await ticket.ready;
+      }
 
-        for (final t in holders) {
-          queue.release(t);
-        }
+      for (final t in holders) {
+        queue.release(t);
+      }
 
-        expect(queue.activeCount, 0);
-        expect(queue.queuedCount, 0);
-      },
-    );
+      expect(queue.activeCount, 0);
+      expect(queue.queuedCount, 0);
+    });
 
-    test(
-      'acquire-release cycle with full throughput',
-      () async {
-        final queue = ImageDownloadQueue.forTesting(maxConcurrent: 2);
+    test('acquire-release cycle with full throughput', () async {
+      final queue = ImageDownloadQueue.forTesting(maxConcurrent: 2);
 
-        for (var i = 0; i < 20; i++) {
-          final ticket = queue.acquire();
-          final granted = await ticket.ready;
-          expect(granted, isTrue);
-          queue.release(ticket);
-        }
+      for (var i = 0; i < 20; i++) {
+        final ticket = queue.acquire();
+        final granted = await ticket.ready;
+        expect(granted, isTrue);
+        queue.release(ticket);
+      }
 
-        expect(queue.activeCount, 0);
-        expect(queue.queuedCount, 0);
-      },
-    );
+      expect(queue.activeCount, 0);
+      expect(queue.queuedCount, 0);
+    });
   });
 
   group('configurable maxConcurrent', () {

--- a/test/utils/image_download_queue_test.dart
+++ b/test/utils/image_download_queue_test.dart
@@ -1,6 +1,17 @@
 import 'package:fluffychat/utils/image_download_queue.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+/// Fills all slots in [queue] and returns the granted tickets.
+Future<List<ImageDownloadTicket>> _fillSlots(ImageDownloadQueue queue) async {
+  final tickets = <ImageDownloadTicket>[];
+  for (var i = 0; i < queue.maxConcurrent; i++) {
+    final ticket = queue.acquire();
+    tickets.add(ticket);
+    await ticket.ready;
+  }
+  return tickets;
+}
+
 void main() {
   late ImageDownloadQueue queue;
 
@@ -11,13 +22,9 @@ void main() {
 
   group('basic acquire/release', () {
     test('acquire grants immediately when under maxConcurrent', () async {
-      final tickets = <ImageDownloadTicket>[];
-      for (var i = 0; i < queue.maxConcurrent; i++) {
-        final ticket = queue.acquire();
-        tickets.add(ticket);
-        final result = await ticket.ready;
-        expect(result, isTrue);
-        expect(ticket.isActive, isTrue);
+      final tickets = await _fillSlots(queue);
+      for (final t in tickets) {
+        expect(t.isActive, isTrue);
       }
 
       // Clean up
@@ -28,12 +35,7 @@ void main() {
     });
 
     test('acquire queues when at maxConcurrent', () async {
-      final tickets = <ImageDownloadTicket>[];
-      for (var i = 0; i < queue.maxConcurrent; i++) {
-        final ticket = queue.acquire();
-        tickets.add(ticket);
-        await ticket.ready;
-      }
+      final tickets = await _fillSlots(queue);
 
       final queuedTicket = queue.acquire();
       expect(queue.queuedCount, 1);
@@ -66,12 +68,7 @@ void main() {
     });
 
     test('release on queued ticket cancels it', () async {
-      final tickets = <ImageDownloadTicket>[];
-      for (var i = 0; i < queue.maxConcurrent; i++) {
-        final ticket = queue.acquire();
-        tickets.add(ticket);
-        await ticket.ready;
-      }
+      final tickets = await _fillSlots(queue);
 
       final queuedTicket = queue.acquire();
       expect(queue.queuedCount, 1);
@@ -91,12 +88,7 @@ void main() {
 
   group('cancel', () {
     test('cancel removes ticket from queue', () async {
-      final tickets = <ImageDownloadTicket>[];
-      for (var i = 0; i < queue.maxConcurrent; i++) {
-        final ticket = queue.acquire();
-        tickets.add(ticket);
-        await ticket.ready;
-      }
+      final tickets = await _fillSlots(queue);
 
       final queued1 = queue.acquire();
       final queued2 = queue.acquire();
@@ -121,12 +113,7 @@ void main() {
 
   group('FIFO ordering', () {
     test('FIFO order is respected', () async {
-      final tickets = <ImageDownloadTicket>[];
-      for (var i = 0; i < queue.maxConcurrent; i++) {
-        final ticket = queue.acquire();
-        tickets.add(ticket);
-        await ticket.ready;
-      }
+      final tickets = await _fillSlots(queue);
 
       final order = <int>[];
       final queued1 = queue.acquire();

--- a/test/utils/image_download_queue_test.dart
+++ b/test/utils/image_download_queue_test.dart
@@ -1,0 +1,305 @@
+import 'package:fluffychat/utils/image_download_queue.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late ImageDownloadQueue queue;
+
+  setUp(() {
+    // Each test gets an isolated queue instance — no shared singleton state.
+    queue = ImageDownloadQueue.forTesting(maxConcurrent: 4);
+  });
+
+  group('basic acquire/release', () {
+    test('acquire grants immediately when under maxConcurrent', () async {
+      final tickets = <ImageDownloadTicket>[];
+      for (var i = 0; i < queue.maxConcurrent; i++) {
+        final ticket = queue.acquire();
+        tickets.add(ticket);
+        final result = await ticket.ready;
+        expect(result, isTrue);
+        expect(ticket.isActive, isTrue);
+      }
+
+      // Clean up
+      for (final t in tickets) {
+        queue.release(t);
+      }
+      expect(queue.activeCount, 0);
+    });
+
+    test('acquire queues when at maxConcurrent', () async {
+      final tickets = <ImageDownloadTicket>[];
+      for (var i = 0; i < queue.maxConcurrent; i++) {
+        final ticket = queue.acquire();
+        tickets.add(ticket);
+        await ticket.ready;
+      }
+
+      final queuedTicket = queue.acquire();
+      expect(queue.queuedCount, 1);
+
+      var resolved = false;
+      queuedTicket.ready.then((_) => resolved = true);
+      await Future.delayed(Duration.zero);
+      expect(resolved, isFalse);
+
+      queue.release(tickets.first);
+      final result = await queuedTicket.ready;
+      expect(result, isTrue);
+      expect(queuedTicket.isActive, isTrue);
+
+      // Clean up
+      queue.release(queuedTicket);
+      for (var i = 1; i < tickets.length; i++) {
+        queue.release(tickets[i]);
+      }
+      expect(queue.activeCount, 0);
+    });
+
+    test('release on active ticket decrements count', () async {
+      final ticket = queue.acquire();
+      await ticket.ready;
+      expect(queue.activeCount, 1);
+
+      queue.release(ticket);
+      expect(queue.activeCount, 0);
+    });
+
+    test('release on queued ticket cancels it', () async {
+      final tickets = <ImageDownloadTicket>[];
+      for (var i = 0; i < queue.maxConcurrent; i++) {
+        final ticket = queue.acquire();
+        tickets.add(ticket);
+        await ticket.ready;
+      }
+
+      final queuedTicket = queue.acquire();
+      expect(queue.queuedCount, 1);
+
+      queue.release(queuedTicket);
+
+      final result = await queuedTicket.ready;
+      expect(result, isFalse);
+
+      // Clean up
+      for (final t in tickets) {
+        queue.release(t);
+      }
+      expect(queue.activeCount, 0);
+    });
+  });
+
+  group('cancel', () {
+    test('cancel removes ticket from queue', () async {
+      final tickets = <ImageDownloadTicket>[];
+      for (var i = 0; i < queue.maxConcurrent; i++) {
+        final ticket = queue.acquire();
+        tickets.add(ticket);
+        await ticket.ready;
+      }
+
+      final queued1 = queue.acquire();
+      final queued2 = queue.acquire();
+      expect(queue.queuedCount, 2);
+
+      queued1.cancel();
+      final result1 = await queued1.ready;
+      expect(result1, isFalse);
+
+      queue.release(tickets.first);
+      final result2 = await queued2.ready;
+      expect(result2, isTrue);
+
+      // Clean up
+      queue.release(queued2);
+      for (var i = 1; i < tickets.length; i++) {
+        queue.release(tickets[i]);
+      }
+      expect(queue.activeCount, 0);
+    });
+  });
+
+  group('FIFO ordering', () {
+    test('FIFO order is respected', () async {
+      final tickets = <ImageDownloadTicket>[];
+      for (var i = 0; i < queue.maxConcurrent; i++) {
+        final ticket = queue.acquire();
+        tickets.add(ticket);
+        await ticket.ready;
+      }
+
+      final order = <int>[];
+      final queued1 = queue.acquire();
+      final queued2 = queue.acquire();
+      final queued3 = queue.acquire();
+
+      queued1.ready.then((_) => order.add(1));
+      queued2.ready.then((_) => order.add(2));
+      queued3.ready.then((_) => order.add(3));
+
+      queue.release(tickets[0]);
+      await Future.delayed(Duration.zero);
+      queue.release(tickets[1]);
+      await Future.delayed(Duration.zero);
+      queue.release(tickets[2]);
+      await Future.delayed(Duration.zero);
+
+      expect(order, [1, 2, 3]);
+
+      // Clean up
+      queue.release(queued1);
+      queue.release(queued2);
+      queue.release(queued3);
+      for (var i = 3; i < tickets.length; i++) {
+        queue.release(tickets[i]);
+      }
+    });
+  });
+
+  group('starvation prevention', () {
+    test(
+      'reacquire without releasing previous queued ticket does not leak slots',
+      () async {
+        final queue = ImageDownloadQueue.forTesting(maxConcurrent: 2);
+
+        final t1 = queue.acquire();
+        final t2 = queue.acquire();
+        await t1.ready;
+        await t2.ready;
+
+        final orphan = queue.acquire();
+        expect(queue.queuedCount, 1);
+
+        orphan.cancel();
+        final replacement = queue.acquire();
+
+        queue.release(t1);
+        await Future.delayed(Duration.zero);
+
+        final result = await replacement.ready;
+        expect(result, isTrue);
+        expect(queue.activeCount, 2);
+
+        queue.release(t2);
+        queue.release(replacement);
+        expect(queue.activeCount, 0);
+        expect(queue.queuedCount, 0);
+      },
+    );
+
+    test(
+      'orphaned granted ticket that is never released causes starvation',
+      () async {
+        final queue = ImageDownloadQueue.forTesting(maxConcurrent: 1);
+
+        final t1 = queue.acquire();
+        await t1.ready;
+        expect(queue.activeCount, 1);
+
+        final t2 = queue.acquire();
+        expect(queue.queuedCount, 1);
+
+        var t2Resolved = false;
+        t2.ready.then((_) => t2Resolved = true);
+        await Future.delayed(Duration.zero);
+        expect(t2Resolved, isFalse);
+
+        queue.release(t1);
+        await Future.delayed(Duration.zero);
+        expect(t2Resolved, isTrue);
+
+        queue.release(t2);
+        expect(queue.activeCount, 0);
+      },
+    );
+  });
+
+  group('stress test', () {
+    test(
+      'rapid acquire/cancel cycles leave queue in clean state',
+      () async {
+        final queue = ImageDownloadQueue.forTesting(maxConcurrent: 3);
+
+        final holders = <ImageDownloadTicket>[];
+        for (var i = 0; i < queue.maxConcurrent; i++) {
+          final t = queue.acquire();
+          await t.ready;
+          holders.add(t);
+        }
+
+        for (var i = 0; i < 50; i++) {
+          final ticket = queue.acquire();
+          ticket.cancel();
+          await ticket.ready;
+        }
+
+        for (final t in holders) {
+          queue.release(t);
+        }
+
+        expect(queue.activeCount, 0);
+        expect(queue.queuedCount, 0);
+      },
+    );
+
+    test(
+      'acquire-release cycle with full throughput',
+      () async {
+        final queue = ImageDownloadQueue.forTesting(maxConcurrent: 2);
+
+        for (var i = 0; i < 20; i++) {
+          final ticket = queue.acquire();
+          final granted = await ticket.ready;
+          expect(granted, isTrue);
+          queue.release(ticket);
+        }
+
+        expect(queue.activeCount, 0);
+        expect(queue.queuedCount, 0);
+      },
+    );
+  });
+
+  group('configurable maxConcurrent', () {
+    test('respects custom maxConcurrent', () async {
+      final smallQueue = ImageDownloadQueue.forTesting(maxConcurrent: 1);
+
+      final t1 = smallQueue.acquire();
+      await t1.ready;
+      expect(smallQueue.activeCount, 1);
+
+      final t2 = smallQueue.acquire();
+      expect(smallQueue.queuedCount, 1);
+
+      var t2Resolved = false;
+      t2.ready.then((_) => t2Resolved = true);
+      await Future.delayed(Duration.zero);
+      expect(t2Resolved, isFalse);
+
+      smallQueue.release(t1);
+      await Future.delayed(Duration.zero);
+      expect(t2Resolved, isTrue);
+
+      smallQueue.release(t2);
+      expect(smallQueue.activeCount, 0);
+    });
+  });
+
+  group('singleton management', () {
+    test('resetInstance creates a fresh queue', () {
+      ImageDownloadQueue.instance.acquire();
+      expect(ImageDownloadQueue.instance.activeCount, 1);
+
+      ImageDownloadQueue.resetInstance();
+      expect(ImageDownloadQueue.instance.activeCount, 0);
+    });
+
+    test('instance setter allows injection', () {
+      final custom = ImageDownloadQueue.forTesting(maxConcurrent: 1);
+      ImageDownloadQueue.instance = custom;
+      expect(ImageDownloadQueue.instance.maxConcurrent, 1);
+
+      ImageDownloadQueue.resetInstance();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Prevent iOS out-of-memory kills caused by unbounded concurrent image downloads when scrolling fast through rooms with many images. Two complementary mechanisms:

1. **Download queue** — limits concurrent image downloads/decodes to 4 via a semaphore in \`MxcImage._tryLoad()\`
2. **Decode resize** — adds \`cacheWidth\`/\`cacheHeight\` to \`ImageBubble\` so images are decoded at display resolution instead of native (~130x memory reduction per image)

### Changes

- **Add \`ImageDownloadQueue\`** (semaphore pattern, max 4 concurrent): Each \`MxcImage\` acquires a slot before loading and releases it when done or disposed. O(1) cancel for fast-scrolling scenarios where widgets appear and disappear in rapid succession.
- **Integrate queue into \`MxcImage._tryLoad()\`**: The actual image consumer — not preview URLs — is now throttled. Pending tickets are cancelled on dispose to prevent slot starvation.
- **Add \`cacheWidth\`/\`cacheHeight\` to \`ImageBubble\`**: Chat images are decoded at display resolution (e.g., 768px on 3x iPhone) instead of native (e.g., 4000px), reducing per-image memory from ~48 MB to ~360 KB.
- **13 unit tests** for \`ImageDownloadQueue\`: FIFO ordering, cancel, starvation prevention, stress test, configurable maxConcurrent, singleton management.

### How it works

```
MxcImage._tryLoad()
  ├─ imageData already in memory? → skip queue, render immediately
  ├─ _releaseDownloadTicket()     → cancel/release any previous ticket
  ├─ acquire() slot from queue    → wait if 4 downloads already running
  ├─ await ticket.ready           → proceeds when slot available
  ├─ !mounted guard               → release slot if widget disposed while waiting
  ├─ _load() → HTTP download + decrypt
  ├─ setState()                   → render image
  └─ _releaseDownloadTicket()     → free slot for next image
  
dispose()
  └─ _releaseDownloadTicket()     → no orphaned slots
```

### Known limitations / follow-up

- \`AvifImage\` does not receive \`cacheWidth\`/\`cacheHeight\` (AVIF is rare in Matrix, \`flutter_avif\` may not support it)
- No retry limit in \`_tryLoad\` — if server returns 500s, retries are unbounded (mitigated by slot release before retry)

---

## Performance results

Measured on a physical iPhone (release build) using a Patrol integration test (`image_scroll_perf_test`) that navigates to two image-heavy rooms ("Bug Me Harder" and "tech-radar"), scrolls for 30 seconds in each, and records `imageCache` size + process RSS at each step.

**Protocol:**
- Script: `scripts/integration_test_patrol.sh` (`patrol test --release --no-generate-bundle --show-flutter-logs`)
- Test: `integration_test/tests/chat/image_scroll_perf_test.dart`
- 3 runs per branch, **median** value retained
- Branches compared: `main` vs `perf/image-download-throttle`
- Integration test infrastructure enabled by #2980

### imageCache bytes (decoded image memory)

| Checkpoint | `main` | `perf/image-download-throttle` | Delta |
|---|---|---|---|
| initial lobby | 2.6 MB | 2.6 MB | — |
| room 1 entered | 15.2 MB | 9.8 MB | **-35%** |
| room 1 after 30s scroll | 24.8 MB | 18.3 MB | **-26%** |
| room 1 left | 4.3 MB | 2.4 MB | **-45%** |
| room 2 entered | 25.7 MB | 15.8 MB | **-39%** |
| room 2 after 30s scroll | 57.1 MB | 42.9 MB | **-25%** |
| room 2 left | 4.7 MB | 2.4 MB | **-50%** |
| final lobby | 4.7 MB | 2.4 MB | **-50%** |

### Process RSS (total memory)

| Checkpoint | `main` | `perf/image-download-throttle` | Delta |
|---|---|---|---|
| room 1 after 30s scroll | 262 MB | 246 MB | **-6%** |
| room 2 after 30s scroll | 292 MB | 278 MB | **-5%** |
| final lobby | 296 MB | 280 MB | **-5%** |

**The throttle reduces decoded image cache by 25–50% during scrolling and at rest, with a consistent ~5% reduction in total process memory.**

---

## Ticket

No ticket — discovered during performance profiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Image downloads now execute in a controlled queue (max 4 concurrent operations), preventing system overload and improving app responsiveness.
  * Enhanced image caching with context-aware memory management for more efficient resource usage.

* **Tests**
  * Added comprehensive test coverage for image download queue functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->