### PR TITLE
fix: timeline incorrectly shows message as unread

### DIFF
--- a/lib/utils/room_status_extension.dart
+++ b/lib/utils/room_status_extension.dart
@@ -1,7 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
-import 'package:fluffychat/utils/string_extension.dart';
 import 'package:flutter/widgets.dart';
 import 'package:matrix/matrix.dart';
 
@@ -57,32 +56,16 @@ extension RoomStatusExtension on Room {
     if (timeline.events.isEmpty) return [];
     eventId ??= timeline.events.first.eventId;
 
-    final lastReceipts = <User>{};
+    final targetIndex = timeline.events.indexWhere((e) => e.eventId == eventId);
+    if (targetIndex == -1) return [];
 
-    if (receiptState.mainThread != null) {
-      // receiptState contains all users and their last seen event
-      // we checked users that have seen the eventId argument or older
-      final mainThreadReceipts = receiptState.mainThread!.otherUsers.entries
-          .where(
-            (element) => element.value.eventId.isEventIdOlderOrSameAs(
-              timeline,
-              eventId!,
-            ),
-          )
-          .map((e) => unsafeGetUserFromMemoryOrFallback(e.key))
-          .toList();
-      lastReceipts.addAll(mainThreadReceipts);
-    } else {
-      // now we iterate the timeline events until we hit the first rendered event
-      for (final event in timeline.events) {
-        lastReceipts.addAll(event.receipts.map((r) => r.user));
-        if (event.eventId == eventId) {
-          break;
-        }
-      }
-      /* Remove the current user from the receipts list, as we don't want to show that the current user
-      has seen their own message. Because sender always sees their own message.  */
-      lastReceipts.removeWhere((user) => user.id == client.userID);
+    final lastReceipts = <User>{};
+    for (final event in timeline.events.take(targetIndex + 1)) {
+      lastReceipts.addAll(
+        event.receipts
+            .where((r) => r.user.id != client.userID)
+            .map((r) => r.user),
+      );
     }
     return lastReceipts.toList();
   }

--- a/test/utils/room_status_extension_test.dart
+++ b/test/utils/room_status_extension_test.dart
@@ -6,8 +6,150 @@ import 'package:mockito/mockito.dart';
 
 import 'room_status_extension_test.mocks.dart';
 
-@GenerateNiceMocks([MockSpec<Room>(), MockSpec<Event>(), MockSpec<Client>()])
+@GenerateNiceMocks([
+  MockSpec<Room>(),
+  MockSpec<Event>(),
+  MockSpec<Client>(),
+  MockSpec<Timeline>(),
+])
 void main() {
+  group('getSeenByUsers', () {
+    late MockRoom mockRoom;
+    late MockClient mockClient;
+    late MockTimeline mockTimeline;
+
+    const ownUserId = '@me:example.com';
+    const otherUserId = '@other:example.com';
+
+    MockEvent createEvent(String eventId, List<Receipt> receipts) {
+      final event = MockEvent();
+      when(event.eventId).thenReturn(eventId);
+      when(event.receipts).thenReturn(receipts);
+      return event;
+    }
+
+    setUp(() {
+      mockRoom = MockRoom();
+      mockClient = MockClient();
+      mockTimeline = MockTimeline();
+
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockClient.userID).thenReturn(ownUserId);
+    });
+
+    test('returns empty list when timeline is empty', () {
+      when(mockTimeline.events).thenReturn([]);
+
+      expect(mockRoom.getSeenByUsers(mockTimeline), isEmpty);
+    });
+
+    test('returns empty list when only own user has receipts', () {
+      final ownUser = MockUser(ownUserId);
+      final event = createEvent('ev1', [Receipt(ownUser, DateTime.now())]);
+      when(mockTimeline.events).thenReturn([event]);
+
+      expect(mockRoom.getSeenByUsers(mockTimeline), isEmpty);
+    });
+
+    test('returns other user who has receipt on latest event', () {
+      final otherUser = MockUser(otherUserId);
+      final event = createEvent('ev1', [Receipt(otherUser, DateTime.now())]);
+      when(mockTimeline.events).thenReturn([event]);
+
+      final result = mockRoom.getSeenByUsers(mockTimeline);
+      expect(result, hasLength(1));
+      expect(result.first.id, otherUserId);
+    });
+
+    test('accumulates receipts from newer events down to target', () {
+      final user1 = MockUser('@a:example.com');
+      final user2 = MockUser('@b:example.com');
+
+      final newest = createEvent('ev1', [Receipt(user1, DateTime.now())]);
+      final target = createEvent('ev2', [Receipt(user2, DateTime.now())]);
+      final older = createEvent('ev3', []);
+
+      when(mockTimeline.events).thenReturn([newest, target, older]);
+
+      final result = mockRoom.getSeenByUsers(mockTimeline, eventId: 'ev2');
+      expect(
+        result.map((u) => u.id),
+        containsAll(['@a:example.com', '@b:example.com']),
+      );
+    });
+
+    test('does not include receipts from events older than target', () {
+      final user1 = MockUser('@a:example.com');
+      final user2 = MockUser('@b:example.com');
+
+      final newest = createEvent('ev1', [Receipt(user1, DateTime.now())]);
+      final target = createEvent('ev2', []);
+      final older = createEvent('ev3', [Receipt(user2, DateTime.now())]);
+
+      when(mockTimeline.events).thenReturn([newest, target, older]);
+
+      final result = mockRoom.getSeenByUsers(mockTimeline, eventId: 'ev2');
+      expect(result.map((u) => u.id), contains('@a:example.com'));
+      expect(result.map((u) => u.id), isNot(contains('@b:example.com')));
+    });
+
+    test(
+      'uses timeline receipts progression when target has no direct receipt',
+      () {
+        final user1 = MockUser('@a:example.com');
+        final user2 = MockUser('@b:example.com');
+        final user3 = MockUser('@c:example.com');
+
+        final newest = createEvent('ev1', [Receipt(user1, DateTime.now())]);
+        final beforeTarget = createEvent('ev2', [
+          Receipt(user2, DateTime.now()),
+        ]);
+        final target = createEvent('ev3', []);
+        final older = createEvent('ev4', [Receipt(user3, DateTime.now())]);
+
+        when(
+          mockTimeline.events,
+        ).thenReturn([newest, beforeTarget, target, older]);
+
+        final result = mockRoom.getSeenByUsers(mockTimeline, eventId: 'ev3');
+        expect(
+          result.map((u) => u.id),
+          containsAll(['@a:example.com', '@b:example.com']),
+        );
+        expect(result.map((u) => u.id), isNot(contains('@c:example.com')));
+      },
+    );
+
+    test('returns empty list when target eventId is not found in timeline', () {
+      final user1 = MockUser('@a:example.com');
+      final user2 = MockUser('@b:example.com');
+
+      final event1 = createEvent('ev1', [Receipt(user1, DateTime.now())]);
+      final event2 = createEvent('ev2', [Receipt(user2, DateTime.now())]);
+      when(mockTimeline.events).thenReturn([event1, event2]);
+
+      expect(
+        mockRoom.getSeenByUsers(mockTimeline, eventId: 'ev-unknown'),
+        isEmpty,
+      );
+    });
+
+    test('excludes own user from results even with mixed receipts', () {
+      final ownUser = MockUser(ownUserId);
+      final otherUser = MockUser(otherUserId);
+
+      final event = createEvent('ev1', [
+        Receipt(ownUser, DateTime.now()),
+        Receipt(otherUser, DateTime.now()),
+      ]);
+      when(mockTimeline.events).thenReturn([event]);
+
+      final result = mockRoom.getSeenByUsers(mockTimeline);
+      expect(result, hasLength(1));
+      expect(result.first.id, otherUserId);
+    });
+  });
+
   group('hasLastEventBeenSeenByOthers', () {
     late MockRoom mockRoom;
     late MockEvent mockEvent;


### PR DESCRIPTION
## Root cause
getSeenByUsers had split logic paths (depending on receiptState.**mainThread**) and could derive seen/unseen status inconsistently from timeline receipts.
That could mark timeline items as unread even when receipts indicated they had been read.

<img width="661" height="317" alt="2991-debug-0" src="https://github.com/user-attachments/assets/5dadf1f6-7185-4021-b653-1d6f668ca21b" />

According to Matrix, read markers should be interpreted consistently from receipt progression (including threaded semantics where applicable). With threads, read progression is scoped by context (thread_id), so we must evaluate receipts in all scopes (main timeline vs a specific thread), or you can show inconsistent states.


## Solution
- Simplified getSeenByUsers in lib/utils/room_status_extension.dart to a single deterministic flow:
  - iterate timeline events down to the target eventId
  - aggregate receipts only within that range
  - exclude the current user directly during aggregation
- Removed now-unused import.
- Added/expanded tests in test/utils/room_status_extension_test.dart for:
  - empty timeline
  - own-user-only receipts
  - latest-event receipts
  - accumulation up to target event
  - exclusion of receipts older than target
  - mixed receipts where own user must be filtered out

## Demos
### Web
First window: Hosted Staging / Second: Local Staging with fix

https://github.com/user-attachments/assets/a0429db5-54ad-4714-8b08-1326212599ec


### Mobile
Left: Hosted Staging / Right: Local Staging with fix

https://github.com/user-attachments/assets/43e84014-bd5c-49c0-a8ba-3330d152c08f


## Test recommendations

- Run unit tests for room_status_extension.
- Manual verification in timeline UI:
  - messages with other-user receipts are no longer incorrectly shown unread
  - own user is not included in “seen by” users
  - behavior is correct when a specific eventId is provided.
- Validate in rooms with different timeline depths to ensure no regression.
- Chat with an other client (ie. element) in a thread, read the message and come back to Twake Chat: message is "unread".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate determination of who has seen a message by limiting receipt aggregation to events up to the specified message and correctly excluding the current user from results.
  * Returns empty results when the target message isn't found.

* **Tests**
  * Added thorough tests covering empty timelines, own-only receipts, multi-event accumulation, missing target message, and filtering out the current user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->