### PR TITLE
TW-3004: Enhance emoji display logic to consider edit events in message timeline

### DIFF
--- a/lib/pages/chat/events/message/message_content_builder.dart
+++ b/lib/pages/chat/events/message/message_content_builder.dart
@@ -55,6 +55,7 @@ class MessageContentBuilder extends StatelessWidget
             Message.responsiveUtils.isMobile(context),
           ),
           isEdited: event.hasAggregatedEvents(timeline, RelationshipTypes.edit),
+          timeline: timeline,
         );
         final stepWidth = sizeMessageBubble?.totalMessageWidth;
         final isNeedAddNewLine = sizeMessageBubble?.isNeedAddNewLine ?? false;

--- a/lib/pages/chat/events/message/message_content_builder_mixin.dart
+++ b/lib/pages/chat/events/message/message_content_builder_mixin.dart
@@ -22,6 +22,7 @@ mixin MessageContentBuilderMixin {
     bool ownMessage = false,
     bool hideDisplayName = false,
     bool isEdited = false,
+    Timeline? timeline,
   }) {
     final isNotSupportCalcSize =
         {
@@ -51,6 +52,7 @@ mixin MessageContentBuilderMixin {
       event,
       maxWidth,
       isEdited: isEdited,
+      timeline: timeline,
     );
 
     if (ownMessage || hideDisplayName) {
@@ -100,8 +102,9 @@ mixin MessageContentBuilderMixin {
   TextPainter _paintMessageText(
     BuildContext context,
     Event event,
-    double maxWidth,
-  ) {
+    double maxWidth, {
+    Timeline? timeline,
+  }) {
     final double messageMaxWidth = maxWidth - AppConfig.messagePadding;
     return TextPainter(
       textScaler: MediaQuery.of(context).textScaler,
@@ -113,7 +116,7 @@ mixin MessageContentBuilderMixin {
                 hideReply: true,
                 plaintextBody: true,
               ),
-        style: event.getMessageTextStyle(context),
+        style: event.getMessageTextStyle(context, timeline),
       ),
       textDirection: TextDirection.ltr,
     )..layout(minWidth: 0, maxWidth: messageMaxWidth);
@@ -168,6 +171,7 @@ mixin MessageContentBuilderMixin {
     Event event,
     double maxWidth, {
     bool isEdited = false,
+    Timeline? timeline,
   }) {
     const spaceMessageAndTime = 4.0;
     final spaceHasEdited = isEdited ? 56.0 : 0.0;
@@ -176,7 +180,12 @@ mixin MessageContentBuilderMixin {
         ? 0.0
         : AppConfig.messagePadding;
 
-    final paintedMessageText = _paintMessageText(context, event, maxWidth);
+    final paintedMessageText = _paintMessageText(
+      context,
+      event,
+      maxWidth,
+      timeline: timeline,
+    );
     final sizeMessageTime = _getWidthMessageTime(context, event, maxWidth);
     final messageTimeAndPaddingWidth =
         sizeMessageTime + spaceMessageAndTime + spaceHasEdited + spaceHasPinned;

--- a/lib/pages/chat/events/message/message_content_builder_mixin.dart
+++ b/lib/pages/chat/events/message/message_content_builder_mixin.dart
@@ -105,18 +105,23 @@ mixin MessageContentBuilderMixin {
     double maxWidth, {
     Timeline? timeline,
   }) {
+    // Use the display event (latest edit) so text content and style both
+    // match what MessageContent actually renders.
+    final displayEvent = timeline != null
+        ? event.getDisplayEventWithoutEditEvent(timeline)
+        : event;
     final double messageMaxWidth = maxWidth - AppConfig.messagePadding;
     return TextPainter(
       textScaler: MediaQuery.of(context).textScaler,
       text: TextSpan(
-        text: event.isCaptionModeOrReply()
-            ? event.body
-            : event.calcLocalizedBodyFallback(
+        text: displayEvent.isCaptionModeOrReply()
+            ? displayEvent.body
+            : displayEvent.calcLocalizedBodyFallback(
                 MatrixLocals(L10n.of(context)!),
                 hideReply: true,
                 plaintextBody: true,
               ),
-        style: event.getMessageTextStyle(context, timeline),
+        style: displayEvent.getMessageTextStyle(context),
       ),
       textDirection: TextDirection.ltr,
     )..layout(minWidth: 0, maxWidth: messageMaxWidth);

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -427,7 +427,7 @@ class _MessageContentWithTimestampBuilderState
       isEnabled: hasReactionEvent,
       children: [
         Container(
-          decoration: widget.event.isDisplayOnlyEmoji()
+          decoration: widget.event.isDisplayOnlyEmoji(widget.timeline)
               ? null
               : BoxDecoration(
                   borderRadius: MessageStyle.bubbleBorderRadius,

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -270,7 +270,7 @@ extension LocalizedBody on Event {
   /// (display event) so that edits that add text return false, and edits that
   /// result in emoji-only content return true.
   bool isDisplayOnlyEmoji([Timeline? timeline]) {
-    if (isReplyEvent()) return false;
+    if (isCaptionModeOrReply()) return false;
     final target = timeline != null
         ? getDisplayEventWithoutEditEvent(timeline)
         : this;

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -265,11 +265,18 @@ extension LocalizedBody on Event {
 
   /// Returns true if message contains only 1-6 emojis and is not a reply.
   /// Used to display emoji in enlarged size.
-  bool isDisplayOnlyEmoji() {
-    return !isReplyEvent() &&
-        onlyEmotes &&
-        numberEmotes > 0 &&
-        numberEmotes < 7;
+  ///
+  /// When [timeline] is provided, evaluates against the latest edited content
+  /// (display event) so that edits that add text return false, and edits that
+  /// result in emoji-only content return true.
+  bool isDisplayOnlyEmoji([Timeline? timeline]) {
+    if (isReplyEvent()) return false;
+    final target = timeline != null
+        ? getDisplayEventWithoutEditEvent(timeline)
+        : this;
+    return target.onlyEmotes &&
+        target.numberEmotes > 0 &&
+        target.numberEmotes < 7;
   }
 
   TextStyle? textStyleForOnlyEmoji(BuildContext context) {
@@ -311,7 +318,7 @@ extension LocalizedBody on Event {
     }
   }
 
-  TextStyle? getMessageTextStyle(BuildContext context) {
+  TextStyle? getMessageTextStyle(BuildContext context, [Timeline? timeline]) {
     if (redacted) {
       return Theme.of(context).textTheme.bodyLarge?.copyWith(
         fontSize: 17,
@@ -320,7 +327,7 @@ extension LocalizedBody on Event {
       );
     }
 
-    if (isDisplayOnlyEmoji()) {
+    if (isDisplayOnlyEmoji(timeline)) {
       return textStyleForOnlyEmoji(context);
     }
 

--- a/test/pages/chat/events/event_extension_test.dart
+++ b/test/pages/chat/events/event_extension_test.dart
@@ -3,6 +3,8 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:matrix/matrix.dart';
+
+// ignore: implementation_imports — TimelineChunk is not yet exported publicly
 import 'package:matrix/src/models/timeline_chunk.dart';
 import 'package:mockito/annotations.dart';
 
@@ -1040,13 +1042,35 @@ void main() {
       expect(event.isDisplayOnlyEmoji(), false);
     });
 
+    test('GIVEN image with emoji caption\n'
+        'AND NOT a reply\n'
+        'THEN return false (caption mode always false)\n', () {
+      final event = Event(
+        senderId: '@user:example.com',
+        type: 'm.room.message',
+        room: room,
+        eventId: '\$caption1',
+        content: {
+          'body': '😊',
+          'filename': 'photo.jpg',
+          'msgtype': 'm.image',
+          'url': 'mxc://example.org/img',
+        },
+        originServerTs: DateTime.fromMillisecondsSinceEpoch(1234567890),
+      );
+
+      expect(event.isDisplayOnlyEmoji(), false);
+    });
+
     group('with edit events (Timeline provided)', () {
-      Timeline createTimeline(Room r, List<Event> events) {
+      /// Builds a Timeline using public SDK APIs only.
+      /// Populates [aggregatedEvents] directly — no private imports needed.
+      Timeline buildTimeline(Room r, List<Event> editEvents) {
         final timeline = Timeline(
           room: r,
-          chunk: TimelineChunk(events: events),
+          chunk: TimelineChunk(events: []),
         );
-        for (final e in events) {
+        for (final e in editEvents) {
           timeline.addAggregatedEvent(e);
         }
         return timeline;
@@ -1062,7 +1086,8 @@ void main() {
           senderId: senderId,
           type: EventTypes.Message,
           room: room,
-          eventId: '\$edit_${newBody.hashCode}',
+          // Deterministic id based on original event + offset, not hash
+          eventId: '${originalEventId}_edit_$tsOffset',
           content: {
             'body': '* $newBody',
             'msgtype': 'm.text',
@@ -1086,7 +1111,7 @@ void main() {
           originalEventId: '\$orig1',
           newBody: 'Hello 😊',
         );
-        final timeline = createTimeline(room, [original, edit]);
+        final timeline = buildTimeline(room, [original, edit]);
 
         expect(original.isDisplayOnlyEmoji(timeline), false);
       });
@@ -1099,7 +1124,7 @@ void main() {
           originalEventId: '\$orig2',
           newBody: '😊😎🎉',
         );
-        final timeline = createTimeline(room, [original, edit]);
+        final timeline = buildTimeline(room, [original, edit]);
 
         expect(original.isDisplayOnlyEmoji(timeline), true);
       });
@@ -1112,7 +1137,7 @@ void main() {
           originalEventId: '\$orig3',
           newBody: '🔥❤️',
         );
-        final timeline = createTimeline(room, [original, edit]);
+        final timeline = buildTimeline(room, [original, edit]);
 
         expect(original.isDisplayOnlyEmoji(timeline), true);
       });
@@ -1121,7 +1146,7 @@ void main() {
           'WHEN no edits\n'
           'THEN return true (same as without timeline)\n', () {
         final original = createEmojiEvent(body: '😊', eventId: '\$orig4');
-        final timeline = createTimeline(room, [original]);
+        final timeline = buildTimeline(room, [original]);
 
         expect(original.isDisplayOnlyEmoji(timeline), true);
       });
@@ -1134,7 +1159,7 @@ void main() {
           originalEventId: '\$orig5',
           newBody: '😊😎🎉🔥❤️👍✨',
         );
-        final timeline = createTimeline(room, [original, edit]);
+        final timeline = buildTimeline(room, [original, edit]);
 
         expect(original.isDisplayOnlyEmoji(timeline), false);
       });

--- a/test/pages/chat/events/event_extension_test.dart
+++ b/test/pages/chat/events/event_extension_test.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:matrix/matrix.dart';
+import 'package:matrix/src/models/timeline_chunk.dart';
 import 'package:mockito/annotations.dart';
 
 import '../../../fake_client.dart';
@@ -1037,6 +1038,106 @@ void main() {
       final event = createEmojiEvent(body: '');
 
       expect(event.isDisplayOnlyEmoji(), false);
+    });
+
+    group('with edit events (Timeline provided)', () {
+      Timeline createTimeline(Room r, List<Event> events) {
+        final timeline = Timeline(
+          room: r,
+          chunk: TimelineChunk(events: events),
+        );
+        for (final e in events) {
+          timeline.addAggregatedEvent(e);
+        }
+        return timeline;
+      }
+
+      Event createEditEvent({
+        required String originalEventId,
+        required String newBody,
+        String senderId = '@user:example.com',
+        int tsOffset = 1000,
+      }) {
+        return Event(
+          senderId: senderId,
+          type: EventTypes.Message,
+          room: room,
+          eventId: '\$edit_${newBody.hashCode}',
+          content: {
+            'body': '* $newBody',
+            'msgtype': 'm.text',
+            'm.new_content': {'body': newBody, 'msgtype': 'm.text'},
+            'm.relates_to': {
+              'rel_type': RelationshipTypes.edit,
+              'event_id': originalEventId,
+            },
+          },
+          originServerTs: DateTime.fromMillisecondsSinceEpoch(
+            1234567890 + tsOffset,
+          ),
+        );
+      }
+
+      test('GIVEN original emoji-only message\n'
+          'WHEN edited to text with emoji\n'
+          'THEN return false\n', () {
+        final original = createEmojiEvent(body: '😊', eventId: '\$orig1');
+        final edit = createEditEvent(
+          originalEventId: '\$orig1',
+          newBody: 'Hello 😊',
+        );
+        final timeline = createTimeline(room, [original, edit]);
+
+        expect(original.isDisplayOnlyEmoji(timeline), false);
+      });
+
+      test('GIVEN original text message\n'
+          'WHEN edited to emoji only\n'
+          'THEN return true\n', () {
+        final original = createEmojiEvent(body: 'Hello', eventId: '\$orig2');
+        final edit = createEditEvent(
+          originalEventId: '\$orig2',
+          newBody: '😊😎🎉',
+        );
+        final timeline = createTimeline(room, [original, edit]);
+
+        expect(original.isDisplayOnlyEmoji(timeline), true);
+      });
+
+      test('GIVEN original emoji-only message\n'
+          'WHEN edited to different emoji only\n'
+          'THEN return true\n', () {
+        final original = createEmojiEvent(body: '😊', eventId: '\$orig3');
+        final edit = createEditEvent(
+          originalEventId: '\$orig3',
+          newBody: '🔥❤️',
+        );
+        final timeline = createTimeline(room, [original, edit]);
+
+        expect(original.isDisplayOnlyEmoji(timeline), true);
+      });
+
+      test('GIVEN original emoji-only message\n'
+          'WHEN no edits\n'
+          'THEN return true (same as without timeline)\n', () {
+        final original = createEmojiEvent(body: '😊', eventId: '\$orig4');
+        final timeline = createTimeline(room, [original]);
+
+        expect(original.isDisplayOnlyEmoji(timeline), true);
+      });
+
+      test('GIVEN original emoji-only message\n'
+          'WHEN edited to too many emojis (>6)\n'
+          'THEN return false\n', () {
+        final original = createEmojiEvent(body: '😊', eventId: '\$orig5');
+        final edit = createEditEvent(
+          originalEventId: '\$orig5',
+          newBody: '😊😎🎉🔥❤️👍✨',
+        );
+        final timeline = createTimeline(room, [original, edit]);
+
+        expect(original.isDisplayOnlyEmoji(timeline), false);
+      });
     });
   });
 }


### PR DESCRIPTION
## Ticket
**Related issue**

- #3004

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/dbdf7385-1148-4cc5-906f-40e7a34aefa4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message bubble sizing and layout now account for timeline-specific displayed content, improving wrapping and newline decisions.
  * Emoji-only detection and bubble styling respect timeline-aware edits, improving display accuracy for edited messages.
  * Message text styling now reflects the timeline-visible content when edits are present.

* **Tests**
  * Added tests covering emoji-only detection and styling across edited message scenarios with timeline context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->