### PR TITLE
perf(chat): fix O(N²) hashCode cascade in ChatAppBarTitle room name resolver

### DIFF
--- a/lib/pages/chat/chat_app_bar_title.dart
+++ b/lib/pages/chat/chat_app_bar_title.dart
@@ -10,8 +10,8 @@ import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/domain/contact_manager/contacts_manager.dart';
 import 'package:fluffychat/pages/chat/chat_app_bar_title_style.dart';
 import 'package:fluffychat/presentation/extensions/contact/presentation_contact_extension.dart';
-import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
 import 'package:fluffychat/pages/chat/typing_timer_wrapper.dart';
+import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/common_helper.dart';
 import 'package:fluffychat/utils/room_status_extension.dart';
@@ -54,34 +54,15 @@ class ChatAppBarTitle extends StatelessWidget {
     BuildContext context,
     Either<Failure, Success> getContactsState,
   ) {
-    final directChatMatrixId = room?.directChatMatrixID;
     final localizedRoomName = room?.getLocalizedDisplayname(
       MatrixLocals(L10n.of(context)!),
     );
-    if (directChatMatrixId == null) {
-      if (roomName != null) return roomName!;
-
-      return localizedRoomName ?? '';
-    }
-
-    final currentContacts = getContactsState.fold(
-      (failure) => <PresentationContact>[],
-      (success) => success is GetContactsSuccess
-          ? success.contacts
-                .fold(
-                  <PresentationContact>{},
-                  (previous, contact) => {
-                    ...previous,
-                    ...contact.toPresentationContacts(),
-                  },
-                )
-                .toList()
-          : <PresentationContact>[],
+    return resolveChatAppBarTitle(
+      directChatMatrixId: room?.directChatMatrixID,
+      fallbackRoomName: roomName,
+      localizedRoomName: localizedRoomName,
+      getContactsState: getContactsState,
     );
-    final availableContact = currentContacts.firstWhereOrNull(
-      (contact) => contact.matrixId == directChatMatrixId,
-    );
-    return availableContact?.displayName ?? localizedRoomName ?? '';
   }
 
   @override
@@ -104,80 +85,75 @@ class ChatAppBarTitle extends StatelessWidget {
       highlightColor: Colors.transparent,
       focusColor: Colors.transparent,
       onTap: isArchived ? null : onPushDetails,
-      child: Row(
-        children: [
-          Padding(
-            padding: ChatAppBarTitleStyle.avatarPadding,
-            child: Stack(
-              children: [
-                Hero(
-                  tag: 'content_banner',
-                  child: ValueListenableBuilder(
-                    valueListenable: getIt
-                        .get<ContactsManager>()
-                        .getContactsNotifier(),
-                    builder: (context, state, child) {
-                      return Avatar(
+      // Single listener drives both the avatar name and the title text;
+      // the status subtree is passed via `child:` so it does not rebuild
+      // when the contacts notifier emits.
+      child: ValueListenableBuilder(
+        valueListenable: getIt.get<ContactsManager>().getContactsNotifier(),
+        child: _ChatAppBarStatusContent(
+          connectivityResultStream: connectivityResultStream,
+          room: room!,
+          cachedPresenceNotifier: cachedPresenceNotifier,
+          cachedPresenceStreamController: cachedPresenceStreamController,
+        ),
+        builder: (context, state, statusContent) {
+          final resolvedRoomName = _getRoomName(context, state);
+          return Row(
+            children: [
+              Padding(
+                padding: ChatAppBarTitleStyle.avatarPadding,
+                child: Stack(
+                  children: [
+                    Hero(
+                      tag: 'content_banner',
+                      child: Avatar(
                         fontSize: ChatAppBarTitleStyle.avatarFontSize,
                         mxContent: room!.avatar,
-                        name: _getRoomName(context, state),
+                        name: resolvedRoomName,
                         size: ChatAppBarTitleStyle.avatarSize(context),
-                      );
-                    },
-                  ),
-                ),
-              ],
-            ),
-          ),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    if (room?.encrypted == true) ...[
-                      Padding(
-                        padding: const EdgeInsets.all(2.0),
-                        child: SvgPicture.asset(
-                          ImagePaths.icEncrypted,
-                          width: 16,
-                          height: 16,
-                        ),
                       ),
-                      const SizedBox(width: 4),
-                    ],
-                    Flexible(
-                      child: ValueListenableBuilder(
-                        valueListenable: getIt
-                            .get<ContactsManager>()
-                            .getContactsNotifier(),
-                        builder: (context, state, child) {
-                          return Text(
-                            _getRoomName(context, state),
+                    ),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      children: [
+                        if (room?.encrypted == true) ...[
+                          Padding(
+                            padding: const EdgeInsets.all(2.0),
+                            child: SvgPicture.asset(
+                              ImagePaths.icEncrypted,
+                              width: 16,
+                              height: 16,
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                        ],
+                        Flexible(
+                          child: Text(
+                            resolvedRoomName,
                             maxLines: 1,
                             overflow: TextOverflow.ellipsis,
                             style: ChatAppBarTitleStyle.appBarTitleStyle(
                               context,
                             ),
-                          );
-                        },
-                      ),
+                          ),
+                        ),
+                      ],
                     ),
+                    statusContent!,
                   ],
                 ),
-                _ChatAppBarStatusContent(
-                  connectivityResultStream: connectivityResultStream,
-                  room: room!,
-                  cachedPresenceNotifier: cachedPresenceNotifier,
-                  cachedPresenceStreamController:
-                      cachedPresenceStreamController,
-                ),
-              ],
-            ),
-          ),
-        ],
+              ),
+            ],
+          );
+        },
       ),
     );
   }
@@ -377,4 +353,34 @@ class _ChatAppBarTitleTyping extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Resolves the string displayed in the chat app bar title (and used as the
+/// avatar fallback text).
+///
+/// For direct chats, walks the contacts state lazily to find the first
+/// [PresentationContact] whose `matrixId` matches [directChatMatrixId], and
+/// uses its display name. Falls back to [localizedRoomName] when no contact
+/// matches or when the state is not a success.
+///
+/// Lazy iteration + short-circuit on match is deliberate: do not rebuild a
+/// `Set<PresentationContact>` here. `PresentationContact` is `Equatable`
+/// with expensive props, and a Set-fold triggers an O(N²) `hashCode` cascade
+/// on every rebuild.
+@visibleForTesting
+String resolveChatAppBarTitle({
+  required String? directChatMatrixId,
+  required String? fallbackRoomName,
+  required String? localizedRoomName,
+  required Either<Failure, Success> getContactsState,
+}) {
+  if (directChatMatrixId == null) {
+    return fallbackRoomName ?? localizedRoomName ?? '';
+  }
+  final availableContact = getContactsState
+      .getSuccessOrNull<GetContactsSuccess>()
+      ?.contacts
+      .expand((contact) => contact.toPresentationContacts())
+      .firstWhereOrNull((contact) => contact.matrixId == directChatMatrixId);
+  return availableContact?.displayName ?? localizedRoomName ?? '';
 }

--- a/test/pages/chat/chat_app_bar_title_test.dart
+++ b/test/pages/chat/chat_app_bar_title_test.dart
@@ -1,0 +1,96 @@
+import 'package:dartz/dartz.dart';
+import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
+import 'package:fluffychat/domain/model/contact/contact.dart';
+import 'package:fluffychat/pages/chat/chat_app_bar_title.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Contact _contactWithMatrixId(String id, String matrixId, String displayName) {
+  return Contact(
+    id: id,
+    displayName: displayName,
+    emails: {Email(address: '$id@example.com', matrixId: matrixId)},
+  );
+}
+
+void main() {
+  group('resolveChatAppBarTitle', () {
+    test('returns fallbackRoomName when directChatMatrixId is null', () {
+      final name = resolveChatAppBarTitle(
+        directChatMatrixId: null,
+        fallbackRoomName: 'Team #42',
+        localizedRoomName: 'Ignored',
+        getContactsState: const Right(GetContactsSuccess(contacts: [])),
+      );
+      expect(name, 'Team #42');
+    });
+
+    test('returns localizedRoomName when directChatMatrixId is null and '
+        'no fallbackRoomName is provided', () {
+      final name = resolveChatAppBarTitle(
+        directChatMatrixId: null,
+        fallbackRoomName: null,
+        localizedRoomName: 'Room loc',
+        getContactsState: const Right(GetContactsSuccess(contacts: [])),
+      );
+      expect(name, 'Room loc');
+    });
+
+    test(
+      'returns the displayName of the matching contact for a direct chat',
+      () {
+        final match = _contactWithMatrixId('1', '@alice:m.org', 'Alice');
+        final other = _contactWithMatrixId('2', '@bob:m.org', 'Bob');
+        final name = resolveChatAppBarTitle(
+          directChatMatrixId: '@alice:m.org',
+          fallbackRoomName: null,
+          localizedRoomName: 'fallback',
+          getContactsState: Right(GetContactsSuccess(contacts: [other, match])),
+        );
+        expect(name, 'Alice');
+      },
+    );
+
+    test(
+      'falls back to localizedRoomName when no contact matches the matrixId',
+      () {
+        final contact = _contactWithMatrixId('1', '@alice:m.org', 'Alice');
+        final name = resolveChatAppBarTitle(
+          directChatMatrixId: '@missing:m.org',
+          fallbackRoomName: null,
+          localizedRoomName: 'Fallback room',
+          getContactsState: Right(GetContactsSuccess(contacts: [contact])),
+        );
+        expect(name, 'Fallback room');
+      },
+    );
+
+    test('falls back to localizedRoomName when state is a Failure', () {
+      final name = resolveChatAppBarTitle(
+        directChatMatrixId: '@alice:m.org',
+        fallbackRoomName: null,
+        localizedRoomName: 'Fallback on failure',
+        getContactsState: const Left(
+          GetContactsFailure(keyword: '', exception: 'boom'),
+        ),
+      );
+      expect(name, 'Fallback on failure');
+    });
+
+    test('returns the first matching contact in iteration order when multiple '
+        'contacts share the same matrixId', () {
+      final first = _contactWithMatrixId('1', '@shared:m.org', 'From source A');
+      final second = _contactWithMatrixId(
+        '2',
+        '@shared:m.org',
+        'From source B',
+      );
+      final name = resolveChatAppBarTitle(
+        directChatMatrixId: '@shared:m.org',
+        fallbackRoomName: null,
+        localizedRoomName: 'Fallback',
+        getContactsState: Right(GetContactsSuccess(contacts: [first, second])),
+      );
+      expect(name, 'From source A');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`ChatAppBarTitle._getRoomName` was the dominant CPU hotspot on room-switch rebuilds. A Set-fold with spread (`{...prev, ...contact.toPresentationContacts()}`) rebuilt a `LinkedHashSet<PresentationContact>` at every iteration, hashing Equatable-based contacts with expensive props on every rebuild of the two `ValueListenableBuilder`s bound to `getContactsNotifier()`.

Changes:
- Replace the Set-fold by a lazy `expand().firstWhereOrNull()` that short-circuits on the first `matrixId` match.
- Hoist a single `ValueListenableBuilder` at the InkWell level so both the avatar name and the title text share one rebuild cycle. `_ChatAppBarStatusContent` is passed via `child:` so it no longer rebuilds on contacts notifier emissions.
- Extract resolution logic into a top-level `resolveChatAppBarTitle` function (`@visibleForTesting`).
- 6 unit tests covering fallback, match, and failure branches.

## Measured impact (10-run bench, same methodology for baseline and fix)

Seeds 1–10, randomized 15-room parcours, profile-mode local build, Chrome fresh + auto-OIDC login per run.

| Metric | Baseline (median) | Fix (median) | Delta |
|---|---:|---:|---:|
| `script_total_s` | 14.28s | **6.41s** | **-55%** |
| `long_task_total_ms` | 9 206 ms | **846 ms** | **-91%** |
| `long_task_count` | 30 | 10 | -67% |
| `long_task_max_ms` | 418 ms | 133 ms | -68% |
| `wall_total_s` | 33.86s | 28.63s | -15% |
| `heap_end_mb` | 112.35 | 104.07 | -7% |

Cross-checked via inverted call tree on runs 1, 3, 6, 9: `_getRoomName` self-time = 0.000s, `mapPropsToHashCode` self-time ≤ 0.001s — the hotspot is gone.

Full report: `docs/plan/findings/2026-04-14-perf-web-cpu-report.md` (§10).

## Known blind spots (out of scope, follow-ups)

The bench exercises room switching (which matches the user-reported "5 s to open a room"). The following paths were not measured and may still contain independent hotspots in production:
- Typing lag (composer focus / onChanged rebuilds).
- Very long sessions (accumulated Matrix SDK state over 1 h+).
- Large address books (> 500 contacts — the new code is O(N) without memoization).
- Deep navigation stacks (space/room rapid switching).

Independent second opinions (wingspan + rodin-tech) validated semantic equivalence, metric consistency, and flagged these blind spots.

## Test plan

- [x] `fvm flutter analyze lib/pages/chat/chat_app_bar_title.dart test/pages/chat/chat_app_bar_title_test.dart` — clean
- [x] `fvm flutter test test/pages/chat/chat_app_bar_title_test.dart` — 6/6 passing
- [ ] Manual smoke: open a direct chat and verify the app bar shows the contact display name (not the MXID)
- [ ] Manual smoke: open a group chat and verify the app bar shows the localized room name
- [ ] Manual smoke: go offline while a direct chat is open; app bar still shows a sensible name (no crash on the `Failure` branch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized chat app bar title display with improved contact matching for direct chats and reduced render cycles.

* **Tests**


https://github.com/user-attachments/assets/8744caa0-029e-4272-9c48-d9cd2f3ee571



<!-- end of auto-generated comment: release notes by coderabbit.ai -->