### PR TITLE
Update autofocus behavior for non-Safari web platforms

### DIFF
--- a/lib/pages/chat/chat_input_row.dart
+++ b/lib/pages/chat/chat_input_row.dart
@@ -428,7 +428,7 @@ class ChatInputRow extends StatelessWidget {
       room: controller.room!,
       minLines: 1,
       maxLines: 8,
-      autofocus: !PlatformInfos.isMobile && !PlatformInfos.isSafari,
+      autofocus: PlatformInfos.isDesktopNonSafari,
       keyboardType: TextInputType.multiline,
       textInputAction: null,
       onSubmitted: (_) => controller.onInputBarSubmitted(),

--- a/lib/utils/platform_infos.dart
+++ b/lib/utils/platform_infos.dart
@@ -102,6 +102,9 @@ abstract class PlatformInfos {
 
   static bool get isSafari => isWeb && browserName == 'Safari';
 
+  static bool get isDesktopNonSafari =>
+      !PlatformInfos.isMobile && !PlatformInfos.isSafari;
+
   static String get clientName => isWeb
       ? '$webDomain: $browserName on $operatingSystemName ${kReleaseMode ? '' : 'Debug'}'
       : '${AppConfig.applicationName} ${Platform.operatingSystem} ${kReleaseMode ? '' : 'Debug'}';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted chat input autofocus so it only activates on desktop non‑Safari browsers; Safari and other non‑desktop contexts no longer auto‑focus. This prevents unintended focus/keyboard pop-ups on Safari and mobile, improving typing behavior and cross‑browser consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->