### PR TITLE
TW-2898: Add selection area to enable text copying in message preview

### DIFF
--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -261,19 +261,21 @@ class _MessageContentWithTimestampBuilderState
                                             )
                                           : null,
                                     ),
-                                    child: SingleChildScrollView(
-                                      primary: true,
-                                      physics: const ClampingScrollPhysics(),
-                                      child: _messageBuilder(
-                                        key: ValueKey(
-                                          'PreviewReactionWidgetKey%${DateTime.now().millisecondsSinceEpoch}',
+                                    child: SelectionArea(
+                                      child: SingleChildScrollView(
+                                        primary: true,
+                                        physics: const ClampingScrollPhysics(),
+                                        child: _messageBuilder(
+                                          key: ValueKey(
+                                            'PreviewReactionWidgetKey%${DateTime.now().millisecondsSinceEpoch}',
+                                          ),
+                                          context: context,
+                                          timelineText: timelineText,
+                                          noBubble: noBubble,
+                                          displayTime: displayTime,
+                                          paddingBubble: .zero,
+                                          enableBorder: false,
                                         ),
-                                        context: context,
-                                        timelineText: timelineText,
-                                        noBubble: noBubble,
-                                        displayTime: displayTime,
-                                        paddingBubble: .zero,
-                                        enableBorder: false,
                                       ),
                                     ),
                                   ),


### PR DESCRIPTION
## Ticket
**Related issue**

- #2898

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/996aeec0-22ba-40a5-9def-d77ba11565ae



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled text selection capability within message previews that contain emoji reactions, improving the user experience for copying or highlighting message content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->