### PR TITLE
fix: replace FluffyChat deep link prefix with Twake scheme

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -119,7 +119,7 @@ abstract class AppConfig {
   static const bool hideTypingUsernames = false;
   static const bool hideAllStateEvents = false;
   static const String inviteLinkPrefix = 'https://matrix.to/#/';
-  static const String deepLinkPrefix = 'im.fluffychat://chat/';
+  static const String deepLinkPrefix = 'twake.chat://chat/';
   static const String httpAppLinkUniversalLinkPrefix =
       'http://${AppConstants.appLinkUniversalLinkDomain}/';
   static const String httpsAppLinkUniversalLinkPrefix =


### PR DESCRIPTION
## Problem

`AppConfig.deepLinkPrefix` was set to `'im.fluffychat://chat/'`, inherited from the FluffyChat fork. This scheme is **not registered** in `ios/Runner/Info.plist` or `AndroidManifest.xml`, so any incoming room deep link using this format (`im.fluffychat://chat/!roomid:server`) would be silently ignored by the OS — the app would never open.

This affects:
- `url_launcher.dart` — detection of in-app routable links
- `receive_sharing_intent_mixin.dart` — detection of shared room links

## Fix

Replace with `'twake.chat://chat/'`. The `twake.chat` scheme is already declared in both native manifests, so no config changes are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the deep link URL scheme for accessing chats via external links and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->