### PR TITLE
Update Xcode version to 26.2 in build and release configurations

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ name: Build
 
 env:
   FLUTTER_VERSION: 3.38.9
-  XCODE_VERSION: 26.0
+  XCODE_VERSION: 26.2
 
 jobs:
   build_debug_mobile:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
 
 env:
   FLUTTER_VERSION: 3.38.9
-  XCODE_VERSION: 26.0
+  XCODE_VERSION: 26.2
 
 name: Release
 


### PR DESCRIPTION
  Final Configuration:

  - Runner: macos-26 (latest stable macOS runner)
  - Xcode: 26.2 (default, guaranteed to work)
  - iOS SDK: Includes iOS 26.0, 26.1, 26.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Xcode version from 26.0 to 26.2 in build and release workflows to leverage the latest Xcode tools and improvements for iOS development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->