### PR TITLE
TW-2965: Enable autoplay of GIFs in chat

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3208,5 +3208,6 @@
       "successCount": {},
       "totalCount": {}
     }
-  }
+  },
+  "gifAutoplay": "GIF autoplay"
 }

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -116,6 +116,7 @@ abstract class AppConfig {
   static bool experimentalVoip = false;
   static bool appGridDashboardAvailable = true;
   static bool enableRightAndLeftMessageAlignmentOnWeb = false;
+  static bool gifAutoplay = false;
   static const bool hideTypingUsernames = false;
   static const bool hideAllStateEvents = false;
   static const String inviteLinkPrefix = 'https://matrix.to/#/';

--- a/lib/config/setting_keys.dart
+++ b/lib/config/setting_keys.dart
@@ -29,4 +29,5 @@ abstract class SettingKeys {
   static const String experimentalVoip = 'chat.fluffy.experimental_voip';
   static const String enableRightAndLeftMessageAlignmentOnWeb =
       'chat.twake.enable_right_and_left_message_alignment_on_web';
+  static const String gifAutoplay = 'chat.twake.gif_autoplay';
 }

--- a/lib/pages/chat/events/images_builder/message_content_image_builder.dart
+++ b/lib/pages/chat/events/images_builder/message_content_image_builder.dart
@@ -109,7 +109,9 @@ class _MessageImageBuilderState extends State<MessageImageBuilder> {
           onTapSelectMode: widget.onTapSelectMode,
           onTapPreview: widget.onTapPreview,
           animated: true,
-          thumbnailOnly: true,
+          // For GIF files, download the full image to preserve animation
+          // For other images, use thumbnail for better performance
+          thumbnailOnly: !widget.event.isGifImage,
         );
       },
     );

--- a/lib/pages/chat/events/images_builder/message_content_image_builder.dart
+++ b/lib/pages/chat/events/images_builder/message_content_image_builder.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/events/images_builder/image_bubble.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
@@ -100,6 +101,9 @@ class _MessageImageBuilderState extends State<MessageImageBuilder> {
             bubbleWidth: widget.maxWidth,
           );
         }
+        // Use full image for GIFs only when gifAutoplay is enabled,
+        // otherwise use thumbnail (no animation).
+        final isAnimatedGif = AppConfig.gifAutoplay && widget.event.isGifImage;
         return ImageBubble(
           widget.event,
           bubbleMaxWidth: widget.maxWidth,
@@ -109,9 +113,7 @@ class _MessageImageBuilderState extends State<MessageImageBuilder> {
           onTapSelectMode: widget.onTapSelectMode,
           onTapPreview: widget.onTapPreview,
           animated: true,
-          // For GIF files, download the full image to preserve animation
-          // For other images, use thumbnail for better performance
-          thumbnailOnly: !widget.event.isGifImage,
+          thumbnailOnly: !isAnimatedGif,
         );
       },
     );

--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -130,7 +130,10 @@ class _ImageWidget extends StatelessWidget {
         );
       }
       return FutureBuilder(
-        future: event.downloadAndDecryptAttachment(getThumbnail: true),
+        // Download full image for GIFs to preserve animation
+        future: event.downloadAndDecryptAttachment(
+          getThumbnail: !event.isGifImage,
+        ),
         builder: (context, snapshot) {
           if (snapshot.data == null || snapshot.data!.bytes.isEmpty != false) {
             return const CircularProgressIndicator();

--- a/lib/pages/settings_dashboard/settings_chat/settings_chat_view.dart
+++ b/lib/pages/settings_dashboard/settings_chat/settings_chat_view.dart
@@ -88,6 +88,12 @@ class SettingsChatView extends StatelessWidget {
                   defaultValue:
                       AppConfig.enableRightAndLeftMessageAlignmentOnWeb,
                 ),
+              SettingsSwitchListTile.adaptive(
+                title: L10n.of(context)!.gifAutoplay,
+                onChanged: (value) => AppConfig.gifAutoplay = value,
+                storeKey: SettingKeys.gifAutoplay,
+                defaultValue: AppConfig.gifAutoplay,
+              ),
               const Divider(),
               if (Matrix.of(context).webrtcIsSupported)
                 SettingsSwitchListTile.adaptive(

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -605,6 +605,12 @@ extension LocalizedBody on Event {
     return thisInfoMap['size'] is int &&
         (thisInfoMap['size'] as int) <= database.maxFileSize;
   }
+
+  /// Returns true if this event contains a GIF image.
+  /// GIFs should be displayed as full images (not thumbnails) to preserve animation.
+  bool get isGifImage {
+    return messageType == MessageTypes.Image && mimeType == 'image/gif';
+  }
 }
 
 extension FutureEventExtension on Event {

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -609,7 +609,12 @@ extension LocalizedBody on Event {
   /// Returns true if this event contains a GIF image.
   /// GIFs should be displayed as full images (not thumbnails) to preserve animation.
   bool get isGifImage {
-    return messageType == MessageTypes.Image && mimeType == 'image/gif';
+    if (messageType != MessageTypes.Image) return false;
+
+    final normalizedMimeType = mimeType?.toLowerCase().split(';').first.trim();
+    if (normalizedMimeType == 'image/gif') return true;
+
+    return filename.toLowerCase().endsWith('.gif');
   }
 }
 

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -620,7 +620,12 @@ extension LocalizedBody on Event {
   /// Returns true if this event contains a GIF image.
   /// GIFs should be displayed as full images (not thumbnails) to preserve animation.
   bool get isGifImage {
-    return messageType == MessageTypes.Image && mimeType == 'image/gif';
+    if (messageType != MessageTypes.Image) return false;
+
+    final normalizedMimeType = mimeType?.toLowerCase().split(';').first.trim();
+    if (normalizedMimeType == 'image/gif') return true;
+
+    return filename.toLowerCase().endsWith('.gif');
   }
 }
 

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -616,6 +616,12 @@ extension LocalizedBody on Event {
     return thisInfoMap['size'] is int &&
         (thisInfoMap['size'] as int) <= database.maxFileSize;
   }
+
+  /// Returns true if this event contains a GIF image.
+  /// GIFs should be displayed as full images (not thumbnails) to preserve animation.
+  bool get isGifImage {
+    return messageType == MessageTypes.Image && mimeType == 'image/gif';
+  }
 }
 
 extension FutureEventExtension on Event {

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1292,6 +1292,9 @@ class MatrixState extends State<Matrix>
             .getItemBool(SettingKeys.autoplayImages, AppConfig.autoplayImages)
             .then((value) => AppConfig.autoplayImages = value),
         store
+            .getItemBool(SettingKeys.gifAutoplay, AppConfig.gifAutoplay)
+            .then((value) => AppConfig.gifAutoplay = value),
+        store
             .getItemBool(
               SettingKeys.experimentalVoip,
               AppConfig.experimentalVoip,


### PR DESCRIPTION
## Ticket
**Related issue**

- #2965 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/4908a674-4e06-483f-bdad-b269d4f4e385


https://github.com/user-attachments/assets/b18ecee6-93a0-4169-8339-e978a234db0e

## Memory

<img width="1799" height="1130" alt="Screenshot 2026-03-30 at 14 15 51" src="https://github.com/user-attachments/assets/7260cc63-f471-4e91-a604-eece310cc209" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GIF autoplay toggle in Chat settings to control whether GIFs play automatically.

* **Bug Fixes**
  * Chat images respect the autoplay setting: GIFs render as full animated images when autoplay is on, otherwise they show thumbnails; non-GIF images keep thumbnail-first loading.
  * Image viewer preserves GIF animation by downloading full image bytes when appropriate.

* **Localization**
  * Fixed a translation file structure issue to ensure the new setting key is recognized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->