### PR TITLE
perf: add cacheWidth/cacheHeight to Image widgets to reduce GPU memory

### DIFF
--- a/lib/pages/add_story/add_story_view.dart
+++ b/lib/pages/add_story/add_story_view.dart
@@ -79,7 +79,13 @@ class AddStoryView extends StatelessWidget {
                 image: controller.image == null
                     ? null
                     : DecorationImage(
-                        image: MemoryImage(controller.image!.bytes),
+                        image: ResizeImage(
+                          MemoryImage(controller.image!.bytes),
+                          width:
+                              (MediaQuery.sizeOf(context).width *
+                                      MediaQuery.devicePixelRatioOf(context))
+                                  .round(),
+                        ),
                         fit: controller.fit,
                         opacity: 0.75,
                       ),

--- a/lib/pages/chat/chat_invitation_body.dart
+++ b/lib/pages/chat/chat_invitation_body.dart
@@ -24,6 +24,10 @@ class ChatInvitationBody extends StatelessWidget with MessageContentMixin {
             Matrix.of(context).wallpaper!,
             width: double.infinity,
             height: double.infinity,
+            cacheWidth:
+                (MediaQuery.sizeOf(context).width *
+                        MediaQuery.devicePixelRatioOf(context))
+                    .round(),
             fit: BoxFit.cover,
             filterQuality: FilterQuality.medium,
           ),

--- a/lib/pages/chat/chat_view_body.dart
+++ b/lib/pages/chat/chat_view_body.dart
@@ -55,6 +55,10 @@ class ChatViewBody extends StatelessWidget with MessageContentMixin {
                 Matrix.of(context).wallpaper!,
                 width: double.infinity,
                 height: double.infinity,
+                cacheWidth:
+                    (MediaQuery.sizeOf(context).width *
+                            MediaQuery.devicePixelRatioOf(context))
+                        .round(),
                 fit: BoxFit.cover,
                 filterQuality: FilterQuality.medium,
               ),

--- a/lib/pages/chat/events/event_video_player.dart
+++ b/lib/pages/chat/events/event_video_player.dart
@@ -5,6 +5,7 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:fluffychat/pages/chat_details/chat_details_page_view/media/chat_details_media_style.dart';
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:flutter/material.dart';
@@ -97,6 +98,12 @@ class EventVideoPlayer extends StatelessWidget {
                     File(thumbnailPath!),
                     width: MessageContentStyle.imageBubbleWidth(imageWidth),
                     height: MessageContentStyle.videoBubbleHeight(imageHeight),
+                    cacheWidth: context.getCacheSize(
+                      MessageContentStyle.imageBubbleWidth(imageWidth),
+                    ),
+                    cacheHeight: context.getCacheSize(
+                      MessageContentStyle.videoBubbleHeight(imageHeight),
+                    ),
                     fit: BoxFit.cover,
                   )
                 else

--- a/lib/pages/chat/events/sending_video_widget.dart
+++ b/lib/pages/chat/events/sending_video_widget.dart
@@ -5,6 +5,7 @@ import 'package:fluffychat/presentation/mixins/play_video_action_mixin.dart';
 import 'package:fluffychat/presentation/model/chat/upload_file_ui_state.dart';
 import 'package:fluffychat/presentation/model/file/display_image_info.dart';
 import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/widgets/mixins/upload_file_mixin.dart';
 import 'package:flutter/material.dart';
@@ -182,6 +183,8 @@ class _VideoWidgetState extends State<VideoWidget> {
           snapshot.data!.bytes,
           width: widget.imageWidth,
           height: widget.imageHeight,
+          cacheWidth: context.getCacheSize(widget.imageWidth),
+          cacheHeight: context.getCacheSize(widget.imageHeight),
           fit: BoxFit.cover,
           filterQuality: FilterQuality.medium,
         );

--- a/lib/pages/settings_dashboard/settings_style/settings_style_view.dart
+++ b/lib/pages/settings_dashboard/settings_style/settings_style_view.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 
@@ -109,7 +110,12 @@ class SettingsStyleView extends StatelessWidget {
             ),
             if (wallpaper != null)
               ListTile(
-                title: Image.file(wallpaper, height: 38, fit: BoxFit.cover),
+                title: Image.file(
+                  wallpaper,
+                  height: 38,
+                  cacheHeight: context.getCacheSize(38),
+                  fit: BoxFit.cover,
+                ),
                 trailing: const Icon(Icons.delete_outlined, color: Colors.red),
                 onTap: controller.deleteWallpaperAction,
               ),

--- a/lib/pages/story/story_view.dart
+++ b/lib/pages/story/story_view.dart
@@ -212,6 +212,10 @@ class StoryView extends StatelessWidget {
                       child: Image.memory(
                         matrixFile.bytes,
                         fit: controller.storyThemeData.fit,
+                        cacheWidth:
+                            (MediaQuery.sizeOf(context).width *
+                                    MediaQuery.devicePixelRatioOf(context))
+                                .round(),
                       ),
                     );
                   },

--- a/lib/widgets/file_widget/base_file_tile_widget.dart
+++ b/lib/widgets/file_widget/base_file_tile_widget.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
+import 'package:fluffychat/utils/extension/build_context_extension.dart';
 import 'package:fluffychat/utils/extension/mime_type_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/string_extension.dart';
@@ -71,6 +72,8 @@ class BaseFileTileWidget extends StatelessWidget {
                         imageBytes!,
                         width: style.imageSize,
                         height: style.imageSize,
+                        cacheWidth: context.getCacheSize(style.imageSize),
+                        cacheHeight: context.getCacheSize(style.imageSize),
                         fit: BoxFit.cover,
                       ),
                     ),


### PR DESCRIPTION
## Summary
- Add `cacheWidth`/`cacheHeight` to **8 Image widgets** that decoded at full native resolution regardless of display size
- Example: a 1920×1445 thumbnail shown at 60×60 was consuming ~14 MB — now ~15 KB
- Full-screen viewers (pinch-zoom) intentionally left at full resolution

## Changed files
- **Wallpaper images**: `chat_view_body`, `chat_invitation_body` — `cacheWidth` sized to screen width
- **Video thumbnails**: `event_video_player`, `sending_video_widget` — `cacheWidth`/`cacheHeight` via `getCacheSize()`
- **File tile thumbnails**: `base_file_tile_widget` — `cacheWidth`/`cacheHeight` via `getCacheSize()`
- **Story images**: `story_view`, `add_story_view` — `cacheWidth` sized to screen width / `ResizeImage`
- **Settings wallpaper preview**: `settings_style_view` — `cacheHeight` at 38px

## Performance benchmark

Protocol: **iOS device (Mangue), Flutter profile mode (AOT)**, scroll 30s in Bug Me Harder (77 members) + 30s in tech-radar (51 members). Memory measured via Dart VM service (`_currentRSS` = total process RSS).

| Metric | `main` | `perf/image-cache-dimensions` |
|---|---|---|
| Initial RSS (lobby) | 294.8 MB | 282.4 MB |
| RSS after Bug Me Harder | 341.2 MB | 308.3 MB |
| RSS after tech-radar | 341.9 MB | 310.8 MB |
| **Peak RSS** | **366.9 MB** | **344.2 MB** |

**−31 MB final RSS (−9%) · −22.7 MB peak RSS**

> **Caveat:** single run per branch. Typical iOS RSS variance is ±20–30 MB, so the peak delta is within the noise margin. The final RSS delta is more robust but should be confirmed with additional runs. For OOM kill prevention, `phys_footprint` (not RSS) is the relevant metric — RSS is the best available via the Dart VM service.

> **Flutter web note:** the decode-time resize still applies on web via CanvasKit, but the effect is not measurable via JS heap tooling (`performance.memory` does not capture GPU/CanvasKit memory).

## Test plan
- [ ] Open a chat with many images/thumbnails — verify images display correctly
- [ ] Check wallpaper rendering in chat view and invitation body
- [ ] Verify video thumbnails render correctly
- [ ] Check file tile thumbnails in file messages
- [ ] Monitor memory usage — should be significantly lower with many images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized image rendering across story creation, messaging, settings, and file management features.
  * Enhanced image caching and decoding mechanisms throughout the app to improve responsiveness when displaying and processing images.
  * Fine-tuned memory handling for image assets to ensure smoother performance during image viewing and sharing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->