### PR TITLE
TW-2973: update chat room preset to private and remove power level overrides

### DIFF
--- a/lib/domain/usecase/room/create_support_chat_interactor.dart
+++ b/lib/domain/usecase/room/create_support_chat_interactor.dart
@@ -64,7 +64,7 @@ class CreateSupportChatInteractor {
       final powerLevelManager = getIt.get<PowerLevelManager>();
       roomId = await client.createGroupChat(
         groupName: 'Support Twake Workplace',
-        preset: CreateRoomPreset.trustedPrivateChat,
+        preset: CreateRoomPreset.privateChat,
         enableEncryption: false,
         initialState: [
           if (avatarUrl != null)
@@ -74,11 +74,6 @@ class CreateSupportChatInteractor {
               stateKey: '',
             ),
         ],
-        powerLevelContentOverride: {
-          'events': powerLevelManager.getDefaultPowerLevelEventForMember(),
-          'invite': powerLevelManager.getAdminPowerLevel(),
-          'kick': powerLevelManager.getAdminPowerLevel(),
-        },
       );
       room = client.getRoomById(roomId);
       if (room == null) {

--- a/lib/domain/usecase/room/create_support_chat_interactor.dart
+++ b/lib/domain/usecase/room/create_support_chat_interactor.dart
@@ -82,10 +82,6 @@ class CreateSupportChatInteractor {
 
       await room.invite(supportChatTwakeId);
       await Future.wait([
-        room.setPower(
-          supportChatTwakeId,
-          powerLevelManager.getAdminPowerLevel(),
-        ),
         room.setFavourite(true),
         client.setAccountData(userId, type, {accountDataKey: roomId}),
       ]);

--- a/test/domain/usecase/room/create_support_chat_interactor_test.dart
+++ b/test/domain/usecase/room/create_support_chat_interactor_test.dart
@@ -72,9 +72,6 @@ void main() {
           when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
             (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
           );
-          when(
-            mockPowerLevelManager.getDefaultPowerLevelEventForMember(),
-          ).thenReturn({});
           when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
           when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
           when(
@@ -83,7 +80,6 @@ void main() {
               enableEncryption: anyNamed('enableEncryption'),
               preset: anyNamed('preset'),
               initialState: anyNamed('initialState'),
-              powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
             ),
           ).thenAnswer((_) async => testRoomId);
           when(mockClient.getRoomById(testRoomId)).thenReturn(mockRoom);
@@ -126,9 +122,8 @@ void main() {
             mockClient.createGroupChat(
               groupName: 'Support Twake Workplace',
               enableEncryption: false,
-              preset: CreateRoomPreset.trustedPrivateChat,
+              preset: CreateRoomPreset.privateChat,
               initialState: anyNamed('initialState'),
-              powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
             ),
           ).called(1);
           verify(mockRoom.invite(testSupportContactId)).called(1);
@@ -184,7 +179,6 @@ void main() {
               enableEncryption: anyNamed('enableEncryption'),
               preset: anyNamed('preset'),
               initialState: anyNamed('initialState'),
-              powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
             ),
           );
         },
@@ -208,9 +202,6 @@ void main() {
           when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
             (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
           );
-          when(
-            mockPowerLevelManager.getDefaultPowerLevelEventForMember(),
-          ).thenReturn({});
           when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
           when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
           when(
@@ -219,7 +210,6 @@ void main() {
               enableEncryption: anyNamed('enableEncryption'),
               preset: anyNamed('preset'),
               initialState: anyNamed('initialState'),
-              powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
             ),
           ).thenAnswer((_) async => testRoomId);
           when(mockClient.getRoomById(testRoomId)).thenReturn(mockRoom);
@@ -261,9 +251,8 @@ void main() {
             mockClient.createGroupChat(
               groupName: 'Support Twake Workplace',
               enableEncryption: false,
-              preset: CreateRoomPreset.trustedPrivateChat,
+              preset: CreateRoomPreset.privateChat,
               initialState: anyNamed('initialState'),
-              powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
             ),
           ).called(1);
           verify(mockRoom.invite(testSupportContactId)).called(1);
@@ -307,7 +296,6 @@ void main() {
               enableEncryption: anyNamed('enableEncryption'),
               preset: anyNamed('preset'),
               initialState: anyNamed('initialState'),
-              powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
             ),
           );
         },
@@ -370,7 +358,6 @@ void main() {
             enableEncryption: anyNamed('enableEncryption'),
             preset: anyNamed('preset'),
             initialState: anyNamed('initialState'),
-            powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
           ),
         );
       });
@@ -413,7 +400,6 @@ void main() {
             enableEncryption: anyNamed('enableEncryption'),
             preset: anyNamed('preset'),
             initialState: anyNamed('initialState'),
-            powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
           ),
         );
       });
@@ -432,9 +418,6 @@ void main() {
         when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
           (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
         );
-        when(
-          mockPowerLevelManager.getDefaultPowerLevelEventForMember(),
-        ).thenReturn({});
         when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
         when(
           mockClient.createGroupChat(
@@ -442,7 +425,6 @@ void main() {
             enableEncryption: anyNamed('enableEncryption'),
             preset: anyNamed('preset'),
             initialState: anyNamed('initialState'),
-            powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
           ),
         ).thenThrow(Exception('Room creation failed'));
 
@@ -466,9 +448,8 @@ void main() {
           mockClient.createGroupChat(
             groupName: 'Support Twake Workplace',
             enableEncryption: false,
-            preset: CreateRoomPreset.trustedPrivateChat,
+            preset: CreateRoomPreset.privateChat,
             initialState: anyNamed('initialState'),
-            powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
           ),
         ).called(1);
       });
@@ -487,9 +468,6 @@ void main() {
         when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
           (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
         );
-        when(
-          mockPowerLevelManager.getDefaultPowerLevelEventForMember(),
-        ).thenReturn({});
         when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
         when(
           mockClient.createGroupChat(
@@ -497,7 +475,6 @@ void main() {
             enableEncryption: anyNamed('enableEncryption'),
             preset: anyNamed('preset'),
             initialState: anyNamed('initialState'),
-            powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
           ),
         ).thenAnswer((_) async => testRoomId);
         when(mockClient.getRoomById(testRoomId)).thenReturn(null);
@@ -535,9 +512,6 @@ void main() {
         when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
           (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
         );
-        when(
-          mockPowerLevelManager.getDefaultPowerLevelEventForMember(),
-        ).thenReturn({});
         when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
         when(
           mockClient.createGroupChat(
@@ -545,7 +519,6 @@ void main() {
             enableEncryption: anyNamed('enableEncryption'),
             preset: anyNamed('preset'),
             initialState: anyNamed('initialState'),
-            powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
           ),
         ).thenAnswer((_) async => testRoomId);
         when(mockClient.getRoomById(testRoomId)).thenReturn(mockRoom);
@@ -598,9 +571,6 @@ void main() {
           when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
             (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
           );
-          when(
-            mockPowerLevelManager.getDefaultPowerLevelEventForMember(),
-          ).thenReturn({});
           when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
           when(
             mockClient.createGroupChat(
@@ -608,7 +578,6 @@ void main() {
               enableEncryption: anyNamed('enableEncryption'),
               preset: anyNamed('preset'),
               initialState: anyNamed('initialState'),
-              powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
             ),
           ).thenAnswer((_) async => testRoomId);
           when(mockClient.getRoomById(testRoomId)).thenReturn(mockRoom);
@@ -667,9 +636,6 @@ void main() {
         when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
           (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
         );
-        when(
-          mockPowerLevelManager.getDefaultPowerLevelEventForMember(),
-        ).thenReturn({});
         when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
         when(
           mockClient.createGroupChat(
@@ -677,7 +643,6 @@ void main() {
             enableEncryption: anyNamed('enableEncryption'),
             preset: anyNamed('preset'),
             initialState: anyNamed('initialState'),
-            powerLevelContentOverride: anyNamed('powerLevelContentOverride'),
           ),
         ).thenAnswer((_) async => testRoomId);
         when(mockClient.getRoomById(testRoomId)).thenReturn(mockRoom);

--- a/test/domain/usecase/room/create_support_chat_interactor_test.dart
+++ b/test/domain/usecase/room/create_support_chat_interactor_test.dart
@@ -72,7 +72,6 @@ void main() {
           when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
             (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
           );
-          when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
           when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
           when(
             mockClient.createGroupChat(
@@ -86,9 +85,6 @@ void main() {
           when(
             mockRoom.invite(testSupportContactId),
           ).thenAnswer((_) async => {});
-          when(
-            mockRoom.setPower(testSupportContactId, 100),
-          ).thenAnswer((_) async => 'event_id');
           when(
             mockRoom.setPower(testUserId, 0),
           ).thenAnswer((_) async => 'event_id');
@@ -127,9 +123,8 @@ void main() {
             ),
           ).called(1);
           verify(mockRoom.invite(testSupportContactId)).called(1);
-          verify(mockRoom.setPower(testSupportContactId, 100)).called(1);
-          verify(mockRoom.setPower(testUserId, 0)).called(1);
           verify(mockRoom.setFavourite(true)).called(1);
+          verify(mockRoom.setPower(testUserId, 0)).called(1);
           verify(
             mockClient.setAccountData(testUserId, 'app.twake.support_room', {
               'createdSupportChat': testRoomId,
@@ -202,7 +197,6 @@ void main() {
           when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
             (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
           );
-          when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
           when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
           when(
             mockClient.createGroupChat(
@@ -216,9 +210,6 @@ void main() {
           when(
             mockRoom.invite(testSupportContactId),
           ).thenAnswer((_) async => {});
-          when(
-            mockRoom.setPower(testSupportContactId, 100),
-          ).thenAnswer((_) async => 'event_id');
           when(
             mockRoom.setPower(testUserId, 0),
           ).thenAnswer((_) async => 'event_id');
@@ -256,7 +247,6 @@ void main() {
             ),
           ).called(1);
           verify(mockRoom.invite(testSupportContactId)).called(1);
-          verify(mockRoom.setPower(testSupportContactId, 100)).called(1);
           verify(mockRoom.setPower(testUserId, 0)).called(1);
         },
       );
@@ -418,7 +408,7 @@ void main() {
         when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
           (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
         );
-        when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
+        when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
         when(
           mockClient.createGroupChat(
             groupName: anyNamed('groupName'),
@@ -468,7 +458,7 @@ void main() {
         when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
           (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
         );
-        when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
+        when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
         when(
           mockClient.createGroupChat(
             groupName: anyNamed('groupName'),
@@ -512,7 +502,7 @@ void main() {
         when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
           (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
         );
-        when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
+        when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
         when(
           mockClient.createGroupChat(
             groupName: anyNamed('groupName'),
@@ -524,8 +514,8 @@ void main() {
         when(mockClient.getRoomById(testRoomId)).thenReturn(mockRoom);
         when(mockRoom.invite(testSupportContactId)).thenAnswer((_) async => {});
         when(
-          mockRoom.setPower(testSupportContactId, 100),
-        ).thenAnswer((_) async => 'event_id');
+          mockClient.setAccountData(testUserId, 'app.twake.support_room', any),
+        ).thenAnswer((_) async => {});
         when(
           mockRoom.setFavourite(true),
         ).thenThrow(Exception('setFavourite failed'));
@@ -547,7 +537,6 @@ void main() {
         );
 
         verify(mockRoom.invite(testSupportContactId)).called(1);
-        verify(mockRoom.setPower(testSupportContactId, 100)).called(1);
         verify(mockRoom.setFavourite(true)).called(1);
       });
     });
@@ -571,7 +560,7 @@ void main() {
           when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
             (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
           );
-          when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
+          when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
           when(
             mockClient.createGroupChat(
               groupName: anyNamed('groupName'),
@@ -585,8 +574,12 @@ void main() {
             mockRoom.invite(testSupportContactId),
           ).thenAnswer((_) async => {});
           when(
-            mockRoom.setPower(testSupportContactId, 100),
-          ).thenAnswer((_) async => 'event_id');
+            mockClient.setAccountData(
+              testUserId,
+              'app.twake.support_room',
+              any,
+            ),
+          ).thenAnswer((_) async => {});
           when(
             mockRoom.setFavourite(true),
           ).thenThrow(Exception('setFavourite failed'));
@@ -636,7 +629,7 @@ void main() {
         when(mockMediaAPI.uploadFileWeb(file: anyNamed('file'))).thenAnswer(
           (_) async => const UploadFileResponse(contentUri: testAvatarUrl),
         );
-        when(mockPowerLevelManager.getAdminPowerLevel()).thenReturn(100);
+        when(mockPowerLevelManager.getUserPowerLevel()).thenReturn(0);
         when(
           mockClient.createGroupChat(
             groupName: anyNamed('groupName'),
@@ -648,8 +641,8 @@ void main() {
         when(mockClient.getRoomById(testRoomId)).thenReturn(mockRoom);
         when(mockRoom.invite(testSupportContactId)).thenAnswer((_) async => {});
         when(
-          mockRoom.setPower(testSupportContactId, 100),
-        ).thenAnswer((_) async => 'event_id');
+          mockClient.setAccountData(testUserId, 'app.twake.support_room', any),
+        ).thenAnswer((_) async => {});
         when(
           mockRoom.setFavourite(true),
         ).thenThrow(Exception('setFavourite failed'));


### PR DESCRIPTION
## Ticket
**Related issue**

- #2973 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/e6daef3a-8318-4548-9c4c-538a0a44fdbc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Support chat creation now uses the standard private-chat configuration and relies on default permission handling instead of explicit custom permission overrides.

* **Tests**
  * Test suite updated to reflect the new support chat preset and the removal of explicit permission-override expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->