### PR TITLE
fix: resolve GoRouter type cast crash when opening pinned messages

### DIFF
--- a/lib/config/go_routes/app_routes.dart
+++ b/lib/config/go_routes/app_routes.dart
@@ -766,7 +766,7 @@ class RoomRoute extends GoRouteData with $RoomRoute {
   const RoomRoute({required this.roomid, this.event, this.$extra});
   final String roomid;
   final String? event; // query param: ?event=xxx
-  final ChatRouterInputArgument? $extra;
+  final Object? $extra;
 
   @override
   FutureOr<String?> redirect(BuildContext context, GoRouterState state) =>
@@ -774,21 +774,22 @@ class RoomRoute extends GoRouteData with $RoomRoute {
 
   @override
   Page<void> buildPage(BuildContext context, GoRouterState state) {
-    if ($extra != null) {
-      switch ($extra!.type) {
+    final extra = $extra is ChatRouterInputArgument ? $extra : null;
+    if (extra != null) {
+      switch (extra.type) {
         case ChatRouterInputArgumentType.draft:
           return _buildRoomPage(
             context,
             state,
             prefix: 'Draft',
-            roomName: $extra!.data is String ? $extra!.data as String? : null,
+            roomName: extra.data is String ? extra.data as String? : null,
           );
         case ChatRouterInputArgumentType.share:
           return _buildRoomPage(
             context,
             state,
             prefix: 'Share',
-            shareFiles: $extra!.data as List<MatrixFile?>?,
+            shareFiles: extra.data as List<MatrixFile?>?,
           );
       }
     }

--- a/lib/config/go_routes/app_routes.dart
+++ b/lib/config/go_routes/app_routes.dart
@@ -774,7 +774,8 @@ class RoomRoute extends GoRouteData with $RoomRoute {
 
   @override
   Page<void> buildPage(BuildContext context, GoRouterState state) {
-    final extra = $extra is ChatRouterInputArgument ? $extra : null;
+    final extra =
+        $extra is ChatRouterInputArgument ? $extra as ChatRouterInputArgument : null;
     if (extra != null) {
       switch (extra.type) {
         case ChatRouterInputArgumentType.draft:

--- a/lib/config/go_routes/app_routes.dart
+++ b/lib/config/go_routes/app_routes.dart
@@ -774,8 +774,9 @@ class RoomRoute extends GoRouteData with $RoomRoute {
 
   @override
   Page<void> buildPage(BuildContext context, GoRouterState state) {
-    final extra =
-        $extra is ChatRouterInputArgument ? $extra as ChatRouterInputArgument : null;
+    final extra = $extra is ChatRouterInputArgument
+        ? $extra as ChatRouterInputArgument
+        : null;
     if (extra != null) {
       switch (extra.type) {
         case ChatRouterInputArgumentType.draft:

--- a/lib/config/go_routes/app_routes.dart
+++ b/lib/config/go_routes/app_routes.dart
@@ -791,7 +791,9 @@ class RoomRoute extends GoRouteData with $RoomRoute {
             context,
             state,
             prefix: 'Share',
-            shareFiles: extra.data as List<MatrixFile?>?,
+            shareFiles: extra.data is List<MatrixFile?>
+                ? extra.data as List<MatrixFile?>
+                : null,
           );
       }
     }


### PR DESCRIPTION
## Summary
- **Bug**: Navigating to the pinned messages screen crashed with `GoException: type 'PinnedEventsArgument' is not a subtype of type 'ChatRouterInputArgument?' in type cast`
- **Root cause**: `RoomRoute.$extra` was typed as `ChatRouterInputArgument?`, so the generated `_fromState` hard-casts `state.extra`. When the child `PinnedMessagesRoute` passes a `PinnedEventsArgument`, the parent route's cast fails during redirect.
- **Fix**: Widen `RoomRoute.$extra` to `Object?` and add a safe `is` check in `buildPage`, preserving existing draft/share behavior.

Closes #3006

https://github.com/user-attachments/assets/6545952c-6cc8-4750-80be-b5868bd2c150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Safer handling of routing parameters with runtime validation and guarded access.
  * Reduces risk of routing-related crashes while preserving existing draft and share behaviors (including prefix, room name, and shared files).
  * Internal change only; no visible UI or workflow changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->