### PR TITLE
HOTFIX Disoriented notification avatar

### DIFF
--- a/ios/NSE/Provider/ImageProviderProtocol.swift
+++ b/ios/NSE/Provider/ImageProviderProtocol.swift
@@ -22,6 +22,8 @@ protocol ImageProviderProtocol {
     func loadImageFromSource(_ source: MediaSourceProxy, size: CGSize?) async -> Result<UIImage, MediaProviderError>
     
     func loadImageDataFromSource(_ source: MediaSourceProxy) async -> Result<Data, MediaProviderError>
+
+    func loadThumbnailForSource(_ source: MediaSourceProxy, size: CGSize) async -> Result<Data, MediaProviderError>
 }
 
 extension ImageProviderProtocol {

--- a/ios/NSE/Provider/MediaProvider.swift
+++ b/ios/NSE/Provider/MediaProvider.swift
@@ -89,6 +89,16 @@ struct MediaProvider: MediaProviderProtocol {
         }
     }
     
+    func loadThumbnailForSource(_ source: MediaSourceProxy, size: CGSize) async -> Result<Data, MediaProviderError> {
+        do {
+            let data = try await mediaLoader.loadMediaThumbnailForSource(source, width: UInt(size.width), height: UInt(size.height))
+            return .success(data)
+        } catch {
+            MXLog.error("Failed retrieving thumbnail with error: \(error)")
+            return .failure(.failedRetrievingImage)
+        }
+    }
+
     // MARK: Files
     
     func loadFileFromSource(_ source: MediaSourceProxy, body: String?) async -> Result<MediaFileHandleProxy, MediaProviderError> {

--- a/ios/NSE/Provider/MockMediaProvider.swift
+++ b/ios/NSE/Provider/MockMediaProvider.swift
@@ -47,6 +47,14 @@ struct MockMediaProvider: MediaProviderProtocol {
         return .success(data)
     }
     
+    func loadThumbnailForSource(_ source: MediaSourceProxy, size: CGSize) async -> Result<Data, MediaProviderError> {
+        guard let image = UIImage(systemName: "photo"),
+              let data = image.pngData() else {
+            fatalError()
+        }
+        return .success(data)
+    }
+
     func loadFileFromSource(_ source: MediaSourceProxy, body: String?) async -> Result<MediaFileHandleProxy, MediaProviderError> {
         .failure(.failedRetrievingFile)
     }

--- a/ios/NSE/Sources/Other/NSEUserSession.swift
+++ b/ios/NSE/Sources/Other/NSEUserSession.swift
@@ -65,7 +65,7 @@ final class NSEUserSession {
         var proxy: NotificationItemProxyProtocol? = await fetchNotificationItem(roomID: roomID, eventID: eventID)
         if let proxy, !proxy.isEncrypted { return proxy }
 
-        for attempt in 0..<2 {
+        for attempt in 0..<3 {
             let delaySeconds = 1 << attempt
             MXLog.info("NSE: Notification is \(proxy == nil ? "nil" : "encrypted"), retrying in \(delaySeconds)s (attempt \(attempt)) - roomID: \(roomID)")
             try? await Task.sleep(nanoseconds: UInt64(delaySeconds) * 1_000_000_000)

--- a/ios/NSE/UNNotificationContent.swift
+++ b/ios/NSE/UNNotificationContent.swift
@@ -113,9 +113,10 @@ extension UNMutableNotificationContent {
         var fetchedImage: INImage?
         let image: INImage
         if let mediaSource = icon.mediaSource {
-            switch await mediaProvider?.loadImageDataFromSource(mediaSource) {
-            case .success(let data):
-                fetchedImage = INImage(imageData: data)
+            let avatarSize = CGSize(width: 50, height: 50)
+            switch await mediaProvider?.loadImageFromSource(mediaSource, size: avatarSize) {
+            case .success(let uiImage):
+                fetchedImage = uiImage.pngData().map { INImage(imageData: $0) }
             case .failure(let error):
                 MXLog.error("Couldn't add sender icon: \(error)")
                 // ...The provider failed to fetch

--- a/ios/NSE/UNNotificationContent.swift
+++ b/ios/NSE/UNNotificationContent.swift
@@ -19,8 +19,6 @@ import Intents
 import SwiftUI
 import UserNotifications
 
-import Version
-
 struct NotificationIcon {
     struct GroupInfo {
         let name: String
@@ -113,10 +111,9 @@ extension UNMutableNotificationContent {
         var fetchedImage: INImage?
         let image: INImage
         if let mediaSource = icon.mediaSource {
-            let avatarSize = CGSize(width: 50, height: 50)
-            switch await mediaProvider?.loadImageFromSource(mediaSource, size: avatarSize) {
-            case .success(let uiImage):
-                fetchedImage = uiImage.pngData().map { INImage(imageData: $0) }
+            switch await mediaProvider?.loadThumbnailForSource(mediaSource, size: CGSize(width: 50, height: 50)) {
+            case .success(let data):
+                fetchedImage = INImage(imageData: data)
             case .failure(let error):
                 MXLog.error("Couldn't add sender icon: \(error)")
                 // ...The provider failed to fetch
@@ -186,10 +183,10 @@ extension UNMutableNotificationContent {
         return updatedContent.mutableCopy() as! UNMutableNotificationContent
     }
 
+    @MainActor
     private func getPlaceholderAvatarImageData(name: String, id: String) async -> Data? {
         // The version value is used in case the design of the placeholder is updated to force a replacement
-        let isIOS17Available = isIOS17Available()
-        let prefix = "notification_placeholder\(isIOS17Available ? "V3" : "V2")"
+        let prefix = "notification_placeholderV4"
         let fileName = "\(prefix)_\(name)_\(id).png"
         if let data = try? Data(contentsOf: URL.temporaryDirectory.appendingPathComponent(fileName)) {
             MXLog.info("Found existing notification icon placeholder")
@@ -201,24 +198,18 @@ extension UNMutableNotificationContent {
                                            contentID: id)
             .clipShape(Circle())
             .frame(width: 50, height: 50)
-        let renderer = await ImageRenderer(content: image)
-        guard let image = await renderer.uiImage else {
+        let renderer = ImageRenderer(content: image)
+
+        // Specify the scale so the image is rendered correctly. We don't have access to the screen
+        // here so a hardcoded 3.0 will have to do.
+        renderer.scale = 3.0
+
+        guard let image = renderer.uiImage else {
             MXLog.info("Generating notification icon placeholder failed")
             return nil
         }
 
-        let data: Data?
-        // On simulator and macOS the image is rendered correctly
-        // But on other devices before iOS 17 is rendered upside down so we need to flip it
-        #if targetEnvironment(simulator)
-        data = image.pngData()
-        #else
-        if ProcessInfo.processInfo.isiOSAppOnMac || isIOS17Available {
-            data = image.pngData()
-        } else {
-            data = image.flippedVertically().pngData()
-        }
-        #endif
+        let data = image.pngData()
 
         if let data {
             do {
@@ -231,23 +222,5 @@ extension UNMutableNotificationContent {
         }
         return data
     }
-    
-    private func isIOS17Available() -> Bool {
-        guard let version = Version(UIDevice.current.systemVersion) else {
-            return false
-        }
-        
-        return version.major >= 17
-    }
 }
 
-private extension UIImage {
-    func flippedVertically() -> UIImage {
-        let format = UIGraphicsImageRendererFormat()
-        format.scale = scale
-        return UIGraphicsImageRenderer(size: size, format: format).image { context in
-            context.cgContext.concatenate(CGAffineTransform(scaleX: 1, y: -1))
-            self.draw(at: CGPoint(x: 0, y: -size.height))
-        }
-    }
-}


### PR DESCRIPTION
## Ticket
Avatar of notifications are disoriented.

## Root cause

<img width="473" height="344" alt="Screenshot 2026-04-08 at 15 40 16" src="https://github.com/user-attachments/assets/aedd681e-af24-4667-b995-72608d9034ca" />


### Image avatar
```swift
fetchedImage = INImage(imageData: data)
```
`INImage(imageData:)` uses raw bytes directly. JPEG images embed rotation in EXIF metadata, but INImage ignores it — so photos taken in portrait mode (or any non-landscape orientation) appear rotated.

### Text avatar
```swift
let data: Data?
// On simulator and macOS the image is rendered correctly
// But on other devices before iOS 17 is rendered upside down so we need to flip it
#if targetEnvironment(simulator)
data = image.pngData()
#else
if ProcessInfo.processInfo.isiOSAppOnMac || isIOS17Available {
    data = image.pngData()
} else {
    data = image.flippedVertically().pngData()
}
#endif
```
The code which flips the text avatar up-side down. However, for some reason, on iOS 26.4 (not reproducible on 26.3 or below), it was flipped too.

## Solution
### Image avatar
Follow element-x ios, use get thumbnail data instead.

### Text avatar
No solution yet.


### Demo


<img width="473" height="344" alt="image" src="https://github.com/user-attachments/assets/0711fc95-2ec0-44ba-b458-2a2c13de1630" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added thumbnail loading capability for media content.

* **Bug Fixes**
  * Enhanced notification reliability with improved retry mechanism.
  * Optimized notification icon fetching and display handling.

* **Performance**
  * Notification icons now load faster using optimized thumbnails instead of full-size images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->