### PR TITLE
TW-3666(fix): multi-URL federation lookup with identity fallback and …

### DIFF
--- a/lib/domain/contact_manager/contacts_manager.dart
+++ b/lib/domain/contact_manager/contacts_manager.dart
@@ -365,13 +365,15 @@ class ContactsManager {
                 lookupChunkSize: _lookupChunkSize,
                 argument: FederationLookUpArgument(
                   homeServerUrl: homeServerUrlInterceptor.baseUrl ?? '',
-                  federationUrl:
-                      federationConfigurations
-                          .fedServerInformation
-                          .baseUrls
-                          ?.first
-                          .toString() ??
-                      '',
+                  federationUrls:
+                      federationConfigurations.fedServerInformation.baseUrls
+                          ?.map((u) => u.toString())
+                          .toList() ??
+                      [],
+                  identityServerUrl: federationConfigurations
+                      .identityServerInformation
+                      ?.baseUrl
+                      .toString(),
                   withMxId: withMxId,
                   withAccessToken:
                       authorizationInterceptor.getAccessToken ?? '',

--- a/lib/domain/model/extensions/string_extension.dart
+++ b/lib/domain/model/extensions/string_extension.dart
@@ -10,7 +10,13 @@ extension StringExtension on String {
   }
 
   String get convertToHttps {
-    final domain = split(':').first;
-    return 'https://$domain/';
+    if (startsWith('https://')) {
+      return endsWith('/') ? this : '$this/';
+    }
+    if (startsWith('http://')) {
+      final upgraded = replaceFirst('http://', 'https://');
+      return upgraded.endsWith('/') ? upgraded : '$upgraded/';
+    }
+    return 'https://$this/';
   }
 }

--- a/lib/domain/usecase/contacts/federation_look_up_argument.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_argument.dart
@@ -1,12 +1,16 @@
 import 'package:fluffychat/domain/usecase/contacts/twake_look_up_argument.dart';
 
 class FederationLookUpArgument extends TwakeLookUpArgument {
-  final String federationUrl;
+  final List<String> federationUrls;
+
+  /// Queried directly only when absent from any `third_party_mappings` response.
+  final String? identityServerUrl;
   final String withMxId;
 
   FederationLookUpArgument({
     required super.homeServerUrl,
-    required this.federationUrl,
+    required this.federationUrls,
+    this.identityServerUrl,
     required this.withMxId,
     required super.withAccessToken,
   });
@@ -14,7 +18,8 @@ class FederationLookUpArgument extends TwakeLookUpArgument {
   @override
   List<Object?> get props => [
     homeServerUrl,
-    federationUrl,
+    federationUrls,
+    identityServerUrl,
     withMxId,
     withAccessToken,
   ];

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -92,20 +92,14 @@ class FederationLookUpPhonebookContactInteractor {
     try {
       yield const Right(GetPhonebookContactsLoading());
 
+      Failure? fetchFailure;
       final List<Contact> contacts = [];
-      try {
-        final res = await _phonebookContactRepository.fetchContacts();
-        if (res.isEmpty) {
-          yield const Left(GetPhonebookContactsIsEmpty());
-          return;
-        }
-        contacts.addAll(res);
-      } catch (e) {
-        Logs().e(
-          'FederationLookUpPhonebookContactInteractor::execute: fetchContacts',
-          e,
-        );
-        yield Left(GetPhoneBookContactFailure(exception: e));
+      (await _tryFetchContacts()).fold(
+        (f) => fetchFailure = f,
+        contacts.addAll,
+      );
+      if (fetchFailure != null) {
+        yield Left(fetchFailure!);
         return;
       }
 
@@ -179,53 +173,16 @@ class FederationLookUpPhonebookContactInteractor {
 
       for (final chunkContacts in chunks) {
         try {
-          _ChunkSessionResult? sessionsResult;
-          Object? federationChunkError;
-          StackTrace? federationChunkStackTrace;
-          try {
-            sessionsResult = await _processFederationSessionsForChunk(
-              sessions: sessions,
-              chunkContacts: chunkContacts,
-              argument: argument,
-              globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
-              tokenInfo: sharedTokenInfo!,
-            );
-          } catch (e, s) {
-            federationChunkError = e;
-            federationChunkStackTrace = s;
-          }
-
-          final contactsFromIdentity = identitySession != null
-              ? await _processIdentityServerForChunk(
-                  identitySession: identitySession,
-                  chunkContacts: chunkContacts,
-                  globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
-                )
-              : const <Contact>{};
-
-          if (federationChunkError != null && contactsFromIdentity.isEmpty) {
-            Error.throwWithStackTrace(
-              federationChunkError,
-              federationChunkStackTrace!,
-            );
-          }
-
-          final combinedContacts = chunkContacts.toSet().combineContacts(
-            contactsFromMappings: {
-              ...sessionsResult?.fromMappings ?? {},
-              ...contactsFromIdentity,
-            },
-            contactsFromThirdParty: sessionsResult?.fromThirdParty ?? {},
+          final combinedContacts = await _processChunkContacts(
+            chunkContacts: chunkContacts,
+            sessions: sessions,
+            identitySession: identitySession,
+            argument: argument,
+            globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
+            tokenInfo: sharedTokenInfo!,
           );
-
-          await _storeContactsInHive(
-            contacts: combinedContacts,
-            userId: argument.withMxId,
-          );
-
           updatedContact.addAll(combinedContacts);
           progress++;
-
           yield Right(
             GetPhonebookContactsSuccess(
               progress: (progress / chunks.length * 100).toInt(),
@@ -275,6 +232,75 @@ class FederationLookUpPhonebookContactInteractor {
         contacts: updatedContact.toList(),
       ),
     );
+  }
+
+  Future<Either<Failure, List<Contact>>> _tryFetchContacts() async {
+    try {
+      final res = await _phonebookContactRepository.fetchContacts();
+      if (res.isEmpty) return const Left(GetPhonebookContactsIsEmpty());
+      return Right(res);
+    } catch (e) {
+      Logs().e(
+        'FederationLookUpPhonebookContactInteractor::execute: fetchContacts',
+        e,
+      );
+      return Left(GetPhoneBookContactFailure(exception: e));
+    }
+  }
+
+  Future<Set<Contact>> _processChunkContacts({
+    required List<Contact> chunkContacts,
+    required List<_FederationServerSession> sessions,
+    required _FederationServerSession? identitySession,
+    required FederationLookUpArgument argument,
+    required Set<String> globalSeenThirdPartyUrls,
+    required FederationTokenInformation tokenInfo,
+  }) async {
+    _ChunkSessionResult? sessionsResult;
+    Object? federationChunkError;
+    StackTrace? federationChunkStackTrace;
+    try {
+      sessionsResult = await _processFederationSessionsForChunk(
+        sessions: sessions,
+        chunkContacts: chunkContacts,
+        argument: argument,
+        globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
+        tokenInfo: tokenInfo,
+      );
+    } catch (e, s) {
+      federationChunkError = e;
+      federationChunkStackTrace = s;
+    }
+
+    final contactsFromIdentity = identitySession != null
+        ? await _processIdentityServerForChunk(
+            identitySession: identitySession,
+            chunkContacts: chunkContacts,
+            globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
+          )
+        : const <Contact>{};
+
+    if (federationChunkError != null && contactsFromIdentity.isEmpty) {
+      Error.throwWithStackTrace(
+        federationChunkError,
+        federationChunkStackTrace!,
+      );
+    }
+
+    final combinedContacts = chunkContacts.toSet().combineContacts(
+      contactsFromMappings: {
+        ...sessionsResult?.fromMappings ?? {},
+        ...contactsFromIdentity,
+      },
+      contactsFromThirdParty: sessionsResult?.fromThirdParty ?? {},
+    );
+
+    await _storeContactsInHive(
+      contacts: combinedContacts,
+      userId: argument.withMxId,
+    );
+
+    return combinedContacts;
   }
 
   /// Processes all federation [sessions] for a single [chunkContacts] slice.

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -179,13 +179,21 @@ class FederationLookUpPhonebookContactInteractor {
 
       for (final chunkContacts in chunks) {
         try {
-          final sessionsResult = await _processFederationSessionsForChunk(
-            sessions: sessions,
-            chunkContacts: chunkContacts,
-            argument: argument,
-            globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
-            tokenInfo: sharedTokenInfo!,
-          );
+          _ChunkSessionResult? sessionsResult;
+          Object? federationChunkError;
+          StackTrace? federationChunkStackTrace;
+          try {
+            sessionsResult = await _processFederationSessionsForChunk(
+              sessions: sessions,
+              chunkContacts: chunkContacts,
+              argument: argument,
+              globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
+              tokenInfo: sharedTokenInfo!,
+            );
+          } catch (e, s) {
+            federationChunkError = e;
+            federationChunkStackTrace = s;
+          }
 
           final contactsFromIdentity = identitySession != null
               ? await _processIdentityServerForChunk(
@@ -195,12 +203,19 @@ class FederationLookUpPhonebookContactInteractor {
                 )
               : const <Contact>{};
 
+          if (federationChunkError != null && contactsFromIdentity.isEmpty) {
+            Error.throwWithStackTrace(
+              federationChunkError,
+              federationChunkStackTrace!,
+            );
+          }
+
           final combinedContacts = chunkContacts.toSet().combineContacts(
             contactsFromMappings: {
-              ...sessionsResult.fromMappings,
+              ...sessionsResult?.fromMappings ?? {},
               ...contactsFromIdentity,
             },
-            contactsFromThirdParty: sessionsResult.fromThirdParty,
+            contactsFromThirdParty: sessionsResult?.fromThirdParty ?? {},
           );
 
           await _storeContactsInHive(

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -579,7 +579,12 @@ class FederationLookUpPhonebookContactInteractor {
     return updatedContact;
   }
 
-  String _normalizeUrl(String url) => url.replaceFirst(RegExp(r'/+$'), '');
+  String _normalizeUrl(String url) {
+    final trimmed = url.replaceFirst(RegExp(r'/+$'), '');
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null) return trimmed;
+    return '${uri.scheme}://${uri.host}:${uri.port}';
+  }
 
   Future<void> _storeContactsInHive({
     required Set<Contact> contacts,

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -28,6 +28,43 @@ import 'package:fluffychat/modules/federation_identity_request_token/domain/stat
 import 'package:fluffychat/modules/federation_identity_request_token/manager/federation_identity_request_token_manager.dart';
 import 'package:matrix/matrix.dart' hide Contact;
 
+/// Setup state produced by the request-token → register → hash-details
+/// sequence for a single server URL.
+class _FederationServerSession {
+  final String url;
+  final FederationRegisterResponse registerToken;
+  final FederationHashDetailsResponse hashDetails;
+
+  const _FederationServerSession({
+    required this.url,
+    required this.registerToken,
+    required this.hashDetails,
+  });
+}
+
+/// Result of processing all federation sessions for a single chunk.
+class _ChunkSessionResult {
+  final Set<Contact> fromMappings;
+  final Set<Contact> fromThirdParty;
+
+  const _ChunkSessionResult({
+    required this.fromMappings,
+    required this.fromThirdParty,
+  });
+}
+
+/// Hashed representation of a contact chunk tied to one server's pepper and
+/// algorithms (which may differ between servers).
+class _ContactHashing {
+  final Map<String, List<String>> hashToContactIdMappings;
+  final Map<String, Contact> contactIdToHashMap;
+
+  const _ContactHashing({
+    required this.hashToContactIdMappings,
+    required this.contactIdToHashMap,
+  });
+}
+
 class FederationLookUpPhonebookContactInteractor {
   final PhonebookContactRepository _phonebookContactRepository = getIt
       .get<PhonebookContactRepository>();
@@ -55,221 +92,93 @@ class FederationLookUpPhonebookContactInteractor {
     try {
       yield const Right(GetPhonebookContactsLoading());
 
-      FederationTokenInformation? federationIdentityRequestTokenRes;
-
-      FederationRegisterResponse? federationRegisterToken;
-
       final List<Contact> contacts = [];
-
       try {
         final res = await _phonebookContactRepository.fetchContacts();
-
         if (res.isEmpty) {
           yield const Left(GetPhonebookContactsIsEmpty());
           return;
         }
-
         contacts.addAll(res);
       } catch (e) {
         Logs().e(
-          'FederationLookUpPhonebookContactInteractor::execute: Register: $e',
+          'FederationLookUpPhonebookContactInteractor::execute: fetchContacts',
+          e,
         );
         yield Left(GetPhoneBookContactFailure(exception: e));
         return;
       }
 
-      await _federationIdentityRequestTokenManager
-          .execute(
-            federationTokenRequest: FederationTokenRequest(
-              homeserverUrl: '${argument.homeServerUrl}/',
-              mxid: argument.withMxId,
-              accessToken: argument.withAccessToken,
-            ),
-          )
-          .then(
-            (state) => state.fold((failure) {}, (success) {
-              if (success is FederationIdentityRequestTokenSuccess) {
-                federationIdentityRequestTokenRes = success.tokenInformation;
-              }
-            }),
-          );
-
-      Logs().d(
-        'FederationLookUpPhonebookContactInteractor::execute: federationIdentityRequestTokenRes: $federationIdentityRequestTokenRes',
+      final tokenRequest = FederationTokenRequest(
+        homeserverUrl: '${argument.homeServerUrl}/',
+        mxid: argument.withMxId,
+        accessToken: argument.withAccessToken,
       );
 
-      if (federationIdentityRequestTokenRes == null) {
+      Failure? firstSetupFailure;
+      final List<_FederationServerSession> sessions = [];
+
+      for (final url in argument.federationUrls) {
+        final session = await _setupSession(
+          federationUrl: url,
+          tokenRequest: tokenRequest,
+          contacts: contacts,
+          firstFailureRef: (f) => firstSetupFailure ??= f,
+        );
+        if (session != null) sessions.add(session);
+      }
+
+      // The identity server session is set up upfront. It is only queried
+      // per-chunk when its URL has not yet appeared in any third_party_mappings
+      // response (tracked globally across all chunks).
+      _FederationServerSession? identitySession;
+      if (argument.identityServerUrl != null) {
+        identitySession = await _setupSession(
+          federationUrl: argument.identityServerUrl!,
+          tokenRequest: tokenRequest,
+          contacts: contacts,
+          firstFailureRef: (_) {},
+        );
+      }
+
+      if (sessions.isEmpty && identitySession == null) {
         yield Left(
-          RequestTokenFailure(exception: 'Token is empty', contacts: contacts),
+          firstSetupFailure ??
+              RequestTokenFailure(
+                exception: 'No federation servers available',
+                contacts: contacts,
+              ),
         );
         return;
       }
 
-      try {
-        final res = await _identityLookupManager.register(
-          federationUrl: argument.federationUrl,
-          tokenInformation: federationIdentityRequestTokenRes!,
-        );
-        if (res.token == null || res.token!.isEmpty) {
-          yield Left(
-            RegisterTokenFailure(
-              exception: 'Token is empty',
-              contacts: contacts,
-            ),
-          );
-          return;
-        }
-
-        federationRegisterToken = res;
-      } catch (e) {
-        Logs().e(
-          'FederationLookUpPhonebookContactInteractor::execute: Register: $e',
-        );
-        yield Left(
-          RegisterTokenFailure(
-            exception: 'Register failed',
-            contacts: contacts,
-          ),
-        );
-        return;
-      }
-
-      Logs().d(
-        'FederationLookUpPhonebookContactInteractor::execute: federationRegisterToken: $federationRegisterToken',
-      );
-
-      FederationHashDetailsResponse? hashDetails;
-      try {
-        final res = await _identityLookupManager.getHashDetails(
-          federationUrl: argument.federationUrl,
-          registeredToken: federationRegisterToken.token!,
-        );
-
-        Logs().d(
-          'FederationLookUpPhonebookContactInteractor::execute: hashDetails: $hashDetails',
-        );
-
-        if (res.lookupPepper?.isEmpty == true &&
-            res.algorithms?.isEmpty == true) {
-          yield const Left(
-            GetHashDetailsFailure(exception: 'Hash details is empty'),
-          );
-        }
-
-        hashDetails = res;
-      } catch (e) {
-        Logs().e(
-          'FederationLookUpPhonebookContactInteractor::execute: GetHashDetails: $e',
-        );
-        yield Left(GetHashDetailsFailure(exception: e));
-      }
-
-      final contactIdToHashMap = {
-        for (final contact in contacts) contact.id: contact,
-      };
-
-      final chunks = contactIdToHashMap.values.slices(lookupChunkSize);
+      final Set<String> globalSeenThirdPartyUrls = {};
+      final chunks = contacts.slices(lookupChunkSize).toList();
 
       for (final chunkContacts in chunks) {
-        final Map<String, List<String>> hashToContactIdMappings = {};
-        final Map<String, Contact> contactIdToHashMap = {};
         try {
-          for (final chunkContact in chunkContacts) {
-            final phoneToHashMap = <String, List<String>>{};
-            final emailToHashMap = <String, List<String>>{};
-            if (chunkContact.phoneNumbers != null &&
-                chunkContact.phoneNumbers!.isNotEmpty) {
-              phoneToHashMap.addAll(
-                chunkContact.phoneNumbers!.calculateHashesForPhoneNumbers(
-                  hashDetails,
-                ),
-              );
-
-              hashToContactIdMappings
-                  .putIfAbsent(chunkContact.id, () => [])
-                  .addAll(phoneToHashMap.values.expand((hash) => hash));
-            }
-
-            if (chunkContact.emails != null &&
-                chunkContact.emails!.isNotEmpty) {
-              emailToHashMap.addAll(
-                chunkContact.emails!.calculateHashesForEmails(hashDetails),
-              );
-
-              hashToContactIdMappings
-                  .putIfAbsent(chunkContact.id, () => [])
-                  .addAll(emailToHashMap.values.expand((hash) => hash));
-            }
-
-            final updatedContact = chunkContact.updateContactWithHashes(
-              phoneToHashMap: phoneToHashMap,
-              emailToHashMap: emailToHashMap,
-            );
-
-            contactIdToHashMap[chunkContact.id] = updatedContact;
-          }
-
-          final request = FederationLookupMxidRequest(
-            addresses: hashToContactIdMappings.values
-                .expand((hash) => hash)
-                .toSet(),
-            algorithm: hashDetails?.algorithms?.firstOrNull,
-            pepper: hashDetails?.lookupPepper,
-          );
-          FederationLookupMxidResponse? response;
-          response = await _identityLookupManager.lookupMxid(
-            federationUrl: argument.federationUrl,
-            request: request,
-            registeredToken: federationRegisterToken.token!,
+          final sessionsResult = await _processFederationSessionsForChunk(
+            sessions: sessions,
+            chunkContacts: chunkContacts,
+            argument: argument,
+            globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
           );
 
-          final Set<Contact> contactsFromMappings = {};
-
-          final Set<Contact> contactsFromThirdParty = {};
-
-          try {
-            if (response.mappings != null && response.mappings!.isNotEmpty) {
-              final updatedContact = contactIdToHashMap.values
-                  .toSet()
-                  .handleLookupMappings(
-                    mappings: response.mappings ?? {},
-                    hashToContactIdMappings: hashToContactIdMappings,
-                  );
-
-              contactsFromMappings.addAll(updatedContact);
-            }
-          } catch (e) {
-            Logs().e(
-              'FederationLookUpPhonebookContactInteractor::execute(): handle mappings failed',
-              e,
-            );
-          }
-
-          try {
-            if (response.thirdPartyMappings != null &&
-                response.thirdPartyMappings!.isNotEmpty) {
-              final newContactsThirdParty = await _handleThirdPartyMappings(
-                thirdPartyToHashes: response.thirdPartyMappings ?? {},
-                hashToContactIdMappings: hashToContactIdMappings,
-                newContacts: contactIdToHashMap.values.toList(),
-                argument: argument,
-              );
-
-              Logs().d(
-                'FederationLookUpPhonebookContactInteractor::execute: newContacts: $newContactsThirdParty',
-              );
-
-              contactsFromThirdParty.addAll(newContactsThirdParty);
-            }
-          } catch (e) {
-            Logs().d(
-              'FederationLookUpPhonebookContactInteractor::execute(): handle third party mappings failed',
-            );
-          }
+          final contactsFromIdentity = identitySession != null
+              ? await _processIdentityServerForChunk(
+                  identitySession: identitySession,
+                  chunkContacts: chunkContacts,
+                  globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
+                  argument: argument,
+                )
+              : const <Contact>{};
 
           final combinedContacts = chunkContacts.toSet().combineContacts(
-            contactsFromMappings: contactsFromMappings,
-            contactsFromThirdParty: contactsFromThirdParty,
+            contactsFromMappings: {
+              ...sessionsResult.fromMappings,
+              ...contactsFromIdentity,
+            },
+            contactsFromThirdParty: sessionsResult.fromThirdParty,
           );
 
           await _storeContactsInHive(
@@ -278,20 +187,19 @@ class FederationLookUpPhonebookContactInteractor {
           );
 
           updatedContact.addAll(combinedContacts);
-
           progress++;
-
-          final progressStep = (progress / chunks.length * 100).toInt();
 
           yield Right(
             GetPhonebookContactsSuccess(
-              progress: progressStep,
+              progress: (progress / chunks.length * 100).toInt(),
               contacts: updatedContact.toList(),
             ),
           );
         } catch (e) {
           Logs().e(
-            'FederationLookUpPhonebookContactInteractor::execute(): one chunk exception $e',
+            'FederationLookUpPhonebookContactInteractor::execute: '
+            'chunk exception',
+            e,
           );
           progress++;
           updatedContact.addAll(chunkContacts);
@@ -308,7 +216,6 @@ class FederationLookUpPhonebookContactInteractor {
       return;
     }
 
-    // finalize the process
     if (chunkError != null) {
       await _sharedPreferencesContactCacheManager
           .storeChunkFederationLookUpError(
@@ -321,14 +228,288 @@ class FederationLookUpPhonebookContactInteractor {
         ),
       );
       return;
-    } else {
-      await _sharedPreferencesContactCacheManager
-          .deleteChunkFederationLookUpError();
-      yield Right(
-        GetPhonebookContactsSuccess(
-          progress: 100,
-          contacts: updatedContact.toList(),
+    }
+
+    await _sharedPreferencesContactCacheManager
+        .deleteChunkFederationLookUpError();
+    yield Right(
+      GetPhonebookContactsSuccess(
+        progress: 100,
+        contacts: updatedContact.toList(),
+      ),
+    );
+  }
+
+  /// Processes all federation [sessions] for a single [chunkContacts] slice.
+  /// Mutates [globalSeenThirdPartyUrls] with any third-party server URLs found.
+  /// Returns the collected direct and third-party contacts.
+  Future<_ChunkSessionResult> _processFederationSessionsForChunk({
+    required List<_FederationServerSession> sessions,
+    required List<Contact> chunkContacts,
+    required FederationLookUpArgument argument,
+    required Set<String> globalSeenThirdPartyUrls,
+  }) async {
+    final Set<Contact> fromMappings = {};
+    final Set<Contact> fromThirdParty = {};
+
+    Object? firstLookupError;
+    var successfulLookups = 0;
+
+    for (final session in sessions) {
+      final hashing = _hashContacts(chunkContacts, session.hashDetails);
+      late final FederationLookupMxidResponse response;
+      try {
+        response = await _identityLookupManager.lookupMxid(
+          federationUrl: session.url,
+          request: FederationLookupMxidRequest(
+            addresses: hashing.hashToContactIdMappings.values
+                .expand((h) => h)
+                .toSet(),
+            algorithm: session.hashDetails.algorithms?.firstOrNull,
+            pepper: session.hashDetails.lookupPepper,
+          ),
+          registeredToken: session.registerToken.token!,
+        );
+        successfulLookups++;
+      } catch (e) {
+        firstLookupError ??= e;
+        Logs().e(
+          'FederationLookUpPhonebookContactInteractor::_processFederationSessionsForChunk: '
+          'lookup failed for ${session.url}',
+          e,
+        );
+        continue;
+      }
+
+      _collectMappings(
+        response: response,
+        hashing: hashing,
+        target: fromMappings,
+      );
+
+      if (response.thirdPartyMappings != null &&
+          response.thirdPartyMappings!.isNotEmpty) {
+        globalSeenThirdPartyUrls.addAll(
+          response.thirdPartyMappings!.keys.map(
+            (k) => _normalizeUrl(k.convertToHttps),
+          ),
+        );
+        try {
+          final thirdPartyContacts = await _handleThirdPartyMappings(
+            thirdPartyToHashes: response.thirdPartyMappings!,
+            hashToContactIdMappings: hashing.hashToContactIdMappings,
+            newContacts: hashing.contactIdToHashMap.values.toList(),
+            argument: argument,
+          );
+          fromThirdParty.addAll(thirdPartyContacts);
+        } catch (e) {
+          Logs().d(
+            'FederationLookUpPhonebookContactInteractor::_processFederationSessionsForChunk: '
+            'third party mappings failed for ${session.url}',
+          );
+        }
+      }
+    }
+
+    if (sessions.isNotEmpty &&
+        successfulLookups == 0 &&
+        firstLookupError != null) {
+      throw firstLookupError;
+    }
+
+    return _ChunkSessionResult(
+      fromMappings: fromMappings,
+      fromThirdParty: fromThirdParty,
+    );
+  }
+
+  /// Queries the identity server for [chunkContacts] unless its URL is already
+  /// covered by [globalSeenThirdPartyUrls]. Returns the matched contacts.
+  Future<Set<Contact>> _processIdentityServerForChunk({
+    required _FederationServerSession identitySession,
+    required List<Contact> chunkContacts,
+    required Set<String> globalSeenThirdPartyUrls,
+    required FederationLookUpArgument argument,
+  }) async {
+    if (argument.identityServerUrl != null &&
+        globalSeenThirdPartyUrls.contains(
+          _normalizeUrl(argument.identityServerUrl!),
+        )) {
+      return const {};
+    }
+    final Set<Contact> result = {};
+    try {
+      final hashing = _hashContacts(chunkContacts, identitySession.hashDetails);
+      final idResponse = await _identityLookupManager.lookupMxid(
+        federationUrl: identitySession.url,
+        request: FederationLookupMxidRequest(
+          addresses: hashing.hashToContactIdMappings.values
+              .expand((h) => h)
+              .toSet(),
+          algorithm: identitySession.hashDetails.algorithms?.firstOrNull,
+          pepper: identitySession.hashDetails.lookupPepper,
         ),
+        registeredToken: identitySession.registerToken.token!,
+      );
+      _collectMappings(response: idResponse, hashing: hashing, target: result);
+    } catch (e) {
+      Logs().e(
+        'FederationLookUpPhonebookContactInteractor::_processIdentityServerForChunk: '
+        'identity server lookup failed',
+        e,
+      );
+    }
+    return result;
+  }
+
+  /// Runs request-token → register → hash-details for [federationUrl].
+  /// Returns null if any step fails; [firstFailureRef] receives the first
+  /// [Failure] encountered.
+  Future<_FederationServerSession?> _setupSession({
+    required String federationUrl,
+    required FederationTokenRequest tokenRequest,
+    required List<Contact> contacts,
+    required void Function(Failure) firstFailureRef,
+  }) async {
+    FederationTokenInformation? tokenInfo;
+    await _federationIdentityRequestTokenManager
+        .execute(federationTokenRequest: tokenRequest)
+        .then(
+          (state) => state.fold((failure) {}, (success) {
+            if (success is FederationIdentityRequestTokenSuccess) {
+              tokenInfo = success.tokenInformation;
+            }
+          }),
+        );
+
+    if (tokenInfo == null) {
+      Logs().e(
+        'FederationLookUpPhonebookContactInteractor::_setupSession: '
+        'request token null for $federationUrl',
+      );
+      firstFailureRef(
+        RequestTokenFailure(exception: 'Token is empty', contacts: contacts),
+      );
+      return null;
+    }
+
+    FederationRegisterResponse? registerToken;
+    try {
+      final res = await _identityLookupManager.register(
+        federationUrl: federationUrl,
+        tokenInformation: tokenInfo!,
+      );
+      if (res.token == null || res.token!.isEmpty) {
+        firstFailureRef(
+          RegisterTokenFailure(exception: 'Token is empty', contacts: contacts),
+        );
+        return null;
+      }
+      registerToken = res;
+    } catch (e) {
+      Logs().e(
+        'FederationLookUpPhonebookContactInteractor::_setupSession: '
+        'register failed for $federationUrl',
+        e,
+      );
+      firstFailureRef(
+        RegisterTokenFailure(exception: 'Register failed', contacts: contacts),
+      );
+      return null;
+    }
+
+    try {
+      final hashDetails = await _identityLookupManager.getHashDetails(
+        federationUrl: federationUrl,
+        registeredToken: registerToken.token!,
+      );
+
+      if (hashDetails.lookupPepper == null ||
+          hashDetails.lookupPepper!.isEmpty ||
+          hashDetails.algorithms == null ||
+          hashDetails.algorithms!.isEmpty) {
+        firstFailureRef(
+          const GetHashDetailsFailure(exception: 'Hash details is empty'),
+        );
+        return null;
+      }
+
+      return _FederationServerSession(
+        url: federationUrl,
+        registerToken: registerToken,
+        hashDetails: hashDetails,
+      );
+    } catch (e) {
+      Logs().e(
+        'FederationLookUpPhonebookContactInteractor::_setupSession: '
+        'hash details failed for $federationUrl',
+        e,
+      );
+      firstFailureRef(GetHashDetailsFailure(exception: e));
+      return null;
+    }
+  }
+
+  _ContactHashing _hashContacts(
+    List<Contact> chunkContacts,
+    FederationHashDetailsResponse hashDetails,
+  ) {
+    final Map<String, List<String>> hashToContactIdMappings = {};
+    final Map<String, Contact> contactIdToHashMap = {};
+
+    for (final contact in chunkContacts) {
+      final phoneToHashMap = <String, List<String>>{};
+      final emailToHashMap = <String, List<String>>{};
+
+      if (contact.phoneNumbers != null && contact.phoneNumbers!.isNotEmpty) {
+        phoneToHashMap.addAll(
+          contact.phoneNumbers!.calculateHashesForPhoneNumbers(hashDetails),
+        );
+        hashToContactIdMappings
+            .putIfAbsent(contact.id, () => [])
+            .addAll(phoneToHashMap.values.expand((h) => h));
+      }
+
+      if (contact.emails != null && contact.emails!.isNotEmpty) {
+        emailToHashMap.addAll(
+          contact.emails!.calculateHashesForEmails(hashDetails),
+        );
+        hashToContactIdMappings
+            .putIfAbsent(contact.id, () => [])
+            .addAll(emailToHashMap.values.expand((h) => h));
+      }
+
+      contactIdToHashMap[contact.id] = contact.updateContactWithHashes(
+        phoneToHashMap: phoneToHashMap,
+        emailToHashMap: emailToHashMap,
+      );
+    }
+
+    return _ContactHashing(
+      hashToContactIdMappings: hashToContactIdMappings,
+      contactIdToHashMap: contactIdToHashMap,
+    );
+  }
+
+  void _collectMappings({
+    required FederationLookupMxidResponse response,
+    required _ContactHashing hashing,
+    required Set<Contact> target,
+  }) {
+    if (response.mappings == null || response.mappings!.isEmpty) return;
+    try {
+      final updated = hashing.contactIdToHashMap.values
+          .toSet()
+          .handleLookupMappings(
+            mappings: response.mappings!,
+            hashToContactIdMappings: hashing.hashToContactIdMappings,
+          );
+      target.addAll(updated);
+    } catch (e) {
+      Logs().e(
+        'FederationLookUpPhonebookContactInteractor::_collectMappings: '
+        'failed',
+        e,
       );
     }
   }
@@ -348,16 +529,11 @@ class FederationLookUpPhonebookContactInteractor {
           hashToContactIdMappings: hashToContactIdMappings,
           hash: hash,
         );
-
-        if (contact == null) {
-          continue;
-        }
-
+        if (contact == null) continue;
         contactsNeedToCalculate[contact.id] = contact;
       }
 
       FederationTokenInformation? federationIdentityRequestTokenRes;
-
       await _federationIdentityRequestTokenManager
           .execute(
             federationTokenRequest: FederationTokenRequest(
@@ -388,14 +564,15 @@ class FederationLookUpPhonebookContactInteractor {
       result.fold(
         (failure) {
           Logs().e(
-            'FederationLookUpPhonebookContactInteractor::_handleThirdPartyMappings: failure: $failure',
+            'FederationLookUpPhonebookContactInteractor::_handleThirdPartyMappings: '
+            'failure: $failure',
           );
         },
         (success) {
           Logs().d(
-            'FederationLookUpPhonebookContactInteractor::_handleThirdPartyMappings: success: $success',
+            'FederationLookUpPhonebookContactInteractor::_handleThirdPartyMappings: '
+            'success: $success',
           );
-
           if (success is FederationIdentityLookupSuccess) {
             updatedContact.addAll(success.newContacts.toContacts());
           }
@@ -404,6 +581,8 @@ class FederationLookUpPhonebookContactInteractor {
     }
     return updatedContact;
   }
+
+  String _normalizeUrl(String url) => url.replaceFirst(RegExp(r'/+$'), '');
 
   Future<void> _storeContactsInHive({
     required Set<Contact> contacts,
@@ -420,7 +599,7 @@ class FederationLookUpPhonebookContactInteractor {
         ContactsHiveErrorEnum.storeError,
       );
       Logs().e(
-        'FederationLookUpPhonebookContactInteractor::storeContactsInHive: $e',
+        'FederationLookUpPhonebookContactInteractor::_storeContactsInHive: $e',
       );
     }
   }

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -277,6 +277,7 @@ class FederationLookUpPhonebookContactInteractor {
     final Set<Contact> fromThirdParty = {};
 
     Object? firstLookupError;
+    StackTrace? firstLookupStackTrace;
     var successfulLookups = 0;
 
     for (final session in sessions) {
@@ -295,8 +296,11 @@ class FederationLookUpPhonebookContactInteractor {
           registeredToken: session.registerToken.token!,
         );
         successfulLookups++;
-      } catch (e) {
-        firstLookupError ??= e;
+      } catch (e, s) {
+        if (firstLookupError == null) {
+          firstLookupError = e;
+          firstLookupStackTrace = s;
+        }
         Logs().e(
           'FederationLookUpPhonebookContactInteractor::_processFederationSessionsForChunk: '
           'lookup failed for ${session.url}',
@@ -339,7 +343,7 @@ class FederationLookUpPhonebookContactInteractor {
     if (sessions.isNotEmpty &&
         successfulLookups == 0 &&
         firstLookupError != null) {
-      throw firstLookupError;
+      Error.throwWithStackTrace(firstLookupError, firstLookupStackTrace!);
     }
 
     return _ChunkSessionResult(

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -109,11 +109,33 @@ class FederationLookUpPhonebookContactInteractor {
         return;
       }
 
-      final tokenRequest = FederationTokenRequest(
-        homeserverUrl: '${argument.homeServerUrl}/',
-        mxid: argument.withMxId,
-        accessToken: argument.withAccessToken,
-      );
+      FederationTokenInformation? sharedTokenInfo;
+      await _federationIdentityRequestTokenManager
+          .execute(
+            federationTokenRequest: FederationTokenRequest(
+              homeserverUrl: '${argument.homeServerUrl}/',
+              mxid: argument.withMxId,
+              accessToken: argument.withAccessToken,
+            ),
+          )
+          .then(
+            (state) => state.fold((failure) {}, (success) {
+              if (success is FederationIdentityRequestTokenSuccess) {
+                sharedTokenInfo = success.tokenInformation;
+              }
+            }),
+          );
+
+      if (sharedTokenInfo == null) {
+        Logs().e(
+          'FederationLookUpPhonebookContactInteractor::execute: '
+          'shared token request returned null',
+        );
+        yield Left(
+          RequestTokenFailure(exception: 'Token is empty', contacts: contacts),
+        );
+        return;
+      }
 
       Failure? firstSetupFailure;
       final List<_FederationServerSession> sessions = [];
@@ -121,7 +143,7 @@ class FederationLookUpPhonebookContactInteractor {
       for (final url in argument.federationUrls) {
         final session = await _setupSession(
           federationUrl: url,
-          tokenRequest: tokenRequest,
+          tokenInfo: sharedTokenInfo!,
           contacts: contacts,
           firstFailureRef: (f) => firstSetupFailure ??= f,
         );
@@ -135,7 +157,7 @@ class FederationLookUpPhonebookContactInteractor {
       if (argument.identityServerUrl != null) {
         identitySession = await _setupSession(
           federationUrl: argument.identityServerUrl!,
-          tokenRequest: tokenRequest,
+          tokenInfo: sharedTokenInfo!,
           contacts: contacts,
           firstFailureRef: (_) {},
         );
@@ -162,6 +184,7 @@ class FederationLookUpPhonebookContactInteractor {
             chunkContacts: chunkContacts,
             argument: argument,
             globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
+            tokenInfo: sharedTokenInfo!,
           );
 
           final contactsFromIdentity = identitySession != null
@@ -248,6 +271,7 @@ class FederationLookUpPhonebookContactInteractor {
     required List<Contact> chunkContacts,
     required FederationLookUpArgument argument,
     required Set<String> globalSeenThirdPartyUrls,
+    required FederationTokenInformation tokenInfo,
   }) async {
     final Set<Contact> fromMappings = {};
     final Set<Contact> fromThirdParty = {};
@@ -300,6 +324,7 @@ class FederationLookUpPhonebookContactInteractor {
             hashToContactIdMappings: hashing.hashToContactIdMappings,
             newContacts: hashing.contactIdToHashMap.values.toList(),
             argument: argument,
+            tokenInfo: tokenInfo,
           );
           fromThirdParty.addAll(thirdPartyContacts);
         } catch (e) {
@@ -362,42 +387,20 @@ class FederationLookUpPhonebookContactInteractor {
     return result;
   }
 
-  /// Runs request-token → register → hash-details for [federationUrl].
-  /// Returns null if any step fails; [firstFailureRef] receives the first
-  /// [Failure] encountered.
+  /// Runs register → hash-details for [federationUrl] using a pre-fetched
+  /// [tokenInfo]. Returns null if any step fails; [firstFailureRef] receives
+  /// the first [Failure] encountered.
   Future<_FederationServerSession?> _setupSession({
     required String federationUrl,
-    required FederationTokenRequest tokenRequest,
+    required FederationTokenInformation tokenInfo,
     required List<Contact> contacts,
     required void Function(Failure) firstFailureRef,
   }) async {
-    FederationTokenInformation? tokenInfo;
-    await _federationIdentityRequestTokenManager
-        .execute(federationTokenRequest: tokenRequest)
-        .then(
-          (state) => state.fold((failure) {}, (success) {
-            if (success is FederationIdentityRequestTokenSuccess) {
-              tokenInfo = success.tokenInformation;
-            }
-          }),
-        );
-
-    if (tokenInfo == null) {
-      Logs().e(
-        'FederationLookUpPhonebookContactInteractor::_setupSession: '
-        'request token null for $federationUrl',
-      );
-      firstFailureRef(
-        RequestTokenFailure(exception: 'Token is empty', contacts: contacts),
-      );
-      return null;
-    }
-
     FederationRegisterResponse? registerToken;
     try {
       final res = await _identityLookupManager.register(
         federationUrl: federationUrl,
-        tokenInformation: tokenInfo!,
+        tokenInformation: tokenInfo,
       );
       if (res.token == null || res.token!.isEmpty) {
         firstFailureRef(
@@ -519,6 +522,7 @@ class FederationLookUpPhonebookContactInteractor {
     required Map<String, List<String>> hashToContactIdMappings,
     required List<Contact> newContacts,
     required FederationLookUpArgument argument,
+    required FederationTokenInformation tokenInfo,
   }) async {
     final List<Contact> updatedContact = [];
     for (final server in thirdPartyToHashes.keys) {
@@ -533,30 +537,9 @@ class FederationLookUpPhonebookContactInteractor {
         contactsNeedToCalculate[contact.id] = contact;
       }
 
-      FederationTokenInformation? federationIdentityRequestTokenRes;
-      await _federationIdentityRequestTokenManager
-          .execute(
-            federationTokenRequest: FederationTokenRequest(
-              homeserverUrl: "${argument.homeServerUrl}/",
-              mxid: argument.withMxId,
-              accessToken: argument.withAccessToken,
-            ),
-          )
-          .then(
-            (state) => state.fold((failure) {}, (success) {
-              if (success is FederationIdentityRequestTokenSuccess) {
-                federationIdentityRequestTokenRes = success.tokenInformation;
-              }
-            }),
-          );
-
-      if (federationIdentityRequestTokenRes == null) {
-        return [];
-      }
-
       final arguments = FederationArguments(
         federationUrl: server.convertToHttps,
-        tokenInformation: federationIdentityRequestTokenRes!,
+        tokenInformation: tokenInfo,
         contactMaps: contactsNeedToCalculate.toFederationContactMap(),
       );
       final manager = getIt.get<FederationIdentityLookupManager>();

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -192,7 +192,6 @@ class FederationLookUpPhonebookContactInteractor {
                   identitySession: identitySession,
                   chunkContacts: chunkContacts,
                   globalSeenThirdPartyUrls: globalSeenThirdPartyUrls,
-                  argument: argument,
                 )
               : const <Contact>{};
 
@@ -358,12 +357,8 @@ class FederationLookUpPhonebookContactInteractor {
     required _FederationServerSession identitySession,
     required List<Contact> chunkContacts,
     required Set<String> globalSeenThirdPartyUrls,
-    required FederationLookUpArgument argument,
   }) async {
-    if (argument.identityServerUrl != null &&
-        globalSeenThirdPartyUrls.contains(
-          _normalizeUrl(argument.identityServerUrl!),
-        )) {
+    if (globalSeenThirdPartyUrls.contains(_normalizeUrl(identitySession.url))) {
       return const {};
     }
     final Set<Contact> result = {};

--- a/test/domain/contacts/contacts_manager_test.dart
+++ b/test/domain/contacts/contacts_manager_test.dart
@@ -360,10 +360,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -484,10 +489,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -549,10 +559,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -605,10 +620,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -673,10 +693,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -740,10 +765,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -806,10 +836,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -873,10 +908,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -938,10 +978,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -1031,10 +1076,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -1124,10 +1174,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -1217,10 +1272,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -1308,10 +1368,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -1412,10 +1477,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -1525,10 +1595,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -1614,10 +1689,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -1705,10 +1785,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -1796,10 +1881,15 @@ void main() {
         mockFederationLookUpPhonebookContactInteractor.execute(
           argument: FederationLookUpArgument(
             homeServerUrl: baseUrl,
-            federationUrl:
-                federationConfigurations.fedServerInformation.baseUrls?.first
-                    .toString() ??
-                '',
+            federationUrls:
+                federationConfigurations.fedServerInformation.baseUrls
+                    ?.map((u) => u.toString())
+                    .toList() ??
+                [],
+            identityServerUrl: federationConfigurations
+                .identityServerInformation
+                ?.baseUrl
+                .toString(),
             withMxId: mxId,
             withAccessToken: accessToken,
           ),
@@ -3168,10 +3258,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3220,10 +3315,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3278,10 +3378,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3343,10 +3448,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3399,10 +3509,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3464,10 +3579,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3523,10 +3643,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3606,10 +3731,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3689,10 +3819,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3772,10 +3907,15 @@ void main() {
           mockFederationLookUpPhonebookContactInteractor.execute(
             argument: FederationLookUpArgument(
               homeServerUrl: baseUrl,
-              federationUrl:
-                  federationConfigurations.fedServerInformation.baseUrls?.first
-                      .toString() ??
-                  '',
+              federationUrls:
+                  federationConfigurations.fedServerInformation.baseUrls
+                      ?.map((u) => u.toString())
+                      .toList() ??
+                  [],
+              identityServerUrl: federationConfigurations
+                  .identityServerInformation
+                  ?.baseUrl
+                  .toString(),
               withMxId: mxId,
               withAccessToken: accessToken,
             ),
@@ -3917,13 +4057,15 @@ void main() {
             mockFederationLookUpPhonebookContactInteractor.execute(
               argument: FederationLookUpArgument(
                 homeServerUrl: baseUrl,
-                federationUrl:
-                    federationConfigurations
-                        .fedServerInformation
-                        .baseUrls
-                        ?.first
-                        .toString() ??
-                    '',
+                federationUrls:
+                    federationConfigurations.fedServerInformation.baseUrls
+                        ?.map((u) => u.toString())
+                        .toList() ??
+                    [],
+                identityServerUrl: federationConfigurations
+                    .identityServerInformation
+                    ?.baseUrl
+                    .toString(),
                 withMxId: mxId,
                 withAccessToken: accessToken,
               ),
@@ -3983,13 +4125,15 @@ void main() {
             mockFederationLookUpPhonebookContactInteractor.execute(
               argument: FederationLookUpArgument(
                 homeServerUrl: baseUrl,
-                federationUrl:
-                    federationConfigurations
-                        .fedServerInformation
-                        .baseUrls
-                        ?.first
-                        .toString() ??
-                    '',
+                federationUrls:
+                    federationConfigurations.fedServerInformation.baseUrls
+                        ?.map((u) => u.toString())
+                        .toList() ??
+                    [],
+                identityServerUrl: federationConfigurations
+                    .identityServerInformation
+                    ?.baseUrl
+                    .toString(),
                 withMxId: mxId,
                 withAccessToken: accessToken,
               ),

--- a/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
@@ -63,7 +63,7 @@ void main() {
     homeServerUrl: homeserverUrl,
     withMxId: matrixId,
     withAccessToken: accessToken,
-    federationUrl: federationUrl,
+    federationUrls: [federationUrl],
   );
 
   final testTokenRequest = FederationTokenRequest(
@@ -1436,6 +1436,358 @@ void main() {
           ]),
         );
       });
+
+      test('should query all base_urls and merge their mappings', () async {
+        const secondFederationUrl = 'https://federation2.example.com';
+        final argumentMultiUrl = FederationLookUpArgument(
+          homeServerUrl: homeserverUrl,
+          withMxId: matrixId,
+          withAccessToken: accessToken,
+          federationUrls: [federationUrl, secondFederationUrl],
+        );
+
+        when(
+          mockRepository.fetchContacts(),
+        ).thenAnswer((_) async => testContacts);
+
+        // Both URLs succeed for token request.
+        when(
+          mockRequestTokenManager.execute(
+            federationTokenRequest: testTokenRequest,
+          ),
+        ).thenAnswer(
+          (_) async => const Right<Failure, Success>(
+            FederationIdentityRequestTokenSuccess(
+              tokenInformation: tokenInformation,
+            ),
+          ),
+        );
+
+        // First URL register.
+        when(
+          mockIdentityLookupManager.register(
+            federationUrl: federationUrl,
+            tokenInformation: tokenInformation,
+          ),
+        ).thenAnswer(
+          (_) async =>
+              const FederationRegisterResponse(token: 'token-server-1'),
+        );
+
+        // Second URL register.
+        when(
+          mockIdentityLookupManager.register(
+            federationUrl: secondFederationUrl,
+            tokenInformation: tokenInformation,
+          ),
+        ).thenAnswer(
+          (_) async =>
+              const FederationRegisterResponse(token: 'token-server-2'),
+        );
+
+        const hashDetails = FederationHashDetailsResponse(
+          algorithms: {'sha256'},
+          lookupPepper: 'pepper',
+          altLookupPeppers: {'pepper1'},
+        );
+
+        when(
+          mockIdentityLookupManager.getHashDetails(
+            federationUrl: anyNamed('federationUrl'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer((_) async => hashDetails);
+
+        // First server finds Alice's phone.
+        when(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: federationUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationLookupMxidResponse(
+            mappings: {
+              '6mWe5lBps9Rqabkqc_QIh0-jsdFogvcBi9EWs523fok':
+                  '@alice:matrix.org',
+            },
+            thirdPartyMappings: {},
+          ),
+        );
+
+        // Second server finds nothing new.
+        when(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: secondFederationUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationLookupMxidResponse(
+            mappings: {},
+            thirdPartyMappings: {},
+          ),
+        );
+
+        final result = interactor.execute(argument: argumentMultiUrl);
+
+        await expectLater(
+          result,
+          emitsInOrder(<dynamic>[
+            const Right<Failure, Success>(GetPhonebookContactsLoading()),
+            isA<Right<Failure, Success>>().having(
+              (r) => (r.value as GetPhonebookContactsSuccess).contacts.any(
+                (c) =>
+                    c.phoneNumbers?.any(
+                      (p) => p.matrixId == '@alice:matrix.org',
+                    ) ==
+                    true,
+              ),
+              'alice has matrixId from first server',
+              true,
+            ),
+          ]),
+        );
+
+        verify(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: federationUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).called(1);
+
+        verify(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: secondFederationUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).called(1);
+      });
+
+      test(
+        'should query identity server when not covered by third_party_mappings',
+        () async {
+          const identityUrl = 'https://identity.example.com';
+
+          final argumentWithIdentity = FederationLookUpArgument(
+            homeServerUrl: homeserverUrl,
+            withMxId: matrixId,
+            withAccessToken: accessToken,
+            federationUrls: [federationUrl],
+            identityServerUrl: identityUrl,
+          );
+
+          when(
+            mockRepository.fetchContacts(),
+          ).thenAnswer((_) async => testContacts);
+
+          when(
+            mockRequestTokenManager.execute(
+              federationTokenRequest: testTokenRequest,
+            ),
+          ).thenAnswer(
+            (_) async => const Right<Failure, Success>(
+              FederationIdentityRequestTokenSuccess(
+                tokenInformation: tokenInformation,
+              ),
+            ),
+          );
+
+          when(
+            mockIdentityLookupManager.register(
+              federationUrl: anyNamed('federationUrl'),
+              tokenInformation: anyNamed('tokenInformation'),
+            ),
+          ).thenAnswer(
+            (_) async => const FederationRegisterResponse(
+              token: 'aB7c9Dz4EfGh5iJkLm3nOp==',
+            ),
+          );
+
+          const hashDetails = FederationHashDetailsResponse(
+            algorithms: {'sha256'},
+            lookupPepper: 'pepper',
+            altLookupPeppers: {'pepper1'},
+          );
+
+          when(
+            mockIdentityLookupManager.getHashDetails(
+              federationUrl: anyNamed('federationUrl'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).thenAnswer((_) async => hashDetails);
+
+          final calledWithUrls = <String>[];
+
+          // Federation server returns nothing → identity server must be queried.
+          when(
+            mockIdentityLookupManager.lookupMxid(
+              federationUrl: argumentWithIdentity.federationUrls.first,
+              request: anyNamed('request'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).thenAnswer((inv) async {
+            calledWithUrls.add(
+              inv.namedArguments[const Symbol('federationUrl')] as String,
+            );
+            return const FederationLookupMxidResponse(
+              mappings: {},
+              thirdPartyMappings: {},
+            );
+          });
+
+          // Identity server finds Bob's phone.
+          when(
+            mockIdentityLookupManager.lookupMxid(
+              federationUrl: identityUrl,
+              request: anyNamed('request'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).thenAnswer((inv) async {
+            calledWithUrls.add(
+              inv.namedArguments[const Symbol('federationUrl')] as String,
+            );
+            return const FederationLookupMxidResponse(
+              mappings: {
+                'WYOGPQyKEyY0iTxQoPTfk58eQvGi0_hpP2hI0S8cQeM':
+                    '@bob:matrix.com',
+              },
+              thirdPartyMappings: {},
+            );
+          });
+
+          final result = interactor.execute(argument: argumentWithIdentity);
+
+          await expectLater(
+            result,
+            emitsInOrder(<dynamic>[
+              const Right<Failure, Success>(GetPhonebookContactsLoading()),
+              isA<Right<Failure, Success>>().having(
+                (r) => (r.value as GetPhonebookContactsSuccess).contacts.any(
+                  (c) =>
+                      c.phoneNumbers?.any(
+                        (p) => p.matrixId == '@bob:matrix.com',
+                      ) ==
+                      true,
+                ),
+                'bob has matrixId from identity server',
+                true,
+              ),
+            ]),
+          );
+
+          expect(
+            calledWithUrls,
+            containsAll([
+              argumentWithIdentity.federationUrls.first,
+              identityUrl,
+            ]),
+          );
+        },
+      );
+
+      test(
+        'should skip identity server when its URL is in third_party_mappings',
+        () async {
+          const identityUrl = 'https://identity.example.com';
+
+          final argumentWithIdentity = FederationLookUpArgument(
+            homeServerUrl: homeserverUrl,
+            withMxId: matrixId,
+            withAccessToken: accessToken,
+            federationUrls: [federationUrl],
+            identityServerUrl: identityUrl,
+          );
+
+          when(
+            mockRepository.fetchContacts(),
+          ).thenAnswer((_) async => testContacts);
+
+          when(
+            mockRequestTokenManager.execute(
+              federationTokenRequest: anyNamed('federationTokenRequest'),
+            ),
+          ).thenAnswer(
+            (_) async => const Right<Failure, Success>(
+              FederationIdentityRequestTokenSuccess(
+                tokenInformation: tokenInformation,
+              ),
+            ),
+          );
+
+          when(
+            mockIdentityLookupManager.register(
+              federationUrl: anyNamed('federationUrl'),
+              tokenInformation: anyNamed('tokenInformation'),
+            ),
+          ).thenAnswer(
+            (_) async => const FederationRegisterResponse(
+              token: 'aB7c9Dz4EfGh5iJkLm3nOp==',
+            ),
+          );
+
+          const hashDetails = FederationHashDetailsResponse(
+            algorithms: {'sha256'},
+            lookupPepper: 'pepper',
+          );
+
+          when(
+            mockIdentityLookupManager.getHashDetails(
+              federationUrl: anyNamed('federationUrl'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).thenAnswer((_) async => hashDetails);
+
+          // Federation server delegates the identity URL via third_party_mappings
+          // → identity server must NOT be queried a second time via lookupMxid.
+          when(
+            mockIdentityLookupManager.lookupMxid(
+              federationUrl: federationUrl,
+              request: anyNamed('request'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).thenAnswer(
+            (_) async => const FederationLookupMxidResponse(
+              mappings: <String, String>{},
+              thirdPartyMappings: <String, Set<String>>{
+                'identity.example.com': {'some-hash'},
+              },
+            ),
+          );
+
+          when(
+            mockFederationIdentityLookupManager.execute(
+              arguments: anyNamed('arguments'),
+            ),
+          ).thenAnswer(
+            (_) async => const Right<Failure, Success>(
+              FederationIdentityLookupSuccess(newContacts: {}),
+            ),
+          );
+
+          final result = interactor.execute(argument: argumentWithIdentity);
+
+          await result.last;
+
+          verify(
+            mockIdentityLookupManager.lookupMxid(
+              federationUrl: federationUrl,
+              request: anyNamed('request'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).called(1);
+
+          verifyNever(
+            mockIdentityLookupManager.lookupMxid(
+              federationUrl: identityUrl,
+              request: anyNamed('request'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          );
+        },
+      );
 
       test('should handle empty mappings in lookup response', () async {
         final contacts = [

--- a/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
@@ -1789,6 +1789,191 @@ void main() {
         },
       );
 
+      test(
+        'should skip identity server when third_party key is plain hostname '
+        'and identityServerUrl is full https URL with trailing slash',
+        () async {
+          const identityUrl = 'https://identity.example.com/';
+
+          final argumentWithIdentity = FederationLookUpArgument(
+            homeServerUrl: homeserverUrl,
+            withMxId: matrixId,
+            withAccessToken: accessToken,
+            federationUrls: [federationUrl],
+            identityServerUrl: identityUrl,
+          );
+
+          when(
+            mockRepository.fetchContacts(),
+          ).thenAnswer((_) async => testContacts);
+
+          when(
+            mockRequestTokenManager.execute(
+              federationTokenRequest: anyNamed('federationTokenRequest'),
+            ),
+          ).thenAnswer(
+            (_) async => const Right<Failure, Success>(
+              FederationIdentityRequestTokenSuccess(
+                tokenInformation: tokenInformation,
+              ),
+            ),
+          );
+
+          when(
+            mockIdentityLookupManager.register(
+              federationUrl: anyNamed('federationUrl'),
+              tokenInformation: anyNamed('tokenInformation'),
+            ),
+          ).thenAnswer(
+            (_) async => const FederationRegisterResponse(
+              token: 'aB7c9Dz4EfGh5iJkLm3nOp==',
+            ),
+          );
+
+          const hashDetails = FederationHashDetailsResponse(
+            algorithms: {'sha256'},
+            lookupPepper: 'pepper',
+          );
+
+          when(
+            mockIdentityLookupManager.getHashDetails(
+              federationUrl: anyNamed('federationUrl'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).thenAnswer((_) async => hashDetails);
+
+          when(
+            mockIdentityLookupManager.lookupMxid(
+              federationUrl: federationUrl,
+              request: anyNamed('request'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).thenAnswer(
+            (_) async => const FederationLookupMxidResponse(
+              mappings: <String, String>{},
+              thirdPartyMappings: <String, Set<String>>{
+                'identity.example.com': {'some-hash'},
+              },
+            ),
+          );
+
+          when(
+            mockFederationIdentityLookupManager.execute(
+              arguments: anyNamed('arguments'),
+            ),
+          ).thenAnswer(
+            (_) async => const Right<Failure, Success>(
+              FederationIdentityLookupSuccess(newContacts: {}),
+            ),
+          );
+
+          await interactor.execute(argument: argumentWithIdentity).last;
+
+          verify(
+            mockIdentityLookupManager.lookupMxid(
+              federationUrl: federationUrl,
+              request: anyNamed('request'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          ).called(1);
+
+          verifyNever(
+            mockIdentityLookupManager.lookupMxid(
+              federationUrl: identityUrl,
+              request: anyNamed('request'),
+              registeredToken: anyNamed('registeredToken'),
+            ),
+          );
+        },
+      );
+
+      test('should skip identity server when third_party key is full https URL '
+          'matching identityServerUrl', () async {
+        const identityUrl = 'https://identity.example.com';
+
+        final argumentWithIdentity = FederationLookUpArgument(
+          homeServerUrl: homeserverUrl,
+          withMxId: matrixId,
+          withAccessToken: accessToken,
+          federationUrls: [federationUrl],
+          identityServerUrl: identityUrl,
+        );
+
+        when(
+          mockRepository.fetchContacts(),
+        ).thenAnswer((_) async => testContacts);
+
+        when(
+          mockRequestTokenManager.execute(
+            federationTokenRequest: anyNamed('federationTokenRequest'),
+          ),
+        ).thenAnswer(
+          (_) async => const Right<Failure, Success>(
+            FederationIdentityRequestTokenSuccess(
+              tokenInformation: tokenInformation,
+            ),
+          ),
+        );
+
+        when(
+          mockIdentityLookupManager.register(
+            federationUrl: anyNamed('federationUrl'),
+            tokenInformation: anyNamed('tokenInformation'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationRegisterResponse(
+            token: 'aB7c9Dz4EfGh5iJkLm3nOp==',
+          ),
+        );
+
+        const hashDetails = FederationHashDetailsResponse(
+          algorithms: {'sha256'},
+          lookupPepper: 'pepper',
+        );
+
+        when(
+          mockIdentityLookupManager.getHashDetails(
+            federationUrl: anyNamed('federationUrl'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer((_) async => hashDetails);
+
+        when(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: federationUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationLookupMxidResponse(
+            mappings: <String, String>{},
+            thirdPartyMappings: <String, Set<String>>{
+              'https://identity.example.com': {'some-hash'},
+            },
+          ),
+        );
+
+        when(
+          mockFederationIdentityLookupManager.execute(
+            arguments: anyNamed('arguments'),
+          ),
+        ).thenAnswer(
+          (_) async => const Right<Failure, Success>(
+            FederationIdentityLookupSuccess(newContacts: {}),
+          ),
+        );
+
+        await interactor.execute(argument: argumentWithIdentity).last;
+
+        verifyNever(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: identityUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        );
+      });
+
       test('should handle empty mappings in lookup response', () async {
         final contacts = [
           ContactFixtures.contact1,

--- a/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
@@ -1688,6 +1688,113 @@ void main() {
         },
       );
 
+      test('should dedupe when federation and identity return the same mapping '
+          'for one contact (combineContacts)', () async {
+        const identityUrl = 'https://identity.example.com';
+
+        final argumentWithIdentity = FederationLookUpArgument(
+          homeServerUrl: homeserverUrl,
+          withMxId: matrixId,
+          withAccessToken: accessToken,
+          federationUrls: [federationUrl],
+          identityServerUrl: identityUrl,
+        );
+
+        when(
+          mockRepository.fetchContacts(),
+        ).thenAnswer((_) async => testContacts);
+
+        when(
+          mockRequestTokenManager.execute(
+            federationTokenRequest: testTokenRequest,
+          ),
+        ).thenAnswer(
+          (_) async => const Right<Failure, Success>(
+            FederationIdentityRequestTokenSuccess(
+              tokenInformation: tokenInformation,
+            ),
+          ),
+        );
+
+        when(
+          mockIdentityLookupManager.register(
+            federationUrl: anyNamed('federationUrl'),
+            tokenInformation: anyNamed('tokenInformation'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationRegisterResponse(
+            token: 'aB7c9Dz4EfGh5iJkLm3nOp==',
+          ),
+        );
+
+        const hashDetails = FederationHashDetailsResponse(
+          algorithms: {'sha256'},
+          lookupPepper: 'pepper',
+          altLookupPeppers: {'pepper1'},
+        );
+
+        when(
+          mockIdentityLookupManager.getHashDetails(
+            federationUrl: anyNamed('federationUrl'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer((_) async => hashDetails);
+
+        const sharedAliceMapping = <String, String>{
+          '6mWe5lBps9Rqabkqc_QIh0-jsdFogvcBi9EWs523fok': '@alice:matrix.org',
+        };
+
+        when(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: federationUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationLookupMxidResponse(
+            mappings: sharedAliceMapping,
+            thirdPartyMappings: {},
+          ),
+        );
+
+        when(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: identityUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationLookupMxidResponse(
+            mappings: sharedAliceMapping,
+            thirdPartyMappings: {},
+          ),
+        );
+
+        final events = await interactor
+            .execute(argument: argumentWithIdentity)
+            .toList();
+
+        final lastSuccess = events
+            .whereType<Right<Failure, Success>>()
+            .map((e) => e.value)
+            .whereType<GetPhonebookContactsSuccess>()
+            .last;
+
+        expect(lastSuccess.contacts.length, 2);
+        expect(
+          lastSuccess.contacts.where((c) => c.id == 'id_1').length,
+          1,
+          reason: 'Alice must not be duplicated when both sources map her',
+        );
+        final alice = lastSuccess.contacts.firstWhere((c) => c.id == 'id_1');
+        expect(
+          alice.phoneNumbers?.any((p) => p.matrixId == '@alice:matrix.org'),
+          true,
+        );
+        final bob = lastSuccess.contacts.firstWhere((c) => c.id == 'id_2');
+        expect(bob.phoneNumbers?.every((p) => p.matrixId == null), true);
+      });
+
       test(
         'should skip identity server when its URL is in third_party_mappings',
         () async {

--- a/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
@@ -2081,6 +2081,101 @@ void main() {
         );
       });
 
+      test('should skip identity server when third_party key carries explicit '
+          'default port (:443) but identityServerUrl omits it', () async {
+        // Regression: third_party_mappings key "host:443" was stored as
+        // "https://host:443" while identitySession.url was "https://host"
+        // (no port), causing the dedup check to miss and TOM to be queried
+        // on every chunk after the first.
+        const identityUrl = 'https://identity.example.com';
+
+        final argumentWithIdentity = FederationLookUpArgument(
+          homeServerUrl: homeserverUrl,
+          withMxId: matrixId,
+          withAccessToken: accessToken,
+          federationUrls: [federationUrl],
+          identityServerUrl: identityUrl,
+        );
+
+        when(
+          mockRepository.fetchContacts(),
+        ).thenAnswer((_) async => testContacts);
+
+        when(
+          mockRequestTokenManager.execute(
+            federationTokenRequest: anyNamed('federationTokenRequest'),
+          ),
+        ).thenAnswer(
+          (_) async => const Right<Failure, Success>(
+            FederationIdentityRequestTokenSuccess(
+              tokenInformation: tokenInformation,
+            ),
+          ),
+        );
+
+        when(
+          mockIdentityLookupManager.register(
+            federationUrl: anyNamed('federationUrl'),
+            tokenInformation: anyNamed('tokenInformation'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationRegisterResponse(
+            token: 'aB7c9Dz4EfGh5iJkLm3nOp==',
+          ),
+        );
+
+        const hashDetails = FederationHashDetailsResponse(
+          algorithms: {'sha256'},
+          lookupPepper: 'pepper',
+        );
+
+        when(
+          mockIdentityLookupManager.getHashDetails(
+            federationUrl: anyNamed('federationUrl'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer((_) async => hashDetails);
+
+        // third_party_mappings key includes the default port (:443)
+        when(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: federationUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        ).thenAnswer(
+          (_) async => const FederationLookupMxidResponse(
+            mappings: <String, String>{},
+            thirdPartyMappings: <String, Set<String>>{
+              'identity.example.com:443': {'some-hash'},
+            },
+          ),
+        );
+
+        when(
+          mockFederationIdentityLookupManager.execute(
+            arguments: anyNamed('arguments'),
+          ),
+        ).thenAnswer(
+          (_) async => const Right<Failure, Success>(
+            FederationIdentityLookupSuccess(newContacts: {}),
+          ),
+        );
+
+        await interactor.execute(argument: argumentWithIdentity).last;
+
+        // Identity server must NOT be queried via lookupMxid: the
+        // "host:443" key in third_party_mappings canonicalises to the same
+        // URL as identityServerUrl once the default port is stripped.
+        verifyNever(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: identityUrl,
+            request: anyNamed('request'),
+            registeredToken: anyNamed('registeredToken'),
+          ),
+        );
+      });
+
       test('should handle empty mappings in lookup response', () async {
         final contacts = [
           ContactFixtures.contact1,


### PR DESCRIPTION
# Federated phonebook lookup: iterate all base_urls, optional direct identity lookup, unified merge

## Summary
This change aligns the mobile federated contact lookup flow with the product specification: every URL under m.federated_identity_services is used for the full request-token -> register -> hash-details -> lookup pipeline. Third_party_mappings are still resolvd per delegated server. When m.identity_server is configured and its URL has not appeared in any third_party_mappings response, a direct lookup is performed on that server. Federation, identity, and third-party results are merged per chunk.

## What changed

- FederationLookUpArgument now takes federationUrls (List<String>) and optional identityServerUrl instead of a single federationUrl to best suit the flow described here:
<img width="688" height="414" alt="Capture d’écran 2026-04-21 à 16 34 50" src="https://github.com/user-attachments/assets/f7d389e6-26a6-44ec-b062-3872092a9975" />

- ContactsManager passes all federation base_urls from configuration plus the configured identity server URL into the interactor.
- FederationLookUpPhonebookContactInteractor builds one session per federation URL (and optionally for the identity server), recomputes hashes per server where hash_details may differ, runs lookupMxid for each federation session per chunk, tracks third-party server keys across chunks to skip redundant identity lookups, merges mapping sources via existing combineContacts, and preserves prior behavior where third-party sub-lookup failures do not fail the entire chunk.
- Tests extended for multi-URL merging, identity lookup when not delegated via third_party_mappings, and skipping identity when already delegated.

## Test recommendations
Run flutter test test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart.
On a device or simulator with contacts permission, sign in against a homeserver that exposes m.federated_identity_services (multiple base_urls if available) and optional m.identity_server; open the contacts flow and confirm lookups complete and merged contacts behave as before for a single-URL configuration.

## Demos
**Attach screenshots or videos demonstrating the changes**
No demos provided because no UI changes, only behavioral changes (more exploration)
If you think I should add some, feel free to ask.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contact lookup now queries multiple federation servers and accepts optional identity server info.

* **Improvements**
  * Reduced redundant identity-server queries; normalized URLs (https/trailing slash) for consistent matching.
  * Chunked processing to preserve partial results and improve reliability on large lookups.

* **Tests**
  * Expanded coverage for multi-server federation lookups, identity-server behaviors, deduplication, and skipping redundant identity queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->