### PR TITLE
perf: port PR #2927 — per-room timeline trim

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -107,6 +107,23 @@ import 'sticker_picker_dialog.dart';
 
 typedef OnJumpToMessage = void Function(String eventId);
 
+/// Trims an event list in place to at most [maxEvents], dropping the
+/// oldest entries (tail of the list, since Matrix timeline events are
+/// ordered newest-first).
+///
+/// No-op when `events.length <= maxEvents`. Exposed for unit testing of
+/// the per-room timeline cap used by [ChatController].
+@visibleForTesting
+void trimEventsIfNeeded(List<Event> events, int maxEvents) {
+  if (events.length <= maxEvents) return;
+  final excess = events.length - maxEvents;
+  Logs().d(
+    'trimEventsIfNeeded(): Trimming $excess old events '
+    '(${events.length} -> $maxEvents)',
+  );
+  events.removeRange(maxEvents, events.length);
+}
+
 class Chat extends StatefulWidget {
   final String roomId;
   final List<MatrixFile?>? shareFiles;
@@ -167,6 +184,12 @@ class ChatController extends State<Chat>
   static const double defaultMaxWidthReactionPicker = 326;
 
   static const double defaultMaxHeightReactionPicker = 360;
+
+  /// Maximum number of events to keep in memory per timeline.
+  /// When exceeded after a history request, older events are trimmed
+  /// to prevent unbounded memory growth during long scroll sessions.
+  /// 500 events ≈ a generous scroll buffer while keeping memory bounded.
+  static const int _maxTimelineEvents = 500;
 
   final GlobalKey stickyTimestampKey = GlobalKey(
     debugLabel: 'stickyTimestampKey',
@@ -527,12 +550,28 @@ class ChatController extends State<Chat>
         historyCount: historyCount ?? _loadHistoryCount,
         filter: filter,
       );
+      _trimTimelineIfNeeded();
     } catch (err) {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text((err).toLocalizedString(context))));
       rethrow;
     }
+  }
+
+  /// Trims the timeline event list if it exceeds [_maxTimelineEvents].
+  ///
+  /// Removes the oldest events (at the end of the list, since events
+  /// are ordered newest-first) to keep memory bounded during long
+  /// scroll sessions. This is safe because:
+  /// - The trimmed events are still persisted in the database
+  /// - They will be re-loaded if the user scrolls back to that point
+  /// - The SDK's `canRequestHistory` still works correctly
+  void _trimTimelineIfNeeded() {
+    if (!mounted) return;
+    final events = timeline?.events;
+    if (events == null) return;
+    trimEventsIfNeeded(events, _maxTimelineEvents);
   }
 
   void _updateScrollController() async {

--- a/test/pages/chat/chat_timeline_trim_test.dart
+++ b/test/pages/chat/chat_timeline_trim_test.dart
@@ -1,0 +1,104 @@
+import 'package:fluffychat/pages/chat/chat.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import '../../fake_client.dart';
+
+/// Unit tests for [trimEventsIfNeeded], the pure helper that backs
+/// `ChatController._trimTimelineIfNeeded()`. The per-room timeline cap
+/// (500 events by default) was introduced to prevent unbounded memory
+/// growth during long scroll sessions — see PR #2927.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Client client;
+  late Room room;
+
+  setUpAll(() async {
+    client = await getClient();
+    room = Room(
+      client: client,
+      id: '!trim:test.abc',
+      membership: Membership.join,
+      prev_batch: '',
+    );
+  });
+
+  Event makeEvent(int index) => Event(
+    senderId: '@alice:test.abc',
+    type: 'm.room.message',
+    room: room,
+    eventId: '\$event_$index',
+    originServerTs: DateTime.fromMillisecondsSinceEpoch(index),
+    content: {'msgtype': 'm.text', 'body': 'msg $index'},
+  );
+
+  List<Event> makeEvents(int count) => List<Event>.generate(count, makeEvent);
+
+  group('trimEventsIfNeeded', () {
+    test('keepsAllEventsWhenBelowCap', () {
+      final events = makeEvents(499);
+      trimEventsIfNeeded(events, 500);
+      expect(events.length, 499);
+    });
+
+    test('keepsAllEventsWhenExactlyAtCap', () {
+      final events = makeEvents(500);
+      trimEventsIfNeeded(events, 500);
+      expect(events.length, 500);
+    });
+
+    test('trimsToExactlyCapWhenOneOver', () {
+      final events = makeEvents(501);
+      trimEventsIfNeeded(events, 500);
+      expect(events.length, 500);
+    });
+
+    test('keepsNewestEventsAndDropsOldestWhenAboveCap', () {
+      // Timeline events are ordered newest-first: index 0 is the most
+      // recent message. After trimming, the head must be preserved.
+      final events = makeEvents(650);
+      final newestEventId = events.first.eventId;
+      final boundaryEventId = events[499].eventId;
+      final firstDroppedEventId = events[500].eventId;
+
+      trimEventsIfNeeded(events, 500);
+
+      expect(events.length, 500);
+      expect(events.first.eventId, newestEventId);
+      expect(events.last.eventId, boundaryEventId);
+      expect(
+        events.any((e) => e.eventId == firstDroppedEventId),
+        isFalse,
+        reason: 'The oldest events must be removed, not the newest.',
+      );
+    });
+
+    test('simulatesRequestHistoryGrowthFrom450By200YieldsExactlyCap', () {
+      // Mirrors the real flow: a timeline already holds 450 events, then
+      // requestHistory() appends 200 older events to the tail (list now
+      // 650 long). Trimming must bring it back to exactly 500.
+      final events = makeEvents(450);
+      events.addAll(List<Event>.generate(200, (i) => makeEvent(10000 + i)));
+      expect(events.length, 650);
+
+      trimEventsIfNeeded(events, 500);
+
+      expect(events.length, 500);
+    });
+
+    test('isNoOpOnEmptyList', () {
+      final events = <Event>[];
+      trimEventsIfNeeded(events, 500);
+      expect(events, isEmpty);
+    });
+
+    test('respectsCustomCap', () {
+      final events = makeEvents(10);
+      trimEventsIfNeeded(events, 3);
+      expect(events.length, 3);
+      expect(events.first.eventId, '\$event_0');
+      expect(events.last.eventId, '\$event_2');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Part 1 of 3 of the cross-room timeline cache series. Ports the per-room `Timeline.events` cap from linagora/twake-on-matrix#2927 (merged into `refacto/performance`) onto `main`.

- Caps `Timeline.events` at 500 per room via `_trimTimelineIfNeeded()` called after each `await timeline!.requestHistory(...)`.
- Trimmed events remain in the database and are re-loaded if the user scrolls back.
- No cross-room logic, no feature flag — matches behavior already shipping on `refacto/performance`.

## Why this PR, why now

Without a per-room cap, cross-room memory investigation (Part 2) is confounded by unbounded per-room growth. This PR gives Parts 2–3 a clean baseline.

## What actually landed vs. what PR #2927 listed

The original PR description listed three changes; only **one** is genuinely new on `main`:

| Change in PR #2927                                                         | On `main`? |
|----------------------------------------------------------------------------|------------|
| `_maxTimelineEvents = 500` + `_trimTimelineIfNeeded()`                     | **New**    |
| `cancelSubscriptions()` ordering fix in scrollDown / scrollToEventId / _reloadTimeline | Already present |
| `imageCache.clear()` on `ChatController.dispose()`                         | Already present |

The commit message reflects this — no pretence that the other two were ported here.

## Implementation detail: testability refactor

The original PR kept the trim inline inside `ChatController._trimTimelineIfNeeded()`. Unit-testing a private method on a `State<Chat>` requires mounting the whole widget + dozens of mocks. To keep tests meaningful and cheap, the pure algorithm lives in a top-level `@visibleForTesting void trimEventsIfNeeded(List<Event>, int)` helper. The private method is a thin wrapper that short-circuits when unmounted/null, then delegates.

## Follow-up: post-trim baseline capture

Runtime medians for the image-scroll scenario still need to be captured via `tasks/cdp_inspect.py` on a release web build. Parts 2–3 depend on that baseline, so it must happen before Part 2 starts — tracked locally, not part of this PR.

## Test plan

- [x] `fvm flutter test test/pages/chat/chat_timeline_trim_test.dart` — 7/7 pass
- [x] `fvm flutter test test/pages/chat/` — 143/143 pass
- [x] `fvm flutter analyze lib/pages/chat/chat.dart test/pages/chat/chat_timeline_trim_test.dart` — No issues
- [x] `fvm dart format` — no changes needed
- [ ] Manual smoke: open a room with 1000+ messages, scroll up repeatedly, confirm `timeline.events.length <= 500` (temporary `Logs().d(...)`)
- [ ] Capture post-trim medians via `tasks/cdp_inspect.py` before Part 2

## Follow-ups (non-blocking)

- Reviewer suggested `trimEventsIfNeeded` might better live in `lib/utils/matrix_sdk_extensions/event_list_extension.dart` as `EventListExtension.trimToMax`. Deferring to Part 3, where cross-room code may want the same helper.
- Tests don't cover `!mounted` / `timeline == null` guards directly — those live on the thin wrapper and would require widget-mounting. Acceptable trade-off given the guards are straightforward.

## Links

- Original PR: linagora/twake-on-matrix#2927