### PR TITLE
refactor: extract duplicated event-type sets into EventTypeSets

### DIFF
--- a/lib/domain/matrix_events/event_type_sets.dart
+++ b/lib/domain/matrix_events/event_type_sets.dart
@@ -1,0 +1,36 @@
+import 'package:matrix/matrix.dart';
+
+/// Canonical event-type sets used for filtering, grouping and display.
+abstract final class EventTypeSets {
+  /// Message-like types: messages, stickers, encrypted payloads.
+  static const Set<String> messageContentTypes = {
+    EventTypes.Message,
+    EventTypes.Sticker,
+    EventTypes.Encrypted,
+  };
+
+  static const List<String> messageContentTypesList = [
+    EventTypes.Message,
+    EventTypes.Sticker,
+    EventTypes.Encrypted,
+  ];
+
+  /// [messageContentTypes] + signalling types produced by users (calls).
+  static const Set<String> userContentTypes = {
+    EventTypes.Message,
+    EventTypes.Sticker,
+    EventTypes.Encrypted,
+    EventTypes.CallInvite,
+  };
+
+  /// State events kept visible when "hide unimportant state events" is on.
+  static const Set<String> importantStateEvents = {
+    EventTypes.Encryption,
+    EventTypes.RoomCreate,
+    EventTypes.RoomMember,
+    EventTypes.RoomTombstone,
+    EventTypes.CallInvite,
+    EventTypes.RoomName,
+    EventTypes.RoomAvatar,
+  };
+}

--- a/lib/domain/model/room/room_extension.dart
+++ b/lib/domain/model/room/room_extension.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/default_power_level_member.dart';
+import 'package:fluffychat/domain/matrix_events/event_type_sets.dart';
 import 'package:fluffychat/data/network/extensions/file_info_extension.dart';
 import 'package:fluffychat/domain/model/file_info/file_info.dart';
 import 'package:fluffychat/domain/model/search/recent_chat_model.dart';
@@ -40,11 +41,7 @@ extension RoomExtension on Room {
   }
 
   bool _isLastEventInRoomIsMessage() {
-    return [
-      EventTypes.Message,
-      EventTypes.Sticker,
-      EventTypes.Encrypted,
-    ].contains(lastEvent?.type);
+    return EventTypeSets.messageContentTypes.contains(lastEvent?.type);
   }
 
   Future<void> mute() async {

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -8,6 +8,7 @@ import 'package:desktop_drop/desktop_drop.dart';
 import 'package:fluffychat/app_state/failure.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/domain/matrix_events/event_type_sets.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/domain/app_state/room/report_content_state.dart';
@@ -229,22 +230,18 @@ class ChatController extends State<Chat>
   bool get hasNoMessageEvents {
     if (timeline == null) return true;
 
-    final events = timeline!.events;
-    final visibleEvents = events.where((event) => event.isVisibleInGui);
-    final validEventType = [
-      EventTypes.Message,
-      EventTypes.Sticker,
-      EventTypes.Encrypted,
-      EventTypes.CallInvite,
-    ];
+    final visibleEvents = timeline!.events.where(
+      (event) => event.isVisibleInGui,
+    );
     final validEvents = visibleEvents.where((event) {
+      if (EventTypeSets.userContentTypes.contains(event.type)) {
+        return true;
+      }
       final currentMembership = event.content.tryGet<String>('membership');
       final prevMembership = event.prevContent?.tryGet<String>('membership');
-      final isAcceptInviteEvent =
-          event.type == EventTypes.RoomMember &&
+      return event.type == EventTypes.RoomMember &&
           currentMembership == 'join' &&
           prevMembership == 'invite';
-      return validEventType.contains(event.type) || isAcceptInviteEvent;
     });
     return validEvents.isEmpty;
   }
@@ -259,17 +256,12 @@ class ChatController extends State<Chat>
 
     if (timeline == null) return true;
 
-    final events = timeline!.events;
-    final visibleEvents = events.where((event) => event.isVisibleInGui);
-    final validEventType = [
-      EventTypes.Message,
-      EventTypes.Sticker,
-      EventTypes.Encrypted,
-      EventTypes.CallInvite,
-    ];
-    final validEvents = visibleEvents.where((event) {
-      return validEventType.contains(event.type);
-    });
+    final visibleEvents = timeline!.events.where(
+      (event) => event.isVisibleInGui,
+    );
+    final validEvents = visibleEvents.where(
+      (event) => EventTypeSets.userContentTypes.contains(event.type),
+    );
     return validEvents.isEmpty && isSupportChat;
   }
 
@@ -2972,11 +2964,8 @@ class ChatController extends State<Chat>
     _currentChatScrollState = ChatScrollState.scrolling;
   }
 
-  List<String> get getEventTypeToFilterUnnecessaryEvent => [
-    EventTypes.Message,
-    EventTypes.Encrypted,
-    EventTypes.Sticker,
-  ];
+  List<String> get getEventTypeToFilterUnnecessaryEvent =>
+      EventTypeSets.messageContentTypesList;
 
   Future<void> _tryRequestHistory() async {
     if (timeline == null) return;

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/domain/matrix_events/event_type_sets.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/chat_horizontal_action_menu.dart';
@@ -214,12 +215,7 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
 
   @override
   Widget build(BuildContext context) {
-    if (!{
-      EventTypes.Message,
-      EventTypes.Sticker,
-      EventTypes.Encrypted,
-      EventTypes.CallInvite,
-    }.contains(widget.event.type)) {
+    if (!EventTypeSets.userContentTypes.contains(widget.event.type)) {
       if (widget.event.type.startsWith('m.call.')) {
         return const SizedBox.shrink();
       }

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/domain/matrix_events/event_type_sets.dart';
 import 'package:fluffychat/domain/model/extensions/string_extension.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/pages/chat/events/message_reactions.dart';
@@ -157,11 +158,8 @@ extension LocalizedBody on Event {
       return true;
     }
 
-    final isPreviousOrNextEventMessage = {
-      EventTypes.Message,
-      EventTypes.Sticker,
-      EventTypes.Encrypted,
-    }.contains(comparedEvent.type);
+    final isPreviousOrNextEventMessage = EventTypeSets.messageContentTypes
+        .contains(comparedEvent.type);
 
     final isPreviousOrNextEventRedacted = {
       RelationshipTypes.edit,

--- a/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/filtered_timeline_extension.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/domain/matrix_events/event_type_sets.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:matrix/matrix.dart';
 
@@ -24,7 +25,7 @@ extension IsStateExtension on Event {
       // hide unimportant state events
       (!AppConfig.hideUnimportantStateEvents ||
           !isState ||
-          importantStateEvents.contains(type)) &&
+          EventTypeSets.importantStateEvents.contains(type)) &&
       // hide simple join/leave member events in public rooms
       (!AppConfig.hideUnimportantStateEvents ||
           type != EventTypes.RoomMember ||
@@ -39,21 +40,7 @@ extension IsStateExtension on Event {
       !isActivateEndToEndEncryption() &&
       !isInviteWhenCreate();
 
-  static const Set<String> importantStateEvents = {
-    EventTypes.Encryption,
-    EventTypes.RoomCreate,
-    EventTypes.RoomMember,
-    EventTypes.RoomTombstone,
-    EventTypes.CallInvite,
-    EventTypes.RoomName,
-    EventTypes.RoomAvatar,
-  };
-
-  bool get isState => !{
-    EventTypes.Message,
-    EventTypes.Sticker,
-    EventTypes.Encrypted,
-  }.contains(type);
+  bool get isState => !EventTypeSets.messageContentTypes.contains(type);
 
   bool isSomeoneChangeDisplayName() {
     return stateKey != null &&

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/domain/model/homeserver_summary.dart';
 import 'package:fluffychat/domain/repository/federation_configurations_repository.dart';
 import 'package:fluffychat/domain/repository/user_info/user_info_repository.dart';
 import 'package:fluffychat/domain/usecase/room/create_support_chat_interactor.dart';
+import 'package:fluffychat/domain/matrix_events/event_type_sets.dart';
 import 'package:fluffychat/event/twake_event_types.dart';
 import 'package:fluffychat/pages/chat/events/audio_message/audio_player_widget.dart';
 import 'package:fluffychat/presentation/mixins/connectivity_mixin.dart';
@@ -510,11 +511,9 @@ class MatrixState extends State<Matrix>
             .where(
               (e) =>
                   e.type == EventUpdateType.timeline &&
-                  [
-                    EventTypes.Message,
-                    EventTypes.Sticker,
-                    EventTypes.Encrypted,
-                  ].contains(e.content['type']) &&
+                  EventTypeSets.messageContentTypes.contains(
+                    e.content['type'],
+                  ) &&
                   e.content['sender'] != currentClient.userID,
             )
             .listen(showLocalNotification);

--- a/test/utils/matrix_sdk_extensions/filtered_timeline_extension_test.dart
+++ b/test/utils/matrix_sdk_extensions/filtered_timeline_extension_test.dart
@@ -1,0 +1,352 @@
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/domain/matrix_events/event_type_sets.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import '../../fake_client.dart';
+
+void main() {
+  late Client client;
+  late Room room;
+
+  setUpAll(() async {
+    client = await getClient();
+    room = Room(
+      client: client,
+      id: '!test:example.com',
+      membership: Membership.join,
+    );
+  });
+
+  late bool savedHideRedacted;
+  late bool savedHideUnknown;
+  late bool savedHideUnimportant;
+
+  setUp(() {
+    savedHideRedacted = AppConfig.hideRedactedEvents;
+    savedHideUnknown = AppConfig.hideUnknownEvents;
+    savedHideUnimportant = AppConfig.hideUnimportantStateEvents;
+    // Match AppConfig static defaults so default-config tests are order-independent.
+    AppConfig.hideRedactedEvents = false;
+    AppConfig.hideUnknownEvents = true;
+    AppConfig.hideUnimportantStateEvents = true;
+  });
+
+  tearDown(() {
+    AppConfig.hideRedactedEvents = savedHideRedacted;
+    AppConfig.hideUnknownEvents = savedHideUnknown;
+    AppConfig.hideUnimportantStateEvents = savedHideUnimportant;
+  });
+
+  int seq = 0;
+
+  Event makeEvent({
+    String type = EventTypes.Message,
+    String? senderId,
+    Map<String, dynamic> content = const {'body': 'test', 'msgtype': 'm.text'},
+    Map<String, dynamic>? prevContent,
+    String? stateKey,
+    Map<String, dynamic>? unsigned,
+    Room? overrideRoom,
+  }) {
+    seq++;
+    return Event(
+      senderId: senderId ?? '@other:example.com',
+      type: type,
+      room: overrideRoom ?? room,
+      eventId: '\$ev$seq',
+      content: content,
+      originServerTs: DateTime.now(),
+      prevContent: prevContent,
+      stateKey: stateKey,
+      unsigned: unsigned,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // isState
+  // ---------------------------------------------------------------------------
+  group('isState', () {
+    test('message content types are NOT state', () {
+      for (final type in EventTypeSets.messageContentTypes) {
+        expect(makeEvent(type: type).isState, isFalse, reason: type);
+      }
+    });
+
+    test('other types ARE state', () {
+      const stateTypes = [
+        EventTypes.RoomMember,
+        EventTypes.RoomName,
+        EventTypes.RoomAvatar,
+        EventTypes.CallInvite,
+        EventTypes.Encryption,
+        EventTypes.RoomCreate,
+      ];
+      for (final type in stateTypes) {
+        expect(makeEvent(type: type).isState, isTrue, reason: type);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // isVisibleInGui — default AppConfig
+  // ---------------------------------------------------------------------------
+  group('isVisibleInGui — default config', () {
+    group('message-like events are visible', () {
+      test('m.room.message', () {
+        expect(makeEvent().isVisibleInGui, isTrue);
+      });
+
+      test('m.sticker', () {
+        expect(
+          makeEvent(
+            type: EventTypes.Sticker,
+            content: {'body': ':)', 'url': 'mxc://sticker'},
+          ).isVisibleInGui,
+          isTrue,
+        );
+      });
+
+      test('m.room.encrypted', () {
+        expect(makeEvent(type: EventTypes.Encrypted).isVisibleInGui, isTrue);
+      });
+
+      test('m.call.invite', () {
+        expect(makeEvent(type: EventTypes.CallInvite).isVisibleInGui, isTrue);
+      });
+
+      test('m.room.create', () {
+        expect(
+          makeEvent(
+            type: EventTypes.RoomCreate,
+            content: {'creator': '@admin:fakeServer'},
+          ).isVisibleInGui,
+          isTrue,
+        );
+      });
+    });
+
+    group('always-hidden events', () {
+      test('edit relationship', () {
+        final e = makeEvent(
+          content: {
+            'body': 'edit',
+            'msgtype': 'm.text',
+            'm.relates_to': {
+              'rel_type': RelationshipTypes.edit,
+              'event_id': '\$original',
+            },
+          },
+        );
+        expect(e.isVisibleInGui, isFalse);
+      });
+
+      test('reaction relationship (m.annotation)', () {
+        final e = makeEvent(
+          type: EventTypes.Reaction,
+          content: {
+            'm.relates_to': {
+              'rel_type': RelationshipTypes.reaction,
+              'event_id': '\$original',
+              'key': '👍',
+            },
+          },
+        );
+        expect(e.isVisibleInGui, isFalse);
+      });
+
+      test('key verification events', () {
+        expect(
+          makeEvent(type: 'm.key.verification.request').isVisibleInGui,
+          isFalse,
+        );
+        expect(
+          makeEvent(type: 'm.key.verification.start').isVisibleInGui,
+          isFalse,
+        );
+      });
+
+      test('m.reaction type', () {
+        expect(
+          makeEvent(type: EventTypes.Reaction, content: {}).isVisibleInGui,
+          isFalse,
+        );
+      });
+
+      test('m.room.redaction type', () {
+        expect(
+          makeEvent(type: EventTypes.Redaction, content: {}).isVisibleInGui,
+          isFalse,
+        );
+      });
+
+      test('m.room.encryption (activation)', () {
+        expect(
+          makeEvent(
+            type: EventTypes.Encryption,
+            content: {'algorithm': 'm.megolm.v1.aes-sha2'},
+          ).isVisibleInGui,
+          isFalse,
+        );
+      });
+    });
+
+    group('content-based filtering', () {
+      test('display name change is hidden', () {
+        final e = makeEvent(
+          type: EventTypes.RoomMember,
+          stateKey: '@other:example.com',
+          content: {'displayname': 'New Name', 'membership': 'join'},
+          prevContent: {'displayname': 'Old Name', 'membership': 'join'},
+        );
+        expect(e.isVisibleInGui, isFalse);
+      });
+
+      test('avatar change is hidden', () {
+        final e = makeEvent(
+          type: EventTypes.RoomMember,
+          stateKey: '@other:example.com',
+          content: {'avatar_url': 'mxc://new', 'membership': 'join'},
+          prevContent: {'avatar_url': 'mxc://old', 'membership': 'join'},
+        );
+        expect(e.isVisibleInGui, isFalse);
+      });
+
+      test('self-join is hidden', () {
+        final e = makeEvent(
+          type: EventTypes.RoomMember,
+          senderId: client.userID!,
+          stateKey: client.userID!,
+          content: {'membership': 'join'},
+        );
+        expect(e.isVisibleInGui, isFalse);
+      });
+
+      test('invite without reason is hidden', () {
+        final e = makeEvent(
+          type: EventTypes.RoomMember,
+          stateKey: '@invited:example.com',
+          content: {'membership': 'invite'},
+        );
+        expect(e.isVisibleInGui, isFalse);
+      });
+
+      test('room name set at creation is hidden', () {
+        final e = makeEvent(
+          type: EventTypes.RoomName,
+          content: {'name': 'My Room'},
+        );
+        expect(e.isVisibleInGui, isFalse);
+      });
+
+      test('room avatar placeholder at creation is hidden', () {
+        final e = makeEvent(type: EventTypes.RoomAvatar, content: {});
+        expect(e.isVisibleInGui, isFalse);
+      });
+    });
+
+    test(
+      'unknown event type is hidden (hideUnknownEvents defaults to true)',
+      () {
+        expect(AppConfig.hideUnknownEvents, isTrue);
+        expect(
+          makeEvent(type: 'com.example.custom', content: {}).isVisibleInGui,
+          isFalse,
+        );
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // isVisibleInGui — config variations
+  // ---------------------------------------------------------------------------
+  group('isVisibleInGui — config variations', () {
+    Map<String, dynamic> redactedUnsigned() => {
+      'redacted_because': {
+        'event_id': '\$redact',
+        'sender': '@mod:example.com',
+        'type': EventTypes.Redaction,
+        'content': {},
+        'origin_server_ts': DateTime.now().millisecondsSinceEpoch,
+      },
+    };
+
+    test('redacted message hidden when hideRedactedEvents = true', () {
+      AppConfig.hideRedactedEvents = true;
+      final e = makeEvent(unsigned: redactedUnsigned());
+      expect(e.isVisibleInGui, isFalse);
+    });
+
+    test('redacted message visible when hideRedactedEvents = false', () {
+      AppConfig.hideRedactedEvents = false;
+      final e = makeEvent(unsigned: redactedUnsigned());
+      expect(e.isVisibleInGui, isTrue);
+    });
+
+    test('unknown type visible when hideUnknownEvents = false', () {
+      AppConfig.hideUnknownEvents = false;
+      AppConfig.hideUnimportantStateEvents = false;
+      expect(
+        makeEvent(type: 'com.example.custom', content: {}).isVisibleInGui,
+        isTrue,
+      );
+    });
+
+    test('simple join hidden in public room', () {
+      final publicRoom = Room(
+        client: client,
+        id: '!public:example.com',
+        membership: Membership.join,
+      );
+      publicRoom.setState(
+        Event(
+          type: EventTypes.RoomJoinRules,
+          content: {'join_rule': 'public'},
+          senderId: '@admin:fakeServer',
+          eventId: '\$joinrule',
+          room: publicRoom,
+          stateKey: '',
+          originServerTs: DateTime.now(),
+        ),
+      );
+
+      final e = makeEvent(
+        type: EventTypes.RoomMember,
+        senderId: '@someone:example.com',
+        stateKey: '@someone:example.com',
+        content: {'membership': 'join'},
+        overrideRoom: publicRoom,
+      );
+      expect(e.isVisibleInGui, isFalse);
+    });
+
+    test('ban event visible in public room', () {
+      final publicRoom = Room(
+        client: client,
+        id: '!public2:example.com',
+        membership: Membership.join,
+      );
+      publicRoom.setState(
+        Event(
+          type: EventTypes.RoomJoinRules,
+          content: {'join_rule': 'public'},
+          senderId: '@admin:fakeServer',
+          eventId: '\$joinrule2',
+          room: publicRoom,
+          stateKey: '',
+          originServerTs: DateTime.now(),
+        ),
+      );
+
+      final e = makeEvent(
+        type: EventTypes.RoomMember,
+        senderId: '@admin:fakeServer',
+        stateKey: '@banned:example.com',
+        content: {'membership': 'ban'},
+        overrideRoom: publicRoom,
+      );
+      expect(e.isVisibleInGui, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Introduces `EventTypeSets` (`lib/config/event_type_sets.dart`), a single source of truth for the event-type sets that were duplicated as inline literals across 6 files. Later it will be the source of truth where we can add new events or change the visibility behavior of each.
- Replaces every occurrence with a reference to the shared constants — **zero behavioral change**.
- Adds 25 unit tests on `isVisibleInGui` and `isState` to freeze the current filtering contract before further refactoring or spec changes.

### Three sets extracted

| Constant | Contents | Replaced in |
|----------|----------|-------------|
| `messageContentTypes` | Message, Sticker, Encrypted | `isState`, `isSameSenderWith`, local notifications, chat-list preview, server history filter |
| `userContentTypes` | Message, Sticker, Encrypted, CallInvite | `Message.build` type guard, `hasNoMessageEvents`, `isEmptySupportChat` |
| `importantStateEvents` | Encryption, RoomCreate, RoomMember, RoomTombstone, CallInvite, RoomName, RoomAvatar | `isVisibleInGui` unimportant-state filter |

### What this does NOT change

- No logic in `isVisibleInGui` is modified (yet) (same chain of `&&`, same guards)
- No methods removed (`shouldHideBannedEvent`, `isActivateEndToEndEncryption`… stay as-is for now)
- `lastEventAvailableInPreview` is untouched for now
- `chat_list_item_subtitle.dart` is untouched for now

## Tests

- 25 new tests added in `filtered_timeline_extension_test.dart`
- You can open chat list, open a conversation, send message/sticker, verify timeline renders identically
- You can verify room list sorting and last-message preview unchanged

## Demos
No demos added as there is zero behavioral change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized event-type groupings used across the app (message-like, user-content, important state) for consistent filtering and rendering.
* **Tests**
  * Added comprehensive tests validating event categorization and GUI visibility under various configurations and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->