### PR TITLE
HOTFIX Encrypted chat distorted images

### DIFF
--- a/lib/domain/model/file_info/file_info.dart
+++ b/lib/domain/model/file_info/file_info.dart
@@ -77,6 +77,44 @@ class FileInfo with EquatableMixin {
 
   Map<String, dynamic> toJson() => _$FileInfoToJson(this);
 
+  FileInfo copyBytes(Uint8List updatedBytes) {
+    return switch (this) {
+      ImageFileInfo(
+        :final fileName,
+        :final customMimeType,
+        :final filePath,
+        :final height,
+        :final width,
+      ) =>
+        ImageFileInfo(
+          fileName,
+          bytes: updatedBytes,
+          customMimeType: customMimeType,
+          filePath: filePath,
+          height: height,
+          width: width,
+        ),
+      VideoFileInfo(
+        :final fileName,
+        :final filePath,
+        :final width,
+        :final height,
+        :final customMimeType,
+        :final duration,
+      ) =>
+        VideoFileInfo(
+          fileName,
+          filePath: filePath,
+          bytes: updatedBytes,
+          width: width,
+          height: height,
+          customMimeType: customMimeType,
+          duration: duration,
+        ),
+      _ => FileInfo(fileName, filePath: filePath, bytes: updatedBytes),
+    };
+  }
+
   @override
   List<Object?> get props => [fileName, filePath, customMimeType, bytes];
 }

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -264,11 +264,7 @@ extension SendFileExtension on Room {
         return null;
       }
 
-      fileInfo = FileInfo(
-        fileInfo.fileName,
-        filePath: fileInfo.filePath,
-        bytes: encryptedFileInfo.data,
-      );
+      fileInfo = fileInfo.copyBytes(encryptedFileInfo.data);
       if (thumbnail != null) {
         try {
           uploadStreamController?.add(
@@ -359,11 +355,9 @@ extension SendFileExtension on Room {
 
         if (thumbnail != null) {
           final thumbnailResponse = await mediaApi.uploadFileMobile(
-            fileInfo: FileInfo(
-              thumbnail.fileName,
-              filePath: thumbnail.filePath,
-              bytes: encryptedThumbnail?.data ?? thumbnail.bytes,
-            ),
+            fileInfo: encryptedThumbnail != null
+                ? thumbnail.copyBytes(encryptedThumbnail.data)
+                : thumbnail,
             cancelToken: cancelToken,
             onSendProgress: (receive, total) {
               if (uploadStreamController?.isClosed == true) return;


### PR DESCRIPTION
## Ticket
Some images, when sent in encrypted chat, get distorted.

## Root cause
When encrypted `fileInfo`, a completely new `FileInfo` is created to host the encrypted bytes regardless of the original `fileInfo` type (`ImageFileInfo` or `VideoFileInfo`, which holds size)

### Why not all images sent in encrypted chat get affected?

https://github.com/linagora/twake-on-matrix/blob/056da354e61e783f850bc1db07ceb5ce1a95380b/lib/presentation/extensions/send_file_extension.dart#L498-L500
- `fileInfo.metadata` is completely deprived of size when sent in encrypted chat, but `thumbnail?.metadata` have size data, so the event which has thumbnail can still have the size of image properly
- In case the thumbnail is failed to created OR the size of thumbnail is not smaller than of the original, which the thumbnail will be discarded, there will be nothing to input the size for that sent image.

Take this image for example:
![IMG_20260326_131756_847](https://github.com/user-attachments/assets/4a32f2be-02bc-488f-bf97-10363882b9ae)

Its size is 78kb. For some reason, after going through the compress process, its thumbnail's size is > 100kb, which is why when sending this image in the encrypted chat, it will be distorted.

## Solution
Retain the original file info, only copy the encrypted bytes to the original file.

## Resolved

https://github.com/user-attachments/assets/bb218d53-b409-4ec3-a321-533e0a3bb87a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal file data handling during encryption operations for improved code efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->