### PR TITLE
TW-2952 Scroll glitch

### DIFF
--- a/lib/pages/chat/events/message/message_content_builder_mixin.dart
+++ b/lib/pages/chat/events/message/message_content_builder_mixin.dart
@@ -275,6 +275,9 @@ mixin MessageContentBuilderMixin {
         event.messageType == MessageTypes.Text) {
       return true;
     }
+    if (event.body.getFirstValidUrl() != null) {
+      return true;
+    }
     if (totalMessageWidth == maxWidth) {
       return true;
     } else {

--- a/lib/presentation/mixins/linkify_mixin.dart
+++ b/lib/presentation/mixins/linkify_mixin.dart
@@ -1,6 +1,5 @@
 import 'package:fluffychat/pages/chat/phone_number_context_menu_actions.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
-import 'package:fluffychat/utils/extension/value_notifier_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
@@ -16,8 +15,6 @@ import 'package:pull_down_button/pull_down_button.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 mixin LinkifyMixin {
-  final ValueNotifier<bool> openingPopupMenu = ValueNotifier(false);
-
   List<PhoneNumberContextMenuActions> get phoneNumberContextMenuOnWeb => [
     PhoneNumberContextMenuActions.copy,
   ];
@@ -34,10 +31,6 @@ mixin LinkifyMixin {
     }).toList();
   }
 
-  void _handleStateContextMenu() {
-    openingPopupMenu.toggle();
-  }
-
   void _handleContextMenuAction({
     required BuildContext context,
     required TapDownDetails tapDownDetails,
@@ -52,7 +45,6 @@ mixin LinkifyMixin {
       context: context,
       offset: offset,
       listActions: listActions,
-      onClose: _handleStateContextMenu,
     );
     if (selectedActionIndex != null && selectedActionIndex is int) {
       _handleClickOnContextMenuItem(
@@ -189,9 +181,5 @@ mixin LinkifyMixin {
         Logs().i('LinkifyMixin: handleOnTappedLink: Unhandled link: $link');
         break;
     }
-  }
-
-  void linkifyDispose() {
-    openingPopupMenu.dispose();
   }
 }

--- a/lib/widgets/mixins/get_preview_url_mixin.dart
+++ b/lib/widgets/mixins/get_preview_url_mixin.dart
@@ -1,4 +1,6 @@
-import 'package:dartz/dartz.dart';
+import 'dart:async';
+
+import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
@@ -7,7 +9,7 @@ import 'package:fluffychat/domain/usecase/preview_url/get_preview_url_interactor
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
 
-mixin GetPreviewUrlMixin {
+mixin GetPreviewUrlMixin<T extends StatefulWidget> on State<T> {
   static const int _defaultPreferredPreviewTimeInMilliseconds = 2000;
 
   final GetPreviewURLInteractor _getPreviewURLInteractor = getIt
@@ -16,6 +18,14 @@ mixin GetPreviewUrlMixin {
   final getPreviewUrlStateNotifier = ValueNotifier<Either<Failure, Success>>(
     Right(GetPreviewUrlInitial()),
   );
+  StreamSubscription<Either<Failure, Success>>? _getPreviewUrlSubscription;
+
+  @override
+  void dispose() {
+    getPreviewUrlStateNotifier.dispose();
+    _getPreviewUrlSubscription?.cancel();
+    super.dispose();
+  }
 
   abstract String debugLabel;
 
@@ -23,7 +33,8 @@ mixin GetPreviewUrlMixin {
     required Uri uri,
     int preferredPreviewTime = _defaultPreferredPreviewTimeInMilliseconds,
   }) {
-    _getPreviewURLInteractor
+    _getPreviewUrlSubscription?.cancel();
+    _getPreviewUrlSubscription = _getPreviewURLInteractor
         .execute(uri: uri, preferredPreviewTime: preferredPreviewTime)
         .listen(
           _handleGetPreviewUrlOnData,

--- a/lib/widgets/mixins/get_preview_url_mixin.dart
+++ b/lib/widgets/mixins/get_preview_url_mixin.dart
@@ -57,4 +57,9 @@ mixin GetPreviewUrlMixin<T extends StatefulWidget> on State<T> {
       '$debugLabel::_handleGetPreviewUrlOnError() - error: $error | stackTrace: $stackTrace',
     );
   }
+
+  void clearPreviewUrlState() {
+    _getPreviewUrlSubscription?.cancel();
+    getPreviewUrlStateNotifier.value = Right(GetPreviewUrlInitial());
+  }
 }

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
@@ -1,19 +1,13 @@
-import 'package:fluffychat/domain/app_state/preview_url/get_preview_url_success.dart';
 import 'package:fluffychat/pages/chat/events/formatted_text_widget.dart';
-import 'package:fluffychat/presentation/extensions/media/url_preview_extension.dart';
 import 'package:fluffychat/presentation/mixins/linkify_mixin.dart';
 import 'package:fluffychat/utils/string_extension.dart';
-import 'package:fluffychat/widgets/mixins/get_preview_url_mixin.dart';
 import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart';
-import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview_item_style.dart';
 import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_view.dart';
 import 'package:flutter/material.dart';
-import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:linkfy_text/linkfy_text.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
-import 'package:skeletonizer/skeletonizer.dart';
 
-class TwakeLinkPreview extends StatefulWidget {
+class TwakeLinkPreview extends StatelessWidget with LinkifyMixin {
   final Event event;
   final String localizedBody;
   final bool ownMessage;
@@ -33,47 +27,27 @@ class TwakeLinkPreview extends StatefulWidget {
     this.isCaption = false,
   });
 
-  @override
-  State<TwakeLinkPreview> createState() => TwakeLinkPreviewController();
-}
-
-class TwakeLinkPreviewController extends State<TwakeLinkPreview>
-    with GetPreviewUrlMixin, LinkifyMixin {
-  String? get firstValidUrl => widget.localizedBody.getFirstValidUrl();
-
-  Uri get uri => Uri.parse(firstValidUrl ?? '');
-
   static const twakeLinkViewKey = ValueKey('TwakeLinkPreviewKey');
 
   static const twakeLinkPreviewItemKey = ValueKey('TwakeLinkPreviewItemKey');
 
   @override
-  String debugLabel = 'TwakeLinkPreviewController';
-
-  @override
-  void initState() {
-    if (firstValidUrl != null) {
-      getPreviewUrl(uri: uri);
-    }
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final firstValidUrl = localizedBody.getFirstValidUrl();
     return TwakeLinkView(
       key: twakeLinkViewKey,
       firstValidUrl: firstValidUrl,
-      isCaption: widget.isCaption,
-      body: widget.event.formattedText.isNotEmpty
+      isCaption: isCaption,
+      body: event.formattedText.isNotEmpty
           ? FormattedTextWidget(
-              event: widget.event,
-              linkStyle: widget.linkStyle,
-              fontSize: widget.fontSize,
+              event: event,
+              linkStyle: linkStyle,
+              fontSize: fontSize,
             )
           : MatrixLinkifyText(
-              text: widget.localizedBody,
-              textStyle: widget.richTextStyle,
-              linkStyle: widget.linkStyle,
+              text: localizedBody,
+              textStyle: richTextStyle,
+              linkStyle: linkStyle,
               linkTypes: const [LinkType.url, LinkType.phone, LinkType.date],
               textAlign: TextAlign.start,
               onTapDownLink: (tapDownDetails, link) => handleOnTappedLinkHtml(
@@ -82,94 +56,10 @@ class TwakeLinkPreviewController extends State<TwakeLinkPreview>
                 link: link,
               ),
             ),
-      previewItemWidget: ValueListenableBuilder(
-        valueListenable: getPreviewUrlStateNotifier,
-        builder: (context, state, child) {
-          return state.fold((failure) => const SizedBox.shrink(), (success) {
-            if (success is GetPreviewUrlSuccess) {
-              final previewLink = success.urlPreview.toPresentation();
-              return TwakeLinkPreviewItem(
-                key: twakeLinkPreviewItemKey,
-                ownMessage: widget.ownMessage,
-                urlPreviewPresentation: previewLink,
-                previewLink: firstValidUrl,
-              );
-            }
-            return child!;
-          });
-        },
-        child: Skeletonizer.zone(
-          child: Container(
-            constraints: const BoxConstraints(minWidth: double.infinity),
-            height: TwakeLinkPreviewItemStyle.maxHeightPreviewItem,
-            decoration: ShapeDecoration(
-              color: widget.ownMessage
-                  ? LinagoraRefColors.material().primary[95]
-                  : LinagoraStateLayer(
-                      LinagoraSysColors.material().surfaceTint,
-                    ).opacityLayer1,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(
-                  TwakeLinkPreviewItemStyle.radiusBorder,
-                ),
-              ),
-            ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Bone.button(
-                  width: TwakeLinkPreviewItemStyle.heightMxcImagePreview,
-                  height: TwakeLinkPreviewItemStyle.heightMxcImagePreview,
-                  borderRadius: BorderRadius.vertical(
-                    top: Radius.circular(
-                      TwakeLinkPreviewItemStyle.radiusBorder,
-                    ),
-                    bottom: Radius.circular(
-                      TwakeLinkPreviewItemStyle.radiusBorder,
-                    ),
-                  ),
-                ),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Padding(
-                        key: LinkPreviewBuilder.paddingTitleKey,
-                        padding: TwakeLinkPreviewItemStyle.paddingTitle,
-                        child: Column(
-                          children: [
-                            Bone.text(
-                              style: Theme.of(context).textTheme.titleMedium,
-                            ),
-                            TwakeLinkPreviewItemStyle.skeletonizerTextPadding,
-                            Bone.text(
-                              style: Theme.of(context).textTheme.titleMedium,
-                            ),
-                          ],
-                        ),
-                      ),
-                      Padding(
-                        key: LinkPreviewBuilder.paddingSubtitleKey,
-                        padding: TwakeLinkPreviewItemStyle.paddingSubtitle,
-                        child: Column(
-                          children: [
-                            Bone.text(
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            ),
-                            TwakeLinkPreviewItemStyle.skeletonizerTextPadding,
-                            Bone.text(
-                              style: Theme.of(context).textTheme.bodyMedium,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
+      previewItemWidget: TwakeLinkPreviewItem(
+        key: twakeLinkPreviewItemKey,
+        ownMessage: ownMessage,
+        previewLink: firstValidUrl,
       ),
     );
   }

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
@@ -1,20 +1,21 @@
+import 'package:fluffychat/domain/app_state/preview_url/get_preview_url_success.dart';
+import 'package:fluffychat/presentation/extensions/media/url_preview_extension.dart';
 import 'package:fluffychat/presentation/model/media/url_preview_presentation.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
+import 'package:fluffychat/widgets/mixins/get_preview_url_mixin.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview_item_style.dart';
 import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
-class TwakeLinkPreviewItem extends StatelessWidget {
+class TwakeLinkPreviewItem extends StatefulWidget {
   final bool ownMessage;
-  final UrlPreviewPresentation urlPreviewPresentation;
   final String? previewLink;
 
   const TwakeLinkPreviewItem({
     super.key,
     required this.ownMessage,
-    required this.urlPreviewPresentation,
     this.previewLink,
   });
 
@@ -23,34 +24,151 @@ class TwakeLinkPreviewItem extends StatelessWidget {
   static const linkPreviewLargeKey = ValueKey('LinkPreviewLargeKey');
 
   @override
+  State<TwakeLinkPreviewItem> createState() => _TwakeLinkPreviewItemState();
+}
+
+class _TwakeLinkPreviewItemState extends State<TwakeLinkPreviewItem>
+    with AutomaticKeepAliveClientMixin, GetPreviewUrlMixin {
+  void _getPreviewInfo() {
+    if (widget.previewLink == null || widget.previewLink!.trim().isEmpty) {
+      return;
+    }
+    final uri = Uri.tryParse(widget.previewLink!);
+    if (uri == null) return;
+    getPreviewUrl(uri: uri);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _getPreviewInfo();
+  }
+
+  @override
+  void didUpdateWidget(covariant TwakeLinkPreviewItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.previewLink != widget.previewLink) {
+      _getPreviewInfo();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Container(
-      key: linkPreviewBodyKey,
-      constraints: const BoxConstraints(minWidth: double.infinity),
-      height: TwakeLinkPreviewItemStyle.maxHeightPreviewItem,
-      decoration: ShapeDecoration(
-        color: ownMessage
-            ? LinagoraSysColors.material().primaryContainer
-            : LinagoraSysColors.material().onSurface.withOpacity(0.08),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(
-            TwakeLinkPreviewItemStyle.radiusBorder,
+    super.build(context);
+    return ValueListenableBuilder(
+      valueListenable: getPreviewUrlStateNotifier,
+      builder: (context, state, child) {
+        return state.fold((failure) => const SizedBox.shrink(), (success) {
+          if (success is GetPreviewUrlSuccess) {
+            final previewPresentation = success.urlPreview.toPresentation();
+            return Container(
+              key: TwakeLinkPreviewItem.linkPreviewBodyKey,
+              constraints: const BoxConstraints(minWidth: double.infinity),
+              height: TwakeLinkPreviewItemStyle.maxHeightPreviewItem,
+              decoration: ShapeDecoration(
+                color: widget.ownMessage
+                    ? LinagoraSysColors.material().primaryContainer
+                    : LinagoraSysColors.material().onSurface.withOpacity(0.08),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(
+                    TwakeLinkPreviewItemStyle.radiusBorder,
+                  ),
+                ),
+              ),
+              child: InkWell(
+                onTap: () {
+                  if (widget.previewLink == null) return;
+                  UrlLauncher(context, url: widget.previewLink).launchUrl();
+                },
+                child: LinkPreviewBuilder(
+                  key: TwakeLinkPreviewItem.linkPreviewLargeKey,
+                  urlPreviewPresentation: previewPresentation,
+                  previewLink: widget.previewLink,
+                ),
+              ),
+            );
+          }
+          return child!;
+        });
+      },
+      child: Skeletonizer.zone(
+        child: Container(
+          constraints: const BoxConstraints(minWidth: double.infinity),
+          height: TwakeLinkPreviewItemStyle.maxHeightPreviewItem,
+          decoration: ShapeDecoration(
+            color: widget.ownMessage
+                ? LinagoraRefColors.material().primary[95]
+                : LinagoraStateLayer(
+                    LinagoraSysColors.material().surfaceTint,
+                  ).opacityLayer1,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(
+                TwakeLinkPreviewItemStyle.radiusBorder,
+              ),
+            ),
           ),
-        ),
-      ),
-      child: InkWell(
-        onTap: () {
-          if (previewLink == null) return;
-          UrlLauncher(context, url: previewLink).launchUrl();
-        },
-        child: LinkPreviewBuilder(
-          key: linkPreviewLargeKey,
-          urlPreviewPresentation: urlPreviewPresentation,
-          previewLink: previewLink,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Bone.button(
+                width: TwakeLinkPreviewItemStyle.heightMxcImagePreview,
+                height: TwakeLinkPreviewItemStyle.heightMxcImagePreview,
+                borderRadius: BorderRadius.vertical(
+                  top: Radius.circular(TwakeLinkPreviewItemStyle.radiusBorder),
+                  bottom: Radius.circular(
+                    TwakeLinkPreviewItemStyle.radiusBorder,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      key: LinkPreviewBuilder.paddingTitleKey,
+                      padding: TwakeLinkPreviewItemStyle.paddingTitle,
+                      child: Column(
+                        children: [
+                          Bone.text(
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          TwakeLinkPreviewItemStyle.skeletonizerTextPadding,
+                          Bone.text(
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                        ],
+                      ),
+                    ),
+                    Padding(
+                      key: LinkPreviewBuilder.paddingSubtitleKey,
+                      padding: TwakeLinkPreviewItemStyle.paddingSubtitle,
+                      child: Column(
+                        children: [
+                          Bone.text(
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          TwakeLinkPreviewItemStyle.skeletonizerTextPadding,
+                          Bone.text(
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  String debugLabel = 'TwakeLinkPreviewItem';
 }
 
 class LinkPreviewBuilder extends StatelessWidget {

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
@@ -75,16 +75,10 @@ class _TwakeLinkPreviewItemState extends State<TwakeLinkPreviewItem>
                   ),
                 ),
               ),
-              child: InkWell(
-                onTap: () {
-                  if (widget.previewLink == null) return;
-                  UrlLauncher(context, url: widget.previewLink).launchUrl();
-                },
-                child: LinkPreviewBuilder(
-                  key: TwakeLinkPreviewItem.linkPreviewLargeKey,
-                  urlPreviewPresentation: previewPresentation,
-                  previewLink: widget.previewLink,
-                ),
+              child: LinkPreviewBuilder(
+                key: TwakeLinkPreviewItem.linkPreviewLargeKey,
+                urlPreviewPresentation: previewPresentation,
+                previewLink: widget.previewLink,
               ),
             );
           }

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
@@ -31,10 +31,14 @@ class _TwakeLinkPreviewItemState extends State<TwakeLinkPreviewItem>
     with AutomaticKeepAliveClientMixin, GetPreviewUrlMixin {
   void _getPreviewInfo() {
     if (widget.previewLink == null || widget.previewLink!.trim().isEmpty) {
+      clearPreviewUrlState();
       return;
     }
     final uri = Uri.tryParse(widget.previewLink!);
-    if (uri == null) return;
+    if (uri == null) {
+      clearPreviewUrlState();
+      return;
+    }
     getPreviewUrl(uri: uri);
   }
 

--- a/test/pages/chat/events/message/message_content_builder_mixin_test.dart
+++ b/test/pages/chat/events/message/message_content_builder_mixin_test.dart
@@ -612,7 +612,8 @@ Future<void> main() async {
           "msgtype": "m.text",
           "body": "Check this out: https://example.com/some/path",
           "format": "org.matrix.custom.html",
-          "formatted_body": "<p>Check this out: https://example.com/some/path</p>",
+          "formatted_body":
+              "<p>Check this out: https://example.com/some/path</p>",
         },
         type: 'm.room.message',
         eventId: r'$143273582443PhrSn:example.org',

--- a/test/pages/chat/events/message/message_content_builder_mixin_test.dart
+++ b/test/pages/chat/events/message/message_content_builder_mixin_test.dart
@@ -601,6 +601,71 @@ Future<void> main() async {
       });
     });
 
+    group('[getSizeMessageBubbleWidth] TEST\n'
+        'GIVEN message body contains a URL\n'
+        'THEN isNeedAddNewLine is true\n', () {
+      const messageMaxWidthWeb = 504.0;
+      const messageMaxWidthMobile = 412.0;
+
+      final urlEvent = Event(
+        content: {
+          "msgtype": "m.text",
+          "body": "Check this out: https://example.com/some/path",
+          "format": "org.matrix.custom.html",
+          "formatted_body": "<p>Check this out: https://example.com/some/path</p>",
+        },
+        type: 'm.room.message',
+        eventId: r'$143273582443PhrSn:example.org',
+        senderId: '@example:example.org',
+        originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
+        room: room,
+      );
+
+      testWidgets('GIVEN ownMessage is true AND platform is Web\n'
+          'THEN isNeedAddNewLine is true\n', (WidgetTester tester) async {
+        await runTest(
+          tester,
+          event: urlEvent,
+          maxWidth: messageMaxWidthWeb,
+          expectedIsNeedAddNewLine: true,
+          ownMessage: true,
+        );
+      });
+
+      testWidgets('GIVEN ownMessage is true AND platform is Mobile\n'
+          'THEN isNeedAddNewLine is true\n', (WidgetTester tester) async {
+        await runTest(
+          tester,
+          event: urlEvent,
+          maxWidth: messageMaxWidthMobile,
+          expectedIsNeedAddNewLine: true,
+          ownMessage: true,
+        );
+      });
+
+      testWidgets('GIVEN ownMessage is false AND platform is Web\n'
+          'THEN isNeedAddNewLine is true\n', (WidgetTester tester) async {
+        await runTest(
+          tester,
+          event: urlEvent,
+          maxWidth: messageMaxWidthWeb,
+          expectedIsNeedAddNewLine: true,
+          ownMessage: false,
+        );
+      });
+
+      testWidgets('GIVEN ownMessage is false AND platform is Mobile\n'
+          'THEN isNeedAddNewLine is true\n', (WidgetTester tester) async {
+        await runTest(
+          tester,
+          event: urlEvent,
+          maxWidth: messageMaxWidthMobile,
+          expectedIsNeedAddNewLine: true,
+          ownMessage: false,
+        );
+      });
+    });
+
     group('[isContainsTagName] TEST\n', () {
       test('GIVEN body of event contains tag name\n'
           'THEN return true\n', () {

--- a/test/widget/message/twake_link_preview_item_test.dart
+++ b/test/widget/message/twake_link_preview_item_test.dart
@@ -1,84 +1,52 @@
+import 'package:dartz/dartz.dart';
+import 'package:fluffychat/domain/app_state/preview_url/get_preview_url_success.dart';
+import 'package:fluffychat/domain/model/media/url_preview.dart';
+import 'package:fluffychat/domain/usecase/preview_url/get_preview_url_interactor.dart';
+import 'package:fluffychat/presentation/model/media/url_preview_presentation.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview.dart';
-import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview_item_style.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
-import 'package:fluffychat/presentation/model/media/url_preview_presentation.dart';
 import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart';
+import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview_item_style.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
+import 'twake_link_preview_item_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<GetPreviewURLInteractor>()])
 void main() {
-  group('[WIDGET TEST] - TwakeLinkPreviewItem is own message\n', () {
-    const ownMessage = true;
-
+  group('[WIDGET TEST] - LinkPreviewBuilder content\n', () {
     testWidgets('GIVEN no image uri\n'
         'AND no image width and height\n'
         'AND only title and description\n'
         'THEN not display MxcImage widget', (WidgetTester tester) async {
-      // Define a UrlPreviewPresentation object
       final urlPreviewPresentation = UrlPreviewPresentation(
         title: 'Test Title',
         description: 'Test Description',
       );
 
-      final twakeLinkPreviewItem = TwakeLinkPreviewItem(
-        key: TwakeLinkPreviewController.twakeLinkPreviewItemKey,
-        ownMessage: ownMessage,
-        urlPreviewPresentation: urlPreviewPresentation,
-      );
-
-      // Build the TwakeLinkPreviewItem widget
       await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: twakeLinkPreviewItem)),
+        MaterialApp(
+          home: Scaffold(
+            body: LinkPreviewBuilder(
+              urlPreviewPresentation: urlPreviewPresentation,
+            ),
+          ),
+        ),
       );
 
-      expect(twakeLinkPreviewItem.ownMessage, true);
-
-      final twakeLinkPreviewItemFind = find.byKey(
-        TwakeLinkPreviewItem.linkPreviewBodyKey,
-      );
-
-      expect(twakeLinkPreviewItemFind, findsOneWidget);
-
-      final Container twakeLinkPreviewItemBody = tester.widget(
-        twakeLinkPreviewItemFind,
-      );
-
-      expect(twakeLinkPreviewItemBody.decoration != null, true);
-
-      final ShapeDecoration twakeLinkPreviewItemBodyDecoration =
-          twakeLinkPreviewItemBody.decoration as ShapeDecoration;
-
-      expect(
-        twakeLinkPreviewItemBodyDecoration.color,
-        LinagoraSysColors.material().primaryContainer,
-      );
-
-      expect(twakeLinkPreviewItemBodyDecoration.shape, isNotNull);
-
-      final RoundedRectangleBorder shape =
-          twakeLinkPreviewItemBodyDecoration.shape as RoundedRectangleBorder;
-
-      expect(
-        shape.borderRadius,
-        BorderRadius.circular(TwakeLinkPreviewItemStyle.radiusBorder),
-      );
-
-      final linkPreviewNoImageBody = find.byKey(
-        LinkPreviewBuilder.imageDefaultKey,
-      );
-
-      expect(linkPreviewNoImageBody, findsOneWidget);
+      expect(find.byKey(LinkPreviewBuilder.imageDefaultKey), findsOneWidget);
 
       final paddingTitleFind = find.byKey(LinkPreviewBuilder.paddingTitleKey);
-
-      final paddingSubtitleKey = find.byKey(
+      final paddingSubtitleFind = find.byKey(
         LinkPreviewBuilder.paddingSubtitleKey,
       );
 
       final Padding paddingTitleWidget = tester.widget(paddingTitleFind);
-
-      final Padding paddingSubtitleWidget = tester.widget(paddingSubtitleKey);
+      final Padding paddingSubtitleWidget = tester.widget(paddingSubtitleFind);
 
       expect(
         paddingTitleWidget.padding,
@@ -90,22 +58,17 @@ void main() {
         TwakeLinkPreviewItemStyle.paddingSubtitle,
       );
 
-      final titleTextFind = find.byKey(LinkPreviewBuilder.titleKey);
+      expect(find.byKey(LinkPreviewBuilder.titleKey), findsOneWidget);
+      expect(find.byKey(LinkPreviewBuilder.subtitleKey), findsOneWidget);
 
-      final textSubtitleKeyTextFind = find.byKey(
-        LinkPreviewBuilder.subtitleKey,
+      final Text titleTextWidget = tester.widget(
+        find.byKey(LinkPreviewBuilder.titleKey),
+      );
+      final Text subtitleTextWidget = tester.widget(
+        find.byKey(LinkPreviewBuilder.subtitleKey),
       );
 
-      expect(titleTextFind, findsOneWidget);
-
-      expect(textSubtitleKeyTextFind, findsOneWidget);
-
-      final Text titleTextWidget = tester.widget(titleTextFind);
-
-      final Text subtitleTextWidget = tester.widget(textSubtitleKeyTextFind);
-
       expect(titleTextWidget.data, urlPreviewPresentation.title);
-
       expect(subtitleTextWidget.data, urlPreviewPresentation.description);
 
       expect(find.byType(MxcImage), findsNothing);
@@ -115,41 +78,31 @@ void main() {
         'AND no image width and height\n'
         'AND only title and description\n'
         'THEN not display MxcImage widget', (WidgetTester tester) async {
-      // Define a UrlPreviewPresentation object
       final urlPreviewPresentation = UrlPreviewPresentation(
         imageUri: Uri.parse('https://test.com'),
         title: 'Test Title',
         description: 'Test Description',
       );
 
-      final twakeLinkPreviewItem = TwakeLinkPreviewItem(
-        key: TwakeLinkPreviewController.twakeLinkPreviewItemKey,
-        ownMessage: ownMessage,
-        urlPreviewPresentation: urlPreviewPresentation,
-      );
-
-      // Build the TwakeLinkPreviewItem widget
       await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: twakeLinkPreviewItem)),
+        MaterialApp(
+          home: Scaffold(
+            body: LinkPreviewBuilder(
+              urlPreviewPresentation: urlPreviewPresentation,
+            ),
+          ),
+        ),
       );
 
-      expect(twakeLinkPreviewItem.ownMessage, true);
-
-      final linkPreviewNoImageBody = find.byKey(
-        LinkPreviewBuilder.imageDefaultKey,
-      );
-
-      expect(linkPreviewNoImageBody, findsOneWidget);
+      expect(find.byKey(LinkPreviewBuilder.imageDefaultKey), findsOneWidget);
 
       final paddingTitleFind = find.byKey(LinkPreviewBuilder.paddingTitleKey);
-
-      final paddingSubtitleKey = find.byKey(
+      final paddingSubtitleFind = find.byKey(
         LinkPreviewBuilder.paddingSubtitleKey,
       );
 
       final Padding paddingTitleWidget = tester.widget(paddingTitleFind);
-
-      final Padding paddingSubtitleWidget = tester.widget(paddingSubtitleKey);
+      final Padding paddingSubtitleWidget = tester.widget(paddingSubtitleFind);
 
       expect(
         paddingTitleWidget.padding,
@@ -161,22 +114,14 @@ void main() {
         TwakeLinkPreviewItemStyle.paddingSubtitle,
       );
 
-      final titleTextFind = find.byKey(LinkPreviewBuilder.titleKey);
-
-      final textSubtitleKeyTextFind = find.byKey(
-        LinkPreviewBuilder.subtitleKey,
+      final Text titleTextWidget = tester.widget(
+        find.byKey(LinkPreviewBuilder.titleKey),
+      );
+      final Text subtitleTextWidget = tester.widget(
+        find.byKey(LinkPreviewBuilder.subtitleKey),
       );
 
-      expect(titleTextFind, findsOneWidget);
-
-      expect(textSubtitleKeyTextFind, findsOneWidget);
-
-      final Text titleTextWidget = tester.widget(titleTextFind);
-
-      final Text subtitleTextWidget = tester.widget(textSubtitleKeyTextFind);
-
       expect(titleTextWidget.data, urlPreviewPresentation.title);
-
       expect(subtitleTextWidget.data, urlPreviewPresentation.description);
 
       expect(find.byType(MxcImage), findsNothing);
@@ -186,7 +131,6 @@ void main() {
         'AND an image width is null\n'
         'AND only title and description\n'
         'THEN not display MxcImage widget', (WidgetTester tester) async {
-      // Define a UrlPreviewPresentation object
       final urlPreviewPresentation = UrlPreviewPresentation(
         title: 'Test Title',
         description: 'Test Description',
@@ -194,23 +138,17 @@ void main() {
         imageHeight: 123,
       );
 
-      final twakeLinkPreviewItem = TwakeLinkPreviewItem(
-        key: TwakeLinkPreviewController.twakeLinkPreviewItemKey,
-        ownMessage: ownMessage,
-        urlPreviewPresentation: urlPreviewPresentation,
-      );
-
-      // Build the TwakeLinkPreviewItem widget
       await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: twakeLinkPreviewItem)),
+        MaterialApp(
+          home: Scaffold(
+            body: LinkPreviewBuilder(
+              urlPreviewPresentation: urlPreviewPresentation,
+            ),
+          ),
+        ),
       );
 
-      final linkPreviewNoImageBody = find.byKey(
-        LinkPreviewBuilder.imageDefaultKey,
-      );
-
-      expect(linkPreviewNoImageBody, findsOneWidget);
-
+      expect(find.byKey(LinkPreviewBuilder.imageDefaultKey), findsOneWidget);
       expect(find.byType(MxcImage), findsNothing);
     });
 
@@ -218,7 +156,6 @@ void main() {
         'AND an image height is null\n'
         'AND only title and description\n'
         'THEN not display MxcImage widget', (WidgetTester tester) async {
-      // Define a UrlPreviewPresentation object
       final urlPreviewPresentation = UrlPreviewPresentation(
         title: 'Test Title',
         description: 'Test Description',
@@ -226,34 +163,24 @@ void main() {
         imageWidth: 123,
       );
 
-      final twakeLinkPreviewItem = TwakeLinkPreviewItem(
-        key: TwakeLinkPreviewController.twakeLinkPreviewItemKey,
-        ownMessage: ownMessage,
-        urlPreviewPresentation: urlPreviewPresentation,
-      );
-
-      // Build the TwakeLinkPreviewItem widget
       await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: twakeLinkPreviewItem)),
+        MaterialApp(
+          home: Scaffold(
+            body: LinkPreviewBuilder(
+              urlPreviewPresentation: urlPreviewPresentation,
+            ),
+          ),
+        ),
       );
 
-      expect(twakeLinkPreviewItem.ownMessage, true);
-
-      final linkPreviewNoImageBody = find.byKey(
-        LinkPreviewBuilder.imageDefaultKey,
-      );
-
-      expect(linkPreviewNoImageBody, findsOneWidget);
-
+      expect(find.byKey(LinkPreviewBuilder.imageDefaultKey), findsOneWidget);
       expect(find.byType(MxcImage), findsNothing);
     });
 
     testWidgets('GIVEN an image response\n'
-        'AND an image height > 200 \n'
-        'AND an image width is not empty\n'
+        'AND an image height and width are not null\n'
         'AND only title and description\n'
-        'THEN display MxcImage widget large', (WidgetTester tester) async {
-      // Define a UrlPreviewPresentation object
+        'THEN display MxcImage widget', (WidgetTester tester) async {
       final urlPreviewPresentation = UrlPreviewPresentation(
         title: 'Test Title',
         description: 'Test Description',
@@ -262,24 +189,15 @@ void main() {
         imageHeight: 201,
       );
 
-      final twakeLinkPreviewItem = TwakeLinkPreviewItem(
-        key: TwakeLinkPreviewController.twakeLinkPreviewItemKey,
-        ownMessage: ownMessage,
-        urlPreviewPresentation: urlPreviewPresentation,
-      );
-
-      // Build the TwakeLinkPreviewItem widget
       await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: twakeLinkPreviewItem)),
+        MaterialApp(
+          home: Scaffold(
+            body: LinkPreviewBuilder(
+              urlPreviewPresentation: urlPreviewPresentation,
+            ),
+          ),
+        ),
       );
-
-      expect(twakeLinkPreviewItem.ownMessage, true);
-
-      final linkPreviewLargeBody = find.byKey(
-        TwakeLinkPreviewItem.linkPreviewLargeKey,
-      );
-
-      expect(linkPreviewLargeBody, findsOneWidget);
 
       final clipRRectMxcImage = find.byKey(LinkPreviewBuilder.clipRRectKey);
 
@@ -304,81 +222,107 @@ void main() {
       final MxcImage mxcImage = tester.widget(mxcImageFinder);
 
       expect(mxcImage.uri, urlPreviewPresentation.imageUri);
-
       expect(mxcImage.fit, BoxFit.cover);
-
-      expect(mxcImage.isThumbnail, false);
-    });
-
-    testWidgets('GIVEN an image response\n'
-        'AND an image height < 200 \n'
-        'AND an image width is not empty\n'
-        'AND only title and description\n'
-        'THEN display MxcImage widget small', (WidgetTester tester) async {
-      // Define a UrlPreviewPresentation object
-      final urlPreviewPresentation = UrlPreviewPresentation(
-        title: 'Test Title',
-        description: 'Test Description',
-        imageUri: Uri.parse('https://test.com'),
-        imageWidth: 123,
-        imageHeight: 199,
-      );
-
-      final twakeLinkPreviewItem = TwakeLinkPreviewItem(
-        key: TwakeLinkPreviewController.twakeLinkPreviewItemKey,
-        ownMessage: ownMessage,
-        urlPreviewPresentation: urlPreviewPresentation,
-      );
-
-      // Build the TwakeLinkPreviewItem widget
-      await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: twakeLinkPreviewItem)),
-      );
-
-      expect(twakeLinkPreviewItem.ownMessage, true);
-
-      final mxcImageFinder = find.byKey(LinkPreviewBuilder.mxcImageKey);
-
-      expect(mxcImageFinder, findsOneWidget);
-
-      final MxcImage mxcImage = tester.widget(mxcImageFinder);
-
-      expect(mxcImage.uri, urlPreviewPresentation.imageUri);
-
-      expect(mxcImage.fit, BoxFit.cover);
-
       expect(mxcImage.isThumbnail, false);
     });
   });
 
-  group('[WIDGET TEST] - TwakeLinkPreviewItem is not own message\n', () {
-    const ownMessage = false;
-    testWidgets('GIVEN no image uri\n'
-        'AND no image width and height\n'
-        'AND only title and description\n'
-        'THEN not display MxcImage widget', (WidgetTester tester) async {
-      // Define a UrlPreviewPresentation object
-      final urlPreviewPresentation = UrlPreviewPresentation(
-        title: 'Test Title',
-        description: 'Test Description',
-      );
+  group('[WIDGET TEST] - TwakeLinkPreviewItem ownMessage color\n', () {
+    late MockGetPreviewURLInteractor mockInteractor;
 
-      final twakeLinkPreviewItem = TwakeLinkPreviewItem(
-        key: TwakeLinkPreviewController.twakeLinkPreviewItemKey,
-        ownMessage: ownMessage,
-        urlPreviewPresentation: urlPreviewPresentation,
+    setUp(() {
+      mockInteractor = MockGetPreviewURLInteractor();
+      when(
+        mockInteractor.execute(
+          uri: anyNamed('uri'),
+          preferredPreviewTime: anyNamed('preferredPreviewTime'),
+        ),
+      ).thenAnswer(
+        (_) => Stream.value(
+          Right(
+            GetPreviewUrlSuccess(
+              urlPreview: UrlPreview(
+                title: 'Test Title',
+                description: 'Test Description',
+              ),
+            ),
+          ),
+        ),
       );
+      GetIt.instance.registerSingleton<GetPreviewURLInteractor>(mockInteractor);
+    });
 
-      // Build the TwakeLinkPreviewItem widget
+    tearDown(() {
+      GetIt.instance.unregister<GetPreviewURLInteractor>();
+    });
+
+    testWidgets('GIVEN ownMessage is true\n'
+        'THEN container uses primaryContainer color', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: twakeLinkPreviewItem)),
+        const MaterialApp(
+          home: Scaffold(
+            body: TwakeLinkPreviewItem(
+              key: TwakeLinkPreview.twakeLinkPreviewItemKey,
+              ownMessage: true,
+              previewLink: 'https://test.com',
+            ),
+          ),
+        ),
       );
 
-      expect(twakeLinkPreviewItem.ownMessage, false);
+      await tester.pump();
 
-      expect(find.byKey(LinkPreviewBuilder.imageDefaultKey), findsOneWidget);
+      final bodyFinder = find.byKey(TwakeLinkPreviewItem.linkPreviewBodyKey);
 
-      expect(find.byType(MxcImage), findsNothing);
+      expect(bodyFinder, findsOneWidget);
+
+      final Container body = tester.widget(bodyFinder);
+      final ShapeDecoration decoration = body.decoration! as ShapeDecoration;
+
+      expect(decoration.color, LinagoraSysColors.material().primaryContainer);
+
+      expect(decoration.shape, isNotNull);
+
+      final RoundedRectangleBorder shape =
+          decoration.shape as RoundedRectangleBorder;
+
+      expect(
+        shape.borderRadius,
+        BorderRadius.circular(TwakeLinkPreviewItemStyle.radiusBorder),
+      );
+    });
+
+    testWidgets('GIVEN ownMessage is false\n'
+        'THEN container uses onSurface color with opacity', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: TwakeLinkPreviewItem(
+              key: TwakeLinkPreview.twakeLinkPreviewItemKey,
+              ownMessage: false,
+              previewLink: 'https://test.com',
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      final bodyFinder = find.byKey(TwakeLinkPreviewItem.linkPreviewBodyKey);
+
+      expect(bodyFinder, findsOneWidget);
+
+      final Container body = tester.widget(bodyFinder);
+      final ShapeDecoration decoration = body.decoration! as ShapeDecoration;
+
+      expect(
+        decoration.color,
+        LinagoraSysColors.material().onSurface.withOpacity(0.08),
+      );
     });
   });
 }


### PR DESCRIPTION
## Ticket
- #2952 

## Reproduce

https://github.com/user-attachments/assets/1cb4eacb-32cd-4a5c-8bf7-11f5ac4d7eb7

## Resolved

https://github.com/user-attachments/assets/9df87079-5c55-46f9-9336-16cf681568f6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Messages containing URLs now consistently force a proper line break for improved readability.

* **Refactor**
  * Link preview flow simplified: previews render with a more direct lifecycle and updated loading/placeholder behavior.
  * Context-menu state handling simplified so closing the menu no longer toggles extra popup state.

* **Tests**
  * Added and updated unit/widget tests for message line breaks and link preview behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->