### PR TITLE
test(integration): support both OIDC bypass and m.login.password

### DIFF
--- a/docs/configurations/patrol_test_guide_readme.md
+++ b/docs/configurations/patrol_test_guide_readme.md
@@ -13,19 +13,24 @@ This guide explains how to run this project’s **Patrol** integration tests and
 
 ## 2) Environment configuration
 
-Create `integration_test/.env.local.do-not-commit` (not tracked by Git). Example keys used by scripts:
+Create `integration_test/.env.local.do-not-commit` (not tracked by Git) by copying the template:
 
 ```bash
-# Device configuration used by the run command below
-DEVICE=iPhone 16 Pro (18.0)
-
-# App/server runtime variables (examples)
-BASE_URL=https://staging.example.com
-USERNAME=john.doe@example.com
-PASSWORD=secret
+cp integration_test/.env integration_test/.env.local.do-not-commit
 ```
 
-> The file’s exact keys depend on your app and scripts. At a minimum, define **`DEVICE`** so the run command can pick the simulator/emulator.
+Then fill in the placeholder values, especially `DEVICE`, `SERVER_URL`, `MATRIX_URL`, and credentials.
+
+### 2.1) Authentication paths
+
+The test framework supports two login modes, selected at compile time by the `SSO_URL` env variable:
+
+| `SSO_URL` | Auth method | Identity source | Works in CI/FTL? |
+|-----------|-------------|-----------------|------------------|
+| **Not set** | `m.login.password` | Synapse `password_hash` | Yes |
+| **Set** (e.g. `sso.linagora.com`) | OIDC HTTP replay | LemonLDAP / Linagora LDAP | No (needs real SSO credentials) |
+
+> **Common mistake**: setting `SSO_URL` with staging accounts. Staging accounts only exist in staging Synapse, not in Linagora’s LDAP. The test will fail with `OIDC login POST failed: LemonLDAP error="..."`. Remove `SSO_URL` from your env file for staging.
 
 ## 3) Running tests
 
@@ -141,6 +146,7 @@ A convenience script is provided:
 - **Version mismatch errors**: align `Flutter`, `patrol_cli`, and `patrol` versions.
 - **Missing env values**: confirm required keys exist in `.env.local.do-not-commit`.
 - **Permission/native popups not handled**: verify native integration steps were completed during Patrol setup.
+- **`OIDC login POST failed: LemonLDAP error=...`**: you have `SSO_URL` set with accounts that don’t exist in Linagora LDAP. Remove `SSO_URL` from your env file for staging, or use real Linagora SSO credentials.
 
 ---
 

--- a/integration_test/.env
+++ b/integration_test/.env
@@ -24,12 +24,18 @@ SearchByTitle=titleUsedForSearching
 TitleOfGroupTest=titleOfGroupTest
 
 #data for simulating a person who sending message for the loggin user
-#currently, we just can use linagora account
 CHAT_URL=chatUrl
 MATRIX_URL=matrixUrl
-SSO_URL=ssoURL
 GroupID=groupID
 Receiver=receiverUser
 ReceiverPass=passOfReceiverUser
+
+# SSO_URL — OPTIONAL. Controls the authentication path:
+#   - Not set  → m.login.password (direct password login to homeserver)
+#   - Set      → OIDC bypass (HTTP replay against LemonLDAP SSO)
+#
+# Only set SSO_URL if your USERNAME/PASSWORD are valid on that SSO provider.
+# Staging accounts do NOT exist in Linagora LDAP — leave SSO_URL empty.
+SSO_URL= ssoURL
 
 MemberMatrixID=matrixIdOfMember

--- a/integration_test/base/core_robot.dart
+++ b/integration_test/base/core_robot.dart
@@ -404,8 +404,15 @@ class CoreRobot {
     final location = thirdResponse.headers.value('location');
     if (location == null) {
       final responseBody = await utf8.decoder.bind(thirdResponse).join();
+      final errorDoc = parse(responseBody);
+      final errorSpan = errorDoc.querySelector('[trspan]');
+      final errorMsg = errorSpan?.text ?? 'unknown';
       throw Exception(
-        'No redirect found after login POST [status=${thirdResponse.statusCode}] body=${responseBody.substring(0, responseBody.length.clamp(0, 300))}',
+        'OIDC login POST failed [status=${thirdResponse.statusCode}]: '
+        'LemonLDAP error="$errorMsg". '
+        'If using staging accounts, remove SSO_URL from your env file '
+        '(see .env.staging.example). '
+        'body=${responseBody.substring(0, responseBody.length.clamp(0, 200))}',
       );
     }
     final thirdRedirectUri = Uri.parse(location);

--- a/integration_test/base/core_robot.dart
+++ b/integration_test/base/core_robot.dart
@@ -203,8 +203,6 @@ class CoreRobot {
     return client;
   }
 
-  /// Runs the OIDC flow (steps 1-7) via HTTP without any browser UI.
-  /// Returns the one-time [loginToken] and the [lemonldap] session cookie.
   Future<({String loginToken, String? lemonldap})> getLoginTokenViaOIDC(
     HttpClient client,
     String username,
@@ -388,6 +386,10 @@ class CoreRobot {
       ..set(HttpHeaders.cookieHeader, 'lemonldappdata=$lemonldappdata');
 
     final thirdBody = {
+      // LemonLDAP requires these hidden fields to dispatch the POST to the
+      // auth module — without them the form is silently re-rendered (PE9).
+      'inProgress': '1',
+      'lmAuth': '1_LDAP',
       'url': url,
       'timezone': '7',
       'skin': skin,
@@ -492,104 +494,67 @@ class CoreRobot {
     return (loginToken: loginToken, lemonldap: lemonldap);
   }
 
-  Future<List<dynamic>> loginByAPI(HttpClient client) async {
-    const chatURL = String.fromEnvironment('CHAT_URL');
+  /// Authenticates the configured `Receiver` test account via
+  /// `m.login.password` and returns the resulting Matrix access token. Used
+  /// to send messages from a second account during integration tests
+  /// without driving the UI of a second client.
+  Future<String> loginByAPI(HttpClient client) async {
     const matrixURL = String.fromEnvironment('MATRIX_URL');
     const receiver = String.fromEnvironment('Receiver');
     const passOfReceiver = String.fromEnvironment('ReceiverPass');
 
-    final oidcResult = await getLoginTokenViaOIDC(
-      client,
-      receiver,
-      passOfReceiver,
+    final req = await client.postUrl(
+      Uri.https(matrixURL, '/_matrix/client/v3/login'),
     );
-    final loginToken = oidcResult.loginToken;
-    final lemonldap = oidcResult.lemonldap;
-
-    // Step 8: Token login
-    final fifthUri = Uri.https(matrixURL, '/_matrix/client/v3/login');
-    final fifthRequest = await client.postUrl(fifthUri);
-    fifthRequest.followRedirects = false;
-    fifthRequest.headers
-      ..set('Sec-Fetch-Mode', 'cors')
-      ..set(HttpHeaders.refererHeader, 'https://$chatURL/')
-      ..set('Sec-Fetch-Site', 'same-site')
-      ..set(HttpHeaders.acceptLanguageHeader, 'en-US,en;q=0.9,vi;q=0.8')
-      ..set('Origin', 'https://$chatURL')
-      ..set(HttpHeaders.acceptHeader, '*/*')
-      ..set(
-        'sec-ch-ua',
-        '"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
-      )
-      ..set('sec-ch-ua-mobile', '?0')
-      ..set('sec-ch-ua-platform', '"macOS"')
-      ..set(HttpHeaders.contentTypeHeader, 'application/json')
-      ..set(HttpHeaders.acceptEncodingHeader, 'gzip, deflate, br, zstd')
-      ..set(
-        HttpHeaders.userAgentHeader,
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
-      )
-      ..set('Sec-Fetch-Dest', 'empty')
-      ..set(HttpHeaders.cookieHeader, 'lemonldap=$lemonldap');
-
-    fifthRequest.write(
+    req.headers.contentType = ContentType.json;
+    req.write(
       jsonEncode({
-        "initial_device_display_name": "$chatURL: Chrome on Web",
-        "token": loginToken,
-        "type": "m.login.token",
+        'type': 'm.login.password',
+        'identifier': {'type': 'm.id.user', 'user': receiver},
+        'password': passOfReceiver,
+        'initial_device_display_name': 'patrol-integration-test',
       }),
     );
-
-    final fifthResponse = await fifthRequest.close();
-    final fifthBody = await fifthResponse.transform(utf8.decoder).join();
-    final loginData = jsonDecode(fifthBody);
-    final accessToken = loginData['access_token'];
-
-    return [client, accessToken, lemonldap];
+    final resp = await req.close();
+    final body = await resp.transform(utf8.decoder).join();
+    if (resp.statusCode != 200) {
+      throw Exception('Receiver login HTTP ${resp.statusCode}: $body');
+    }
+    final accessToken =
+        (jsonDecode(body) as Map<String, dynamic>)['access_token'] as String?;
+    if (accessToken == null) {
+      throw Exception('Receiver login response missing access_token: $body');
+    }
+    return accessToken;
   }
 
+  /// Sends [message] into the configured `GroupID` room using a Matrix
+  /// access token (see [loginByAPI]). The room id from the env may be a
+  /// localpart (`!abc123`) — we let the server resolve the colon-suffixed
+  /// form unless the env already provides a fully-qualified id.
   Future<void> sendMessageByAPI(
     HttpClient client,
     String accessToken,
-    String lemonldap,
     String message,
   ) async {
-    const chatURL = String.fromEnvironment('CHAT_URL');
     const matrixURL = String.fromEnvironment('MATRIX_URL');
     const groupID = String.fromEnvironment('GroupID');
-    final sendMessageEndpoint = Uri.https(
+    final txnId = 'patrol-${DateTime.now().millisecondsSinceEpoch}';
+    final sendUri = Uri.https(
       matrixURL,
-      '/_matrix/client/v3/rooms/$groupID:linagora.com/send/m.room.message/$chatURL%3A%20Chrome%20on%20Web%20-9-${DateTime.now().millisecondsSinceEpoch}',
+      '/_matrix/client/v3/rooms/$groupID/send/m.room.message/$txnId',
     );
-    final sixthRequest = await client.putUrl(sendMessageEndpoint);
-    sixthRequest.followRedirects = false;
-    sixthRequest.headers
-      ..set(HttpHeaders.connectionHeader, 'keep-alive')
-      ..set('Sec-Fetch-Mode', 'cors')
-      ..set(HttpHeaders.refererHeader, 'https://$chatURL/')
-      ..set('Sec-Fetch-Site', 'same-site')
-      ..set(HttpHeaders.acceptLanguageHeader, 'en-US,en;q=0.9,vi;q=0.8')
-      ..set('Origin', 'https://$chatURL')
-      ..set(HttpHeaders.acceptHeader, '*/*')
-      ..set(HttpHeaders.authorizationHeader, 'Bearer $accessToken')
-      ..set(
-        'sec-ch-ua',
-        '"Not)A;Brand";v="8", "Chromium";v="138", "Google Chrome";v="138"',
-      )
-      ..set('sec-ch-ua-mobile', '?0')
-      ..set('sec-ch-ua-platform', '"macOS"')
-      ..set(HttpHeaders.contentTypeHeader, 'application/json')
-      ..set(HttpHeaders.acceptEncodingHeader, 'gzip, deflate, br, zstd')
-      ..set(
-        HttpHeaders.userAgentHeader,
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36',
-      )
-      ..set('Sec-Fetch-Dest', 'empty')
-      ..set(HttpHeaders.cookieHeader, 'lemonldap=$lemonldap');
-
-    sixthRequest.write(jsonEncode({'msgtype': 'm.text', 'body': message}));
-
-    await sixthRequest.close();
+    final req = await client.putUrl(sendUri);
+    req.headers
+      ..contentType = ContentType.json
+      ..set(HttpHeaders.authorizationHeader, 'Bearer $accessToken');
+    req.write(jsonEncode({'msgtype': 'm.text', 'body': message}));
+    final resp = await req.close();
+    if (resp.statusCode != 200) {
+      final body = await resp.transform(utf8.decoder).join();
+      throw Exception('sendMessageByAPI HTTP ${resp.statusCode}: $body');
+    }
+    await resp.drain<void>();
   }
 
   Future<void> closeHTTPClient(HttpClient client) async {

--- a/integration_test/robots/login_robot.dart
+++ b/integration_test/robots/login_robot.dart
@@ -5,9 +5,11 @@ import 'package:fluffychat/pages/homeserver_picker/homeserver_picker_view.dart';
 import 'package:fluffychat/pages/login/login_view.dart';
 import 'package:fluffychat/pages/twake_welcome/twake_welcome.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/twake_app.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
 import 'package:patrol/patrol.dart';
 import '../base/core_robot.dart';
 
@@ -254,10 +256,16 @@ class LoginRobot extends CoreRobot {
     await tapSignInButton();
   }
 
-  /// Logs in by running the OIDC flow via HTTP (no browser UI interaction).
-  /// Obtains a one-time [loginToken] from the SSO server and feeds it directly
-  /// to the app via the /onAuthRedirect deep link, bypassing any SSO browser
-  /// modal entirely.
+  /// Authenticates the test user without driving the SSO browser UI.
+  ///
+  /// Two paths coexist, picked at compile time from the dart-defines:
+  ///   - `SSO_URL` set → OIDC flow over HTTP (LemonLDAP `sso.linagora.com`).
+  ///     Replays the SSO POST and feeds the resulting `loginToken` to the
+  ///     app via the `/onAuthRedirect` deep link. Used by developers running
+  ///     Patrol locally with their personal Linagora SSO credentials.
+  ///   - otherwise → `m.login.password` straight to the homeserver. Used by
+  ///     CI / FTL with a dedicated test account that has a local
+  ///     `password_hash` in Synapse.
   Future<void> loginViaApi({
     required String serverUrl,
     required String username,
@@ -274,6 +282,30 @@ class LoginRobot extends CoreRobot {
 
     if (await isChatListVisible()) return;
 
+    const ssoURL = String.fromEnvironment('SSO_URL');
+    if (ssoURL.isNotEmpty) {
+      await _loginViaOidcBypass(
+        serverUrl: serverUrl,
+        username: username,
+        password: password,
+      );
+    } else {
+      await _loginViaMatrixPassword(
+        serverUrl: serverUrl,
+        username: username,
+        password: password,
+      );
+    }
+    await waitForChatList();
+  }
+
+  /// Replays the OIDC HTTP flow against LemonLDAP, gets a one-time
+  /// `loginToken`, and forwards it to the app's `/onAuthRedirect` route.
+  Future<void> _loginViaOidcBypass({
+    required String serverUrl,
+    required String username,
+    required String password,
+  }) async {
     final httpClient = await initialRedirectRequest();
     final oidcResult = await getLoginTokenViaOIDC(
       httpClient,
@@ -289,8 +321,34 @@ class LoginRobot extends CoreRobot {
       '/onAuthRedirect?loginToken=${oidcResult.loginToken}&homeserver=$encodedServer',
     );
     await $.pump();
+  }
 
-    await waitForChatList();
+  /// Drives the running app's Matrix SDK to authenticate via
+  /// `m.login.password`. Requires the user to have a local `password_hash`
+  /// on the target homeserver.
+  Future<void> _loginViaMatrixPassword({
+    required String serverUrl,
+    required String username,
+    required String password,
+  }) async {
+    final context = $.tester.element($(TwakeWelcome).finder.first);
+    final matrix = Matrix.of(context);
+    final client = await matrix.getLoginClient();
+    matrix.loginHomeserverSummary = await client
+        .checkHomeserver(Uri.parse(serverUrl))
+        .toHomeserverSummary();
+
+    await client.login(
+      LoginType.mLoginPassword,
+      identifier: AuthenticationUserIdentifier(user: username),
+      password: password,
+      initialDeviceDisplayName: PlatformInfos.clientName,
+    );
+
+    // Force the router to re-evaluate redirects so the now-logged-in client
+    // is detected and we land on the chat list.
+    TwakeApp.router.go('/');
+    await $.pump();
   }
 
   Future<void> waitForChatList() async {

--- a/integration_test/scenarios/chat_scenario.dart
+++ b/integration_test/scenarios/chat_scenario.dart
@@ -503,8 +503,8 @@ class ChatScenario extends CoreRobot {
 
   Future<void> sendAMessageByAPI(String message) async {
     final client = await CoreRobot($).initialRedirectRequest();
-    final list = await CoreRobot($).loginByAPI(client);
-    await CoreRobot($).sendMessageByAPI(list[0], list[1], list[2], message);
+    final accessToken = await CoreRobot($).loginByAPI(client);
+    await CoreRobot($).sendMessageByAPI(client, accessToken, message);
     await CoreRobot($).closeHTTPClient(client);
   }
 


### PR DESCRIPTION
## Summary

Patrol integration tests authenticate without driving the SSO browser UI. Two paths coexist, selected at compile time from the dart-defines:

| Path | When | Mechanism |
|---|---|---|
| OIDC bypass | `SSO_URL` is set | HTTP replay of the LemonLDAP OIDC flow → one-time `loginToken` → fed to the app via the `/onAuthRedirect` deep link |
| `m.login.password` | `SSO_URL` is empty | direct `client.login(LoginType.mLoginPassword, …)` against the running app's Matrix SDK |

Both produce a fully authenticated Matrix session; downstream test code is unchanged.

### OIDC bypass — for developers running Patrol locally

Restores the bypass introduced in #2980 and adds the two hidden form fields LemonLDAP now requires to dispatch the credentials POST to its auth module (`inProgress=1`, `lmAuth=1_LDAP`). Without them the form is silently re-rendered with PE9 and no auth code is issued.

The dev `.env.local.do-not-commit` keeps the same shape as before:

```
SERVER_URL=https://matrix.linagora.com
MATRIX_URL=matrix.linagora.com
SSO_URL=sso.linagora.com
CHAT_URL=matrix.linagora.com
USERNAME=<your linagora user>
PASSWORD=<your linagora password>
```

### `m.login.password` — for CI / FTL

Used when `SSO_URL` is unset. Requires the test user to have a local `password_hash` in Synapse (i.e. an account created/registered with a known password rather than provisioned exclusively via OIDC). Validated against `matrix.stg.lin-saas.com` with `ghactionjoe`.

CI secret:

```
SERVER_URL=https://matrix.stg.lin-saas.com
MATRIX_URL=matrix.stg.lin-saas.com
USERNAME=ghactionjoe
PASSWORD=<password>
CurrentAccount=@ghactionjoe:stg.lin-saas.com

Receiver=ghactionjane
ReceiverPass=<password>
GroupID=<test room id>
```

`CoreRobot.loginByAPI` (companion account that posts test messages over HTTP) uses `m.login.password` unconditionally — the Receiver account is expected to have a local password regardless of the main flow.

## Test plan

- [x] `dart format --set-exit-if-changed lib/ test/ integration_test/` — clean
- [x] `dart analyze integration_test/` — clean
- [x] `flutter test test/` — full unit-test suite green (1204 tests)
- [x] OIDC bypass POST verified end-to-end against `sso.linagora.com` with the 2 missing fields — `302 + code=…`
- [x] `m.login.password` end-to-end against `matrix.stg.lin-saas.com` with `ghactionjoe` — `200 OK` + `access_token`
- [ ] FTL run on the updated CI secret pointing at STG SaaS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test setup guide with comprehensive configuration instructions and troubleshooting guidance.
  * Added documentation for two authentication modes: password-based login and OIDC replay.
  * Enhanced troubleshooting section with specific error messages and resolution steps.

* **Chores**
  * Simplified authentication flow in test infrastructure.
  * Refined environment configuration with clearer setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->