### PR TITLE
Bump version v2.21.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [2.21.13] - 2026-04-01
+## [2.21.14] - 2026-04-01
 
 ### Added
 - TW-2991: Display recovery key in Privacy & Security settings with masked field and copy-to-clipboard functionality
@@ -9,6 +9,7 @@
 
 ### Fixed
 - perf: Evict image cache on chat dispose to prevent OOM kills in image-heavy rooms (reduces memory usage by ~32 MB)
+- Disable auto focus in Safari
 
 ## [2.21.12] - 2026-03-27
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.21.13+2330
+version: 2.21.14+2330
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
## [2.21.13] - 2026-04-01

### Added
- TW-2991: Display recovery key in Privacy & Security settings with masked field and copy-to-clipboard functionality

### Changed
- TW-2928: Reorder contacts list
- Update Xcode version to 26.2 in build and release configurations

### Fixed
- perf: Evict image cache on chat dispose to prevent OOM kills in image-heavy rooms (reduces memory usage by ~32 MB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery key display in Privacy & Security with masked value and copy-to-clipboard

* **Improvements**
  * Contacts list now supports reordering
  * Updated build and release configurations

* **Bug Fixes**
  * Evict image cache when closing chats to prevent memory issues in image-heavy rooms
  * Disabled automatic focus behavior in Safari to improve accessibility and input handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->