### PR TITLE
TW-2988: Fix emoji display logic to exclude replies

### DIFF
--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -265,8 +265,13 @@ extension LocalizedBody on Event {
     return isAttachmentEncrypted;
   }
 
+  /// Returns true if message contains only 1-6 emojis and is not a reply.
+  /// Used to display emoji in enlarged size.
   bool isDisplayOnlyEmoji() {
-    return onlyEmotes && numberEmotes > 0 && numberEmotes < 7;
+    return !isReplyEvent() &&
+        onlyEmotes &&
+        numberEmotes > 0 &&
+        numberEmotes < 7;
   }
 
   TextStyle? textStyleForOnlyEmoji(BuildContext context) {

--- a/test/pages/chat/events/event_extension_test.dart
+++ b/test/pages/chat/events/event_extension_test.dart
@@ -918,4 +918,160 @@ void main() {
       expect(event.isReplyEventWithAudio(), false);
     });
   });
+
+  group('isDisplayOnlyEmoji test', () {
+    late Client client;
+    late Room room;
+
+    setUpAll(() async {
+      client = await getClient();
+      room = Room(
+        client: client,
+        id: '!test:example.com',
+        membership: Membership.join,
+      );
+    });
+
+    Event createEmojiEvent({
+      required String body,
+      String eventId = '\$event1',
+      String senderId = '@user:example.com',
+      Map<String, dynamic>? relatesTo,
+    }) {
+      return Event(
+        senderId: senderId,
+        type: 'm.room.message',
+        room: room,
+        eventId: eventId,
+        content: {
+          'body': body,
+          'msgtype': 'm.text',
+          if (relatesTo != null) 'm.relates_to': relatesTo,
+        },
+        originServerTs: DateTime.fromMillisecondsSinceEpoch(1234567890),
+      );
+    }
+
+    test('GIVEN message with single emoji\n'
+        'AND NOT a reply\n'
+        'THEN return true\n', () {
+      final event = createEmojiEvent(body: '😊');
+
+      expect(event.isDisplayOnlyEmoji(), true);
+    });
+
+    test('GIVEN message with 2 emojis\n'
+        'AND NOT a reply\n'
+        'THEN return true\n', () {
+      final event = createEmojiEvent(body: '😊😎');
+
+      expect(event.isDisplayOnlyEmoji(), true);
+    });
+
+    test('GIVEN message with 3 emojis\n'
+        'AND NOT a reply\n'
+        'THEN return true\n', () {
+      final event = createEmojiEvent(body: '😊😎🎉');
+
+      expect(event.isDisplayOnlyEmoji(), true);
+    });
+
+    test('GIVEN message with 4 emojis\n'
+        'AND NOT a reply\n'
+        'THEN return true\n', () {
+      final event = createEmojiEvent(body: '😊😎🎉🔥');
+
+      expect(event.isDisplayOnlyEmoji(), true);
+    });
+
+    test('GIVEN message with 5 emojis\n'
+        'AND NOT a reply\n'
+        'THEN return true\n', () {
+      final event = createEmojiEvent(body: '😊😎🎉🔥❤️');
+
+      expect(event.isDisplayOnlyEmoji(), true);
+    });
+
+    test('GIVEN message with 6 emojis\n'
+        'AND NOT a reply\n'
+        'THEN return true\n', () {
+      final event = createEmojiEvent(body: '😊😎🎉🔥❤️👍');
+
+      expect(event.isDisplayOnlyEmoji(), true);
+    });
+
+    test('GIVEN message with 7 emojis\n'
+        'AND NOT a reply\n'
+        'THEN return false (exceeds limit)\n', () {
+      final event = createEmojiEvent(body: '😊😎🎉🔥❤️👍✨');
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+
+    test('GIVEN message with 10 emojis\n'
+        'AND NOT a reply\n'
+        'THEN return false (exceeds limit)\n', () {
+      final event = createEmojiEvent(body: '😊😎🎉🔥❤️👍✨🌟💯🚀');
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+
+    test('GIVEN message with single emoji\n'
+        'BUT is a reply event\n'
+        'THEN return false\n', () {
+      final event = createEmojiEvent(
+        body: '😊',
+        relatesTo: {
+          'm.in_reply_to': {'event_id': '\$original_event'},
+        },
+      );
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+
+    test('GIVEN message with 3 emojis\n'
+        'BUT is a reply event\n'
+        'THEN return false\n', () {
+      final event = createEmojiEvent(
+        body: '😊😎🎉',
+        relatesTo: {
+          'm.in_reply_to': {'event_id': '\$original_event'},
+        },
+      );
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+
+    test('GIVEN message with text and emoji\n'
+        'AND NOT a reply\n'
+        'THEN return false\n', () {
+      final event = createEmojiEvent(body: 'Hello 😊');
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+
+    test('GIVEN message with emoji and text\n'
+        'AND NOT a reply\n'
+        'THEN return false\n', () {
+      final event = createEmojiEvent(body: '😊 world');
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+
+    test('GIVEN plain text message with no emoji\n'
+        'AND NOT a reply\n'
+        'THEN return false\n', () {
+      final event = createEmojiEvent(body: 'Hello world');
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+
+    test('GIVEN empty message\n'
+        'AND NOT a reply\n'
+        'THEN return false\n', () {
+      final event = createEmojiEvent(body: '');
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+  });
 }

--- a/test/pages/chat/events/event_extension_test.dart
+++ b/test/pages/chat/events/event_extension_test.dart
@@ -952,69 +952,34 @@ void main() {
       );
     }
 
-    test('GIVEN message with single emoji\n'
-        'AND NOT a reply\n'
-        'THEN return true\n', () {
-      final event = createEmojiEvent(body: '😊');
+    final validEmojiBodies = <String>[
+      '😊',
+      '😊😎',
+      '😊😎🎉',
+      '😊😎🎉🔥',
+      '😊😎🎉🔥❤️',
+      '😊😎🎉🔥❤️👍',
+    ];
+    for (final body in validEmojiBodies) {
+      test(
+        'GIVEN ${body.runes.length} emojis AND NOT a reply THEN return true',
+        () {
+          final event = createEmojiEvent(body: body);
+          expect(event.isDisplayOnlyEmoji(), isTrue);
+        },
+      );
+    }
 
-      expect(event.isDisplayOnlyEmoji(), true);
-    });
-
-    test('GIVEN message with 2 emojis\n'
-        'AND NOT a reply\n'
-        'THEN return true\n', () {
-      final event = createEmojiEvent(body: '😊😎');
-
-      expect(event.isDisplayOnlyEmoji(), true);
-    });
-
-    test('GIVEN message with 3 emojis\n'
-        'AND NOT a reply\n'
-        'THEN return true\n', () {
-      final event = createEmojiEvent(body: '😊😎🎉');
-
-      expect(event.isDisplayOnlyEmoji(), true);
-    });
-
-    test('GIVEN message with 4 emojis\n'
-        'AND NOT a reply\n'
-        'THEN return true\n', () {
-      final event = createEmojiEvent(body: '😊😎🎉🔥');
-
-      expect(event.isDisplayOnlyEmoji(), true);
-    });
-
-    test('GIVEN message with 5 emojis\n'
-        'AND NOT a reply\n'
-        'THEN return true\n', () {
-      final event = createEmojiEvent(body: '😊😎🎉🔥❤️');
-
-      expect(event.isDisplayOnlyEmoji(), true);
-    });
-
-    test('GIVEN message with 6 emojis\n'
-        'AND NOT a reply\n'
-        'THEN return true\n', () {
-      final event = createEmojiEvent(body: '😊😎🎉🔥❤️👍');
-
-      expect(event.isDisplayOnlyEmoji(), true);
-    });
-
-    test('GIVEN message with 7 emojis\n'
-        'AND NOT a reply\n'
-        'THEN return false (exceeds limit)\n', () {
-      final event = createEmojiEvent(body: '😊😎🎉🔥❤️👍✨');
-
-      expect(event.isDisplayOnlyEmoji(), false);
-    });
-
-    test('GIVEN message with 10 emojis\n'
-        'AND NOT a reply\n'
-        'THEN return false (exceeds limit)\n', () {
-      final event = createEmojiEvent(body: '😊😎🎉🔥❤️👍✨🌟💯🚀');
-
-      expect(event.isDisplayOnlyEmoji(), false);
-    });
+    final invalidEmojiBodies = <String>['😊😎🎉🔥❤️👍✨', '😊😎🎉🔥❤️👍✨🌟💯🚀'];
+    for (final body in invalidEmojiBodies) {
+      test(
+        'GIVEN ${body.runes.length} emojis AND NOT a reply THEN return false',
+        () {
+          final event = createEmojiEvent(body: body);
+          expect(event.isDisplayOnlyEmoji(), isFalse);
+        },
+      );
+    }
 
     test('GIVEN message with single emoji\n'
         'BUT is a reply event\n'


### PR DESCRIPTION
## Ticket
**Related issue**

- #2988

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-04-06 at 16 52 40" src="https://github.com/user-attachments/assets/b2b063a0-dbf4-4970-8715-f38511682576" />

https://github.com/user-attachments/assets/f5e824a4-21a5-4b6a-b756-ef83173dec65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect handling of reply messages containing only emojis, which are no longer treated as display-only emoji messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->