### PR TITLE
test(integration): bypass SSO browser UI with direct OIDC API login flow

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,26 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest"]
+    },
+    "flutter-inspector": {
+      "command": "${MCP_FLUTTER_BIN:-$HOME/tools/flutter_inspector_mcp}",
+      "args": [
+        "--dart-vm-host=localhost",
+        "--dart-vm-port=8181",
+        "--resources",
+        "--images",
+        "--dynamics"
+      ]
+    },
+    "patrol": {
+      "command": "./.claude/run-patrol",
+      "env": {
+        "PROJECT_ROOT": ".",
+        "PATROL_FLAGS": "--device <YOUR_DEVICE_ID> --dart-define-from-file integration_test/.env.local.do-not-commit",
+        "SHOW_TERMINAL": "false"
+      }
+    }
+  }
+}

--- a/integration_test/base/core_robot.dart
+++ b/integration_test/base/core_robot.dart
@@ -203,12 +203,16 @@ class CoreRobot {
     return client;
   }
 
-  Future<List<dynamic>> loginByAPI(HttpClient client) async {
-    const chatURL = String.fromEnvironment('CHAT_URL');
+  /// Runs the OIDC flow (steps 1-7) via HTTP without any browser UI.
+  /// Returns the one-time [loginToken] and the [lemonldap] session cookie.
+  Future<({String loginToken, String? lemonldap})> getLoginTokenViaOIDC(
+    HttpClient client,
+    String username,
+    String password,
+  ) async {
     const matrixURL = String.fromEnvironment('MATRIX_URL');
     const ssoURL = String.fromEnvironment('SSO_URL');
-    const receiver = String.fromEnvironment('Receiver');
-    const passOfReceiver = String.fromEnvironment('ReceiverPass');
+    const chatURL = String.fromEnvironment('CHAT_URL');
 
     // Step 1: Prepare the first request (no redirect)
     final uri = Uri.https(
@@ -320,6 +324,20 @@ class CoreRobot {
     final secondResponse = await secondRequest.close();
 
     // Step 4: Extract token, url from HTML (token is in a hidden input field)
+    // Also extract lemonldappdata cookie – required for the POST in step 5.
+    final allCookiesOfSecondResponse = secondResponse.headers['set-cookie'];
+    String? lemonldappdata;
+    if (allCookiesOfSecondResponse != null) {
+      final lemonldappdataCookie = allCookiesOfSecondResponse.firstWhere(
+        (cookie) => cookie.contains('lemonldappdata='),
+        orElse: () => '',
+      );
+      final lemonldappdataMatch = RegExp(
+        r'lemonldappdata=([^;]+)',
+      ).firstMatch(lemonldappdataCookie);
+      lemonldappdata = lemonldappdataMatch?.group(1);
+    }
+
     final body = await utf8.decoder.bind(secondResponse).join();
     final doc = parse(body);
     final tokenInput = doc.querySelector('input[name=token]');
@@ -332,35 +350,18 @@ class CoreRobot {
     if (url == null) {
       throw Exception('url not found in HTML form');
     }
+    final skinInput = doc.querySelector('input[name=skin]');
+    final skin = skinInput?.attributes['value'] ?? 'twake';
 
-    // Step 5: Submit login form to authorize (third request)
-    final thirdUri = Uri.https(ssoURL, '/oauth2/authorize', {
-      'response_type': 'code',
-      'client_id': 'matrix1',
-      'redirect_uri': 'https://$matrixURL/_synapse/client/oidc/callback',
-      'scope': 'openid profile email',
-      'state': state,
-      'nonce': nonce,
-      'code_challenge_method': codeChallengeMethod,
-      'code_challenge': codeChallenge,
-    });
-
-    final thirdRequest = await client.postUrl(thirdUri);
+    // Step 5: Submit login form to authorize (third request).
+    // The form action is "#" – POST to the same URL as step 3.
+    // Must include the lemonldappdata cookie received in step 4.
+    final thirdRequest = await client.postUrl(requestToSSOAuthorize);
     thirdRequest.followRedirects = false;
 
     thirdRequest.headers
       ..set('Sec-Fetch-Mode', 'navigate')
-      ..set(
-        HttpHeaders.refererHeader,
-        'https://$ssoURL/oauth2/authorize?response_type=code'
-        '&client_id=$clientId'
-        '&redirect_uri=$redirectUriValue'
-        '&scope=$scope'
-        '&state=$state'
-        '&nonce=$nonce'
-        '&code_challenge_method=$codeChallengeMethod'
-        '&code_challenge=$codeChallenge',
-      )
+      ..set(HttpHeaders.refererHeader, requestToSSOAuthorize.toString())
       ..set('Sec-Fetch-Site', 'same-origin')
       ..set(HttpHeaders.acceptLanguageHeader, 'en-US,en;q=0.9,vi;q=0.8')
       ..set('Origin', 'https://$ssoURL')
@@ -383,15 +384,16 @@ class CoreRobot {
         HttpHeaders.userAgentHeader,
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
       )
-      ..set('Sec-Fetch-Dest', 'document');
+      ..set('Sec-Fetch-Dest', 'document')
+      ..set(HttpHeaders.cookieHeader, 'lemonldappdata=$lemonldappdata');
 
     final thirdBody = {
       'url': url,
       'timezone': '7',
-      'skin': 'twake',
+      'skin': skin,
       'token': token,
-      'user': receiver,
-      'password': passOfReceiver,
+      'user': username,
+      'password': password,
     };
     thirdRequest.write(Uri(queryParameters: thirdBody).query);
 
@@ -399,11 +401,19 @@ class CoreRobot {
 
     final location = thirdResponse.headers.value('location');
     if (location == null) {
-      throw Exception('No redirect found after login POST');
+      final responseBody = await utf8.decoder.bind(thirdResponse).join();
+      throw Exception(
+        'No redirect found after login POST [status=${thirdResponse.statusCode}] body=${responseBody.substring(0, responseBody.length.clamp(0, 300))}',
+      );
     }
     final thirdRedirectUri = Uri.parse(location);
     final code = thirdRedirectUri.queryParameters['code'];
     final sessionState = thirdRedirectUri.queryParameters['session_state'];
+    if (code == null) {
+      throw Exception(
+        'No code in redirect after login POST – likely wrong credentials. Location: $location',
+      );
+    }
 
     final allCookiesOfThirdResponse =
         thirdResponse.headers['set-cookie']; // List<String>?
@@ -457,17 +467,44 @@ class CoreRobot {
 
     final fourthResponse = await fourthRequest.close();
 
+    // The OIDC callback either redirects (302) or returns a consent page (200)
+    // containing a "Continue" link with the loginToken already embedded.
     final locationIn4Response = fourthResponse.headers.value('location');
-    if (locationIn4Response == null) {
-      throw Exception('Missing location header in response');
+    String? loginToken;
+    if (locationIn4Response != null) {
+      loginToken = Uri.parse(locationIn4Response).queryParameters['loginToken'];
+    } else {
+      // Consent page: extract loginToken from the <a href="…&loginToken=…"> link.
+      final responseBody = await utf8.decoder.bind(fourthResponse).join();
+      final match = RegExp(r'loginToken=([^"&\s]+)').firstMatch(responseBody);
+      loginToken = match?.group(1);
+      if (loginToken == null) {
+        throw Exception(
+          'Could not extract loginToken from OIDC callback response [status=${fourthResponse.statusCode}] body=${responseBody.substring(0, responseBody.length.clamp(0, 500))}',
+        );
+      }
     }
-
-    final uriIn4Location = Uri.parse(locationIn4Response);
-    final loginToken = uriIn4Location.queryParameters['loginToken'];
 
     if (loginToken == null) {
-      throw Exception('Missing loginToken in redirect URL');
+      throw Exception('Missing loginToken in OIDC callback response');
     }
+
+    return (loginToken: loginToken, lemonldap: lemonldap);
+  }
+
+  Future<List<dynamic>> loginByAPI(HttpClient client) async {
+    const chatURL = String.fromEnvironment('CHAT_URL');
+    const matrixURL = String.fromEnvironment('MATRIX_URL');
+    const receiver = String.fromEnvironment('Receiver');
+    const passOfReceiver = String.fromEnvironment('ReceiverPass');
+
+    final oidcResult = await getLoginTokenViaOIDC(
+      client,
+      receiver,
+      passOfReceiver,
+    );
+    final loginToken = oidcResult.loginToken;
+    final lemonldap = oidcResult.lemonldap;
 
     // Step 8: Token login
     final fifthUri = Uri.https(matrixURL, '/_matrix/client/v3/login');
@@ -615,7 +652,7 @@ class CoreRobot {
     Finder? scrollable,
     int maxSwipes = 10,
   }) async {
-    final container = scrollable ?? find.byType(Scrollable);
+    final container = scrollable ?? find.byType(Scrollable).first;
 
     for (int i = 0; i < maxSwipes; i++) {
       if ($.tester.any(target)) return;

--- a/integration_test/robots/login_robot.dart
+++ b/integration_test/robots/login_robot.dart
@@ -5,6 +5,7 @@ import 'package:fluffychat/pages/homeserver_picker/homeserver_picker_view.dart';
 import 'package:fluffychat/pages/login/login_view.dart';
 import 'package:fluffychat/pages/twake_welcome/twake_welcome.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/widgets/twake_app.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
@@ -87,7 +88,11 @@ class LoginRobot extends CoreRobot {
         Selector(textContains: label),
         appId: appId,
       )) {
-        await $.native.tap(Selector(textContains: label), appId: appId);
+        try {
+          await $.native.tap(Selector(textContains: label), appId: appId);
+        } catch (_) {
+          // Dialog may have been dismissed by iOS before the tap completed.
+        }
       }
     }
   }
@@ -247,6 +252,45 @@ class LoginRobot extends CoreRobot {
     await enterUsername(username);
     await enterPassword(password);
     await tapSignInButton();
+  }
+
+  /// Logs in by running the OIDC flow via HTTP (no browser UI interaction).
+  /// Obtains a one-time [loginToken] from the SSO server and feeds it directly
+  /// to the app via the /onAuthRedirect deep link, bypassing any SSO browser
+  /// modal entirely.
+  Future<void> loginViaApi({
+    required String serverUrl,
+    required String username,
+    required String password,
+  }) async {
+    // Wait for either TwakeWelcome (not logged in) or ChatList (already logged
+    // in from a previous test run whose tokens persisted in the iOS keychain).
+    await waitForEitherVisible(
+      $: $,
+      first: $(TwakeWelcome),
+      second: $(ChatList),
+      timeout: const Duration(seconds: 60),
+    );
+
+    if (await isChatListVisible()) return;
+
+    final httpClient = await initialRedirectRequest();
+    final oidcResult = await getLoginTokenViaOIDC(
+      httpClient,
+      username,
+      password,
+    );
+    await closeHTTPClient(httpClient);
+
+    final encodedServer = Uri.encodeComponent(serverUrl);
+    // Use router.go() directly — bypasses app_links which only listens when
+    // ChatList is active (post-login). go_router navigates synchronously.
+    TwakeApp.router.go(
+      '/onAuthRedirect?loginToken=${oidcResult.loginToken}&homeserver=$encodedServer',
+    );
+    await $.pump();
+
+    await waitForChatList();
   }
 
   Future<void> waitForChatList() async {

--- a/integration_test/scenarios/login_scenario.dart
+++ b/integration_test/scenarios/login_scenario.dart
@@ -1,6 +1,3 @@
-import 'package:fluffychat/pages/chat_list/chat_list.dart';
-import 'package:fluffychat/pages/homeserver_picker/homeserver_picker_view.dart';
-import 'package:flutter_test/flutter_test.dart';
 import '../base/base_scenario.dart';
 import '../robots/login_robot.dart';
 
@@ -20,30 +17,11 @@ class LoginScenario extends BaseScenario {
 
   Future<void> login() async {
     final loginRobot = LoginRobot($);
-    if (await loginRobot.isWelcomePageVisible()) {
-      await loginRobot.tapOnUseYourCompanyServer();
-      await _handleWaitUntilVisibleHomeServerPickerView(loginRobot);
-      await loginRobot.enterServerUrl(serverUrl);
-      await loginRobot.clickOnContinueBtn();
-      await loginRobot.confirmShareInformation();
-    }
-    if (await loginRobot.isSignInPageVisible()) {
-      await loginRobot.enterWebCredentialsWhenVisible(
-        username: username,
-        password: password,
-      );
-    }
-    await $(ChatList).waitUntilVisible(timeout: const Duration(seconds: 120));
+    await loginRobot.loginViaApi(
+      serverUrl: serverUrl,
+      username: username,
+      password: password,
+    );
     await loginRobot.grantNotificationPermission();
-  }
-
-  Future<void> _handleWaitUntilVisibleHomeServerPickerView(
-    LoginRobot loginRobot,
-  ) async {
-    try {
-      await $.waitUntilVisible($(HomeserverPickerView));
-    } catch (e) {
-      loginRobot.ignoreException();
-    }
   }
 }

--- a/lib/pages/login/on_auth_redirect.dart
+++ b/lib/pages/login/on_auth_redirect.dart
@@ -45,6 +45,7 @@ class _OnAuthRedirectState extends State<OnAuthRedirect> with ConnectPageMixin {
     Logs().i(
       'StreamDialogBuilder::_listenClientLoginStateChanged - ${event.multipleAccountLoginType}',
     );
+    if (!mounted) return;
     if (event.multipleAccountLoginType ==
         MultipleAccountLoginType.firstLoggedIn) {
       _clientFirstLoggedIn = event.client;
@@ -55,6 +56,7 @@ class _OnAuthRedirectState extends State<OnAuthRedirect> with ConnectPageMixin {
 
   void _handleLoginSuccess() {
     Logs().i('OnAuthRedirect::_handleLoginSuccess');
+    if (!context.mounted) return;
     if (_clientFirstLoggedIn != null) {
       context.go(
         '/rooms',
@@ -71,10 +73,38 @@ class _OnAuthRedirectState extends State<OnAuthRedirect> with ConnectPageMixin {
       error,
       stackTrace,
     );
-    context.go('/home');
+    if (context.mounted) {
+      context.go('/home');
+    }
   }
 
   Future<void> tryLoggingUsingToken({required BuildContext context}) async {
+    // Read route params SYNCHRONOUSLY before any await — GoRouterState
+    // must not be accessed after an async gap (inherited widget anti-pattern).
+    // AppConfig.homeserver must NOT be captured here on web: on a fresh
+    // /auth.html load after SSO, config.json may not have loaded yet, so
+    // it would still be the default sample value. Resolve it after the
+    // initConfigCompleter await below.
+    final String? loginToken;
+    final String? homeserverFromRoute;
+
+    if (PlatformInfos.isWeb) {
+      loginToken = getQueryParameter('loginToken');
+      homeserverFromRoute = null;
+    } else {
+      final routeParams = GoRouterState.of(context).uri.queryParameters;
+      loginToken = routeParams['loginToken'];
+      homeserverFromRoute = routeParams['homeserver'];
+    }
+
+    if (loginToken == null || loginToken.isEmpty) {
+      _handleLoginError(
+        Exception('tryLoggingUsingToken(): Missing loginToken'),
+        StackTrace.current,
+      );
+      return;
+    }
+
     try {
       final isConfigured = await AppConfig.initConfigCompleter.future;
       if (!isConfigured) {
@@ -83,20 +113,29 @@ class _OnAuthRedirectState extends State<OnAuthRedirect> with ConnectPageMixin {
         } else {
           throw Exception('tryLoggingUsingToken(): Config not found');
         }
-      }
-      final homeserver = AppConfig.homeserver;
-      if (!homeserverIsConfigured) {
-        throw Exception('tryLoggingUsingToken(): Missing homeserver');
+        return;
       }
 
-      final loginToken = getQueryParameter('loginToken');
-      if (loginToken == null || loginToken.isEmpty) {
-        throw Exception('tryLoggingUsingToken(): Missing loginToken');
+      // Resolve homeserver AFTER initConfig: AppConfig.homeserver is now populated.
+      // Route param takes precedence (tests, non-standard deployments);
+      // fallback to AppConfig for standard mobile SSO where the deep link omits it.
+      final homeserver =
+          homeserverFromRoute ??
+          (homeserverIsConfigured ? AppConfig.homeserver : '');
+
+      if (homeserver.isEmpty) {
+        _handleLoginError(
+          Exception('tryLoggingUsingToken(): Missing homeserver'),
+          StackTrace.current,
+        );
+        return;
       }
-      Logs().i('tryLoggingUsingToken::loginToken: $loginToken');
+
+      if (!context.mounted) return;
       Logs().i('tryLoggingUsingToken::homeserver: $homeserver');
       Matrix.of(context).loginType = LoginType.mLoginToken;
       final client = await Matrix.of(context).getLoginClient();
+      if (!context.mounted) return;
       Matrix.of(context).loginHomeserverSummary = await client
           .checkHomeserver(Uri.parse(homeserver))
           .toHomeserverSummary();

--- a/lib/presentation/mixins/init_config_mixin.dart
+++ b/lib/presentation/mixins/init_config_mixin.dart
@@ -33,10 +33,15 @@ mixin InitConfigMixin {
   }
 
   Future<void> initConfigMobile() async {
+    var isConfigured = true;
     try {
       AppConfig.loadEnvironment();
     } catch (e) {
+      isConfigured = false;
       Logs().e('[ConfigLoader] Config mobile error', e);
+    }
+    if (!AppConfig.initConfigCompleter.isCompleted) {
+      AppConfig.initConfigCompleter.complete(isConfigured);
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  adb:
+    dependency: transitive
+    description:
+      name: adb
+      sha256: "1be1de29cdf3877d6ecd8f1fa6e1182edd40672578eaa14b505fb71f01b5a571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   after_layout:
     dependency: "direct main"
     description:
@@ -49,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.11"
+  ansi_styles:
+    dependency: transitive
+    description:
+      name: ansi_styles
+      sha256: "9c656cc12b3c27b17dd982b2cc5c0cfdfbdabd7bc8f3ae5e8542d9867b47ce8a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2+1"
   ansicolor:
     dependency: transitive
     description:
@@ -301,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -329,6 +345,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.8.1"
+  ci:
+    dependency: transitive
+    description:
+      name: ci
+      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
+  cli_completion:
+    dependency: transitive
+    description:
+      name: cli_completion
+      sha256: "1e87700c029c77041d836e57f9016b5c90d353151c43c2ca0c36deaadc05aa3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   cli_config:
     dependency: transitive
     description:
@@ -405,10 +437,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "802bd084fb82e55df091ec8ad1553a7331b61c08251eef19a508b6f3f3a9858d"
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.13.1"
+    version: "1.15.0"
   cross_file:
     dependency: transitive
     description:
@@ -1848,22 +1880,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.2.2"
+  mason_logger:
+    dependency: transitive
+    description:
+      name: mason_logger
+      sha256: "1fdf5c76870eb6fc3611ed6fbae1973a3794abe581ea5e22e68af2f73c688b93"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.16"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   matrix:
     dependency: "direct main"
     description:
@@ -2064,10 +2104,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   package_info_plus:
     dependency: "direct main"
     description:
@@ -2156,6 +2196,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.18.0"
+  patrol_cli:
+    dependency: "direct dev"
+    description:
+      name: patrol_cli
+      sha256: dc76af0b1cfe5b30ea778fc996149b8405fc411a0cff565586e4ce56a12e9f00
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.11.0"
   patrol_finders:
     dependency: transitive
     description:
@@ -2380,6 +2428,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  pub_updater:
+    dependency: transitive
+    description:
+      name: pub_updater
+      sha256: "54e8dc865349059ebe7f163d6acce7c89eb958b8047e6d6e80ce93b13d7c9e60"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   pubspec_parse:
     dependency: transitive
     description:
@@ -2920,18 +2976,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.14"
   timezone:
     dependency: transitive
     description:
@@ -3164,6 +3220,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  version:
+    dependency: transitive
+    description:
+      name: version
+      sha256: "3d4140128e6ea10d83da32fef2fa4003fccbf6852217bb854845802f04191f94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   vibration:
     dependency: "direct main"
     description:
@@ -3403,10 +3467,10 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "3.1.3"
 sdks:
   dart: ">=3.10.4 <4.0.0"
   flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -235,6 +235,7 @@ dev_dependencies:
   mockito: 5.6.3
   patrol: 3.18.0
   html: ^0.15.4
+  patrol_cli: ^3.11.0
 
 flutter_launcher_icons:
   android: false


### PR DESCRIPTION
## Problem

The integration test login was brittle:
- Depended on the **device locale** (button labels like "Continue", "Continuer"…)
- Required navigating the **LemonLDAP browser modal** via native taps — fragile and slow
- Difficult to debug when the SSO portal changed its response structure (missing cookie, consent page, etc.)

## Solution

Replace the browser-based SSO flow with a **headless HTTP OIDC flow** that runs entirely via `dart:io` HttpClient, then feeds the resulting `loginToken` directly to the app.

## Changes

- **`core_robot.dart`** — Extract `getLoginTokenViaOIDC(username, password)`: runs all 7 OIDC steps over HTTP including `lemonldappdata` cookie forwarding and consent-page fallback. Returns `(loginToken, lemonldap)`.
- **`login_robot.dart`** — Add `loginViaApi()`: calls the OIDC helper then navigates via `TwakeApp.router.go('/onAuthRedirect?loginToken=…&homeserver=…')`, bypassing `app_links` entirely.
- **`login_scenario.dart`** — Reduce `login()` to a single `loginViaApi()` call; removes fragile UI steps.
- **`on_auth_redirect.dart`** — Read `GoRouterState` params synchronously before any `await` (inherited widget anti-pattern fix), add `mounted` guards, support `homeserver` as query param.
- **`init_config_mixin.dart`** — Ensure `initConfigCompleter` is always completed even on config fetch error.
- **`pubspec.yaml`** — Add `patrol_cli` dev dependency.

## Test example

https://github.com/user-attachments/assets/cce9c999-000a-4f36-9a54-e466077185eb



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP server configurations (Chrome DevTools, Flutter Inspector, patrol) via a new .mcp.json.

* **Bug Fixes**
  * Prevented navigation/state updates after widget disposal for more stable login.
  * Improved app initialization and homeserver validation on mobile to avoid startup hangs.
  * Enhanced OIDC token extraction and error reporting during API login.

* **Tests**
  * Added an API-based login path and hardened OIDC/login tests; improved UI scroll and iOS confirmation handling.

* **Chores**
  * Added patrol_cli to dev dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->