### PR TITLE
HOTFIX Resolve unclickable link issue

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1153,7 +1153,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: bac4b1489978364b5eea907787cf2d3ae40f2ac3
+      resolved-ref: c136e053a9d8c78ee81a169f4c40dba2ce76802c
       url: "https://github.com/linagora/flutter_matrix_html.git"
     source: git
     version: "1.2.0"


### PR DESCRIPTION
## Ticket
Some link cannot be clicked

## Root cause
`a` tag in `TextParser` of `flutter_matrix_html` only handles `onTapLink` callback, not `onTapDownLink`. And Twake Chat only declare `onTapDownLink`, not `onTapLink`.

## Solution
Add `onTapDownLink` for `a` tag to handle

## Pre-merge
- https://github.com/linagora/flutter_matrix_html/pull/24

## Resolved

https://github.com/user-attachments/assets/8f774b03-c132-488d-87b2-4534d936fa01



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to resolve anchor tag interaction issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->