### PR TITLE
TW-2155(fix): normalize phonebook numbers to E.164 for lookup hashing

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,6 +66,8 @@
 	<string>Play audio and voice messages on bluetooth devices</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Open the camera and take a picture to share them with your contacts on Twake Chat.</string>
+	<key>NSCarrierUsageDescription</key>
+	<string>Used by Twake Chat to determine the default country code for phone number normalization.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>Used by Twake Chat to find existed Twake account, who you can connect directly in Twake Chat or who you can send invitation.</string>
 	<key>NSFaceIDUsageDescription</key>

--- a/lib/data/datasource/contact/sim_country/sim_country_provider.dart
+++ b/lib/data/datasource/contact/sim_country/sim_country_provider.dart
@@ -1,0 +1,5 @@
+abstract class SimCountryProvider {
+  /// Returns the ISO 3166-1 alpha-2 country code of the SIM card
+  /// (e.g. "FR", "US"), or null if it cannot be determined.
+  Future<String?> getCountryCode();
+}

--- a/lib/data/datasource/contact/sim_country/sim_country_provider_impl.dart
+++ b/lib/data/datasource/contact/sim_country/sim_country_provider_impl.dart
@@ -1,0 +1,2 @@
+export 'sim_country_provider_impl_web.dart'
+    if (dart.library.io) 'sim_country_provider_impl_io.dart';

--- a/lib/data/datasource/contact/sim_country/sim_country_provider_impl_io.dart
+++ b/lib/data/datasource/contact/sim_country/sim_country_provider_impl_io.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:fluffychat/data/datasource/contact/sim_country/sim_country_provider.dart';
 import 'package:matrix/matrix.dart';
+import 'package:phone_numbers_parser/phone_numbers_parser.dart' as pnp;
 import 'package:sim_country_code_plus/sim_country_code_plus.dart';
 
 class SimCountryProviderImpl implements SimCountryProvider {
@@ -10,9 +11,11 @@ class SimCountryProviderImpl implements SimCountryProvider {
   @override
   Future<String?> getCountryCode() => _countryCodeFuture ??= _resolve();
 
-  // Only accept strict ISO 3166-1 alpha-2 codes (exactly two ASCII letters).
+  // Accept only codes that phone_numbers_parser itself recognises the same
+  // lookup used by IsoCode.fromJson. This rejects syntactically valid but
+  // unknown codes (e.g. "ZZ") that would otherwise throw downstream.
   bool _isValidSimCode(String? code) =>
-      code != null && RegExp(r'^[A-Za-z]{2}$').hasMatch(code);
+      code != null && pnp.isoCodeConversionMap.containsKey(code.toUpperCase());
 
   Future<String?> _resolve() async {
     // 1. Try SIM card country (most accurate for phone number context).

--- a/lib/data/datasource/contact/sim_country/sim_country_provider_impl_io.dart
+++ b/lib/data/datasource/contact/sim_country/sim_country_provider_impl_io.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:fluffychat/data/datasource/contact/sim_country/sim_country_provider.dart';
+import 'package:matrix/matrix.dart';
+import 'package:sim_country_code_plus/sim_country_code_plus.dart';
+
+class SimCountryProviderImpl implements SimCountryProvider {
+  String? _cache;
+  bool _fetched = false;
+
+  @override
+  Future<String?> getCountryCode() async {
+    if (_fetched) return _cache;
+    _fetched = true;
+    _cache = await _resolve();
+    return _cache;
+  }
+
+  bool _isValidSimCode(String? code) =>
+      code != null && code.isNotEmpty && code != '--';
+
+  Future<String?> _resolve() async {
+    // 1. Try SIM card country (most accurate for phone number context).
+    try {
+      final simCode = await SimCountryCodePlus.simCountryCode;
+      if (_isValidSimCode(simCode)) {
+        return simCode!.toUpperCase();
+      }
+    } catch (e) {
+      Logs().w('SimCountryProvider: SIM country unavailable – $e');
+    }
+
+    // 2. Fallback: derive country from device locale.
+    // Handles both POSIX ("fr_FR", "fr_FR.UTF-8") and BCP-47 ("fr-FR") formats.
+    try {
+      final locale = Platform.localeName;
+      final parts = locale.split(RegExp(r'[_\-]'));
+      if (parts.length >= 2) {
+        return parts[1].split('.').first.toUpperCase();
+      }
+    } catch (e) {
+      Logs().w('SimCountryProvider: locale unavailable – $e');
+    }
+
+    return null;
+  }
+}

--- a/lib/data/datasource/contact/sim_country/sim_country_provider_impl_io.dart
+++ b/lib/data/datasource/contact/sim_country/sim_country_provider_impl_io.dart
@@ -16,8 +16,9 @@ class SimCountryProviderImpl implements SimCountryProvider {
     return _cache;
   }
 
+  // Only accept strict ISO 3166-1 alpha-2 codes (exactly two ASCII letters).
   bool _isValidSimCode(String? code) =>
-      code != null && code.isNotEmpty && code != '--';
+      code != null && RegExp(r'^[A-Za-z]{2}$').hasMatch(code);
 
   Future<String?> _resolve() async {
     // 1. Try SIM card country (most accurate for phone number context).
@@ -31,12 +32,22 @@ class SimCountryProviderImpl implements SimCountryProvider {
     }
 
     // 2. Fallback: derive country from device locale.
-    // Handles both POSIX ("fr_FR", "fr_FR.UTF-8") and BCP-47 ("fr-FR") formats.
+    // Handles POSIX ("fr_FR", "fr_FR.UTF-8", "zh_Hans_CN") and BCP-47 ("fr-FR").
     try {
       final locale = Platform.localeName;
       final parts = locale.split(RegExp(r'[_\-]'));
       if (parts.length >= 2) {
-        return parts[1].split('.').first.toUpperCase();
+        // Strip any trailing codec suffix (e.g. ".UTF-8") before validating.
+        String stripped(String s) => s.split('.').first;
+
+        // Prefer the last token (handles "zh_Hans_CN" → "CN");
+        // fall back to the second token only if the last is not a valid alpha-2.
+        final last = stripped(parts.last);
+        final second = stripped(parts[1]);
+        final token = _isValidSimCode(last)
+            ? last
+            : (_isValidSimCode(second) ? second : null);
+        if (token != null) return token.toUpperCase();
       }
     } catch (e) {
       Logs().w('SimCountryProvider: locale unavailable – $e');

--- a/lib/data/datasource/contact/sim_country/sim_country_provider_impl_io.dart
+++ b/lib/data/datasource/contact/sim_country/sim_country_provider_impl_io.dart
@@ -5,16 +5,10 @@ import 'package:matrix/matrix.dart';
 import 'package:sim_country_code_plus/sim_country_code_plus.dart';
 
 class SimCountryProviderImpl implements SimCountryProvider {
-  String? _cache;
-  bool _fetched = false;
+  Future<String?>? _countryCodeFuture;
 
   @override
-  Future<String?> getCountryCode() async {
-    if (_fetched) return _cache;
-    _fetched = true;
-    _cache = await _resolve();
-    return _cache;
-  }
+  Future<String?> getCountryCode() => _countryCodeFuture ??= _resolve();
 
   // Only accept strict ISO 3166-1 alpha-2 codes (exactly two ASCII letters).
   bool _isValidSimCode(String? code) =>

--- a/lib/data/datasource/contact/sim_country/sim_country_provider_impl_web.dart
+++ b/lib/data/datasource/contact/sim_country/sim_country_provider_impl_web.dart
@@ -1,0 +1,7 @@
+import 'package:fluffychat/data/datasource/contact/sim_country/sim_country_provider.dart';
+
+/// Web: no SIM / no VM [Platform]; country hint is not available for phonebook sync.
+class SimCountryProviderImpl implements SimCountryProvider {
+  @override
+  Future<String?> getCountryCode() async => null;
+}

--- a/lib/data/datasource_impl/contact/phonebook_contact_datasource_impl.dart
+++ b/lib/data/datasource_impl/contact/phonebook_contact_datasource_impl.dart
@@ -1,31 +1,47 @@
 import 'package:fluffychat/data/datasource/contact/contacts_provider.dart';
+import 'package:fluffychat/data/datasource/contact/sim_country/sim_country_provider.dart';
+import 'package:fluffychat/data/datasource/contact/phonebook_datasource.dart';
 import 'package:fluffychat/domain/model/contact/contact.dart';
+import 'package:fluffychat/utils/phone_number_normalizer.dart'
+    show tryNormalizePhoneNumberToE164;
 import 'package:fluffychat/utils/string_extension.dart';
 import 'package:flutter_contacts/flutter_contacts.dart' as flutter_contact;
-import 'package:fluffychat/data/datasource/contact/phonebook_datasource.dart';
 
 class PhonebookContactDatasourceImpl implements PhonebookContactDatasource {
   final ContactsProvider _contactsProvider;
+  final SimCountryProvider _simCountryProvider;
 
-  PhonebookContactDatasourceImpl(this._contactsProvider);
+  PhonebookContactDatasourceImpl(
+    this._contactsProvider,
+    this._simCountryProvider,
+  );
 
   @override
   Future<List<Contact>> fetchContacts() async {
-    final phonebookContacts = await _contactsProvider.getAll(
-      properties: flutter_contact.ContactProperties.all,
-    );
+    final (phonebookContacts, callerIsoCode) = await (
+      _contactsProvider.getAll(
+        properties: flutter_contact.ContactProperties.all,
+      ),
+      _simCountryProvider.getCountryCode(),
+    ).wait;
 
-    final contacts = mappingToContact(phonebookContacts);
+    final contacts = mappingToContact(
+      phonebookContacts,
+      callerIsoCode: callerIsoCode,
+    );
     return _sortContactsByDisplayName(contacts);
   }
 
   List<Contact> mappingToContact(
-    List<flutter_contact.Contact> phoneBookContacts,
-  ) {
+    List<flutter_contact.Contact> phoneBookContacts, {
+    String? callerIsoCode,
+  }) {
     final listAllContacts = phoneBookContacts.map((contact) {
       final phoneNumbers = contact.phones
-          .map((phone) => PhoneNumber(number: phone.number))
+          .map((phone) => _toPhoneNumber(phone.number, callerIsoCode))
+          .whereType<PhoneNumber>()
           .toList();
+
       final emails = contact.emails
           .map((email) => Email(address: email.address))
           .toList();
@@ -44,6 +60,12 @@ class PhonebookContactDatasourceImpl implements PhonebookContactDatasource {
     }).toList();
 
     return listFilteredContacts;
+  }
+
+  PhoneNumber? _toPhoneNumber(String rawNumber, String? callerIsoCode) {
+    final normalized = tryNormalizePhoneNumberToE164(rawNumber, callerIsoCode);
+    if (normalized == null) return null;
+    return PhoneNumber(number: normalized);
   }
 
   List<Contact> _sortContactsByDisplayName(List<Contact> contacts) {

--- a/lib/di/global/get_it_initializer.dart
+++ b/lib/di/global/get_it_initializer.dart
@@ -6,6 +6,8 @@ import 'package:fluffychat/data/datasource/contact/address_book_datasource.dart'
 import 'package:fluffychat/data/datasource/contact/hive_third_party_contact_datasource.dart';
 import 'package:fluffychat/data/datasource/contact/contacts_provider.dart';
 import 'package:fluffychat/data/datasource/contact/phonebook_datasource.dart';
+import 'package:fluffychat/data/datasource/contact/sim_country/sim_country_provider.dart';
+import 'package:fluffychat/data/datasource/contact/sim_country/sim_country_provider_impl.dart';
 import 'package:fluffychat/data/datasource/federation_configurations_datasource.dart';
 import 'package:fluffychat/data/datasource/invitation/hive_invitation_status_datasource.dart';
 import 'package:fluffychat/data/datasource/invitation/invitation_datasource.dart';
@@ -290,8 +292,14 @@ class GetItInitializer {
     getIt.registerFactory<ContactsProvider>(
       () => FlutterContactsProviderImpl(),
     );
+    getIt.registerLazySingleton<SimCountryProvider>(
+      () => SimCountryProviderImpl(),
+    );
     getIt.registerFactory<PhonebookContactDatasource>(
-      () => PhonebookContactDatasourceImpl(getIt.get<ContactsProvider>()),
+      () => PhonebookContactDatasourceImpl(
+        getIt.get<ContactsProvider>(),
+        getIt.get<SimCountryProvider>(),
+      ),
     );
     getIt.registerLazySingleton(
       () => MediaDataSourceImpl(getIt.get<MediaAPI>()),

--- a/lib/utils/phone_number_normalizer.dart
+++ b/lib/utils/phone_number_normalizer.dart
@@ -1,0 +1,27 @@
+import 'package:phone_numbers_parser/phone_numbers_parser.dart' as pnp;
+
+/// Attempts to normalize [rawNumber] to E.164 (e.g. "+33612345678").
+///
+/// When [callerIsoCode] (ISO 3166-1 alpha-2, e.g. "FR") is provided, it is
+/// used as the default region for local/national numbers. Without it, only
+/// numbers already carrying an explicit "+" country prefix can be resolved.
+///
+/// Returns null if the number cannot be parsed or is invalid. The caller
+/// should discard it rather than forwarding an unresolvable 3PID to the
+/// identity server.
+String? tryNormalizePhoneNumberToE164(String rawNumber, String? callerIsoCode) {
+  try {
+    final pnp.PhoneNumber phone;
+    if (callerIsoCode != null) {
+      final isoCode = pnp.IsoCode.fromJson(callerIsoCode.toUpperCase());
+      phone = pnp.PhoneNumber.parse(rawNumber, callerCountry: isoCode);
+    } else {
+      // No country context: only E.164 numbers with "+" can be resolved.
+      phone = pnp.PhoneNumber.parse(rawNumber);
+    }
+    if (!phone.isValid()) return null;
+    return phone.international;
+  } catch (_) {
+    return null;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -317,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -1900,18 +1900,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   matrix:
     dependency: "direct main"
     description:
@@ -2284,6 +2284,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.2"
+  phone_numbers_parser:
+    dependency: "direct main"
+    description:
+      name: phone_numbers_parser
+      sha256: e61571432d3e7909d5c4aa77ace70059766b82ebe54018e5392d65e2ac33f03b
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.21"
   photo_manager:
     dependency: "direct main"
     description:
@@ -2749,6 +2757,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  sim_country_code_plus:
+    dependency: "direct main"
+    description:
+      name: sim_country_code_plus
+      sha256: "1ff826ef5c9da284ff31f62e2e313bd1130effacbefd1cda0680a1b4df96c2a3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   simple_observable:
     dependency: transitive
     description:
@@ -2984,18 +3000,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.12"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -194,6 +194,8 @@ dependencies:
   super_clipboard: 0.9.1
   crypto: ^3.0.3
   flutter_contacts: ^2.0.0-beta.2
+  phone_numbers_parser: ^9.0.21
+  sim_country_code_plus: ^0.1.4
   flutter_localized_locales: ^2.0.5
   after_layout: ^1.2.0
   photo_manager_image_provider: ^2.1.0

--- a/test/data/datasource_impl/contact/phonebook_contact_datasource_impl_test.dart
+++ b/test/data/datasource_impl/contact/phonebook_contact_datasource_impl_test.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/data/datasource/contact/contacts_provider.dart';
+import 'package:fluffychat/data/datasource/contact/sim_country/sim_country_provider.dart';
 import 'package:fluffychat/data/datasource_impl/contact/phonebook_contact_datasource_impl.dart';
 import 'package:fluffychat/domain/model/contact/contact.dart';
 import 'package:flutter_contacts/flutter_contacts.dart' as flutter_contact;
@@ -9,12 +10,16 @@ import 'package:mockito/mockito.dart';
 
 import 'phonebook_contact_datasource_impl_test.mocks.dart';
 
-@GenerateNiceMocks([MockSpec<ContactsProvider>()])
+@GenerateNiceMocks([
+  MockSpec<ContactsProvider>(),
+  MockSpec<SimCountryProvider>(),
+])
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late PhonebookContactDatasourceImpl dataSource;
   late MockContactsProvider mockContactsProvider;
+  late MockSimCountryProvider mockSimCountryProvider;
 
   group('[PhonebookContactDatasourceV2Impl] test\n', () {
     final listAllContacts = [
@@ -139,11 +144,19 @@ void main() {
 
     setUp(() {
       mockContactsProvider = MockContactsProvider();
+      mockSimCountryProvider = MockSimCountryProvider();
+      when(
+        mockSimCountryProvider.getCountryCode(),
+      ).thenAnswer((_) async => 'US');
       final getIt = GetIt.instance;
       getIt.allowReassignment = true;
       getIt.registerFactory<ContactsProvider>(() => mockContactsProvider);
+      getIt.registerFactory<SimCountryProvider>(() => mockSimCountryProvider);
       getIt.registerFactory<PhonebookContactDatasourceImpl>(
-        () => PhonebookContactDatasourceImpl(getIt.get<ContactsProvider>()),
+        () => PhonebookContactDatasourceImpl(
+          getIt.get<ContactsProvider>(),
+          getIt.get<SimCountryProvider>(),
+        ),
       );
       dataSource = getIt.get<PhonebookContactDatasourceImpl>();
 
@@ -159,14 +172,21 @@ void main() {
     test(
       'Give a list of phonebook contacts'
       'When fetchContacts is called'
-      'Then it should return a list of contacts without unknown phone number and email'
-      'Then it should return a list of contacts without duplicated phone number and email',
+      'Then it should return a list of contacts with phone numbers normalized to E.164'
+      'Then it should return a list of contacts without duplicated phone number and email'
+      'Then it should filter contacts whose phone numbers cannot be resolved to a valid E.164',
       () async {
+        // Phone numbers are now normalized to E.164 via phone_numbers_parser (callerIsoCode = 'US').
+        // Numbers that cannot be resolved to a valid E.164 are silently dropped:
+        //   - Eve (id_5): area code 123 is not a real US area code → both numbers rejected.
+        //   - Grace (id_7): ext. notation not supported → both numbers rejected.
+        //   - Hank (id_8): ext. notation + too many digits → both numbers rejected.
+        // Frank (id_6): '81234977890' → pnp resolves as +81 (Japan) + 234977890.
         final List<Contact> expectedListContact = [
           Contact(
             id: 'id_1',
             displayName: 'Alice',
-            phoneNumbers: {PhoneNumber(number: '(212)555-6789')},
+            phoneNumbers: {PhoneNumber(number: '+12125556789')},
             emails: {
               Email(address: 'Alice@domain.com'),
               Email(address: 'Alice_1@domain.com'),
@@ -175,7 +195,7 @@ void main() {
           Contact(
             id: 'id_2',
             displayName: 'Bob',
-            phoneNumbers: {PhoneNumber(number: '2124678190')},
+            phoneNumbers: {PhoneNumber(number: '+12124678190')},
             emails: {
               Email(address: 'bob@domain.com'),
               Email(address: 'bob2@domain.com'),
@@ -184,61 +204,43 @@ void main() {
           Contact(
             id: 'id_3',
             displayName: 'Charlie',
-            phoneNumbers: {PhoneNumber(number: '212 555-6789')},
+            phoneNumbers: {PhoneNumber(number: '+12125556789')},
             emails: const {},
           ),
           Contact(
             id: 'id_4',
             displayName: 'David',
-            phoneNumbers: {PhoneNumber(number: '2124678190')},
-            emails: const {},
-          ),
-          Contact(
-            id: 'id_5',
-            displayName: 'Eve',
-            phoneNumbers: {PhoneNumber(number: '+1.123.456.7890')},
+            phoneNumbers: {PhoneNumber(number: '+12124678190')},
             emails: const {},
           ),
           Contact(
             id: 'id_6',
             displayName: 'Frank',
-            phoneNumbers: {PhoneNumber(number: '81234977890')},
-            emails: const {},
-          ),
-          Contact(
-            id: 'id_7',
-            displayName: 'Grace',
-            phoneNumbers: {PhoneNumber(number: '+1 (800)-555-1234 ext. 123')},
-            emails: const {},
-          ),
-          Contact(
-            id: 'id_8',
-            displayName: 'Hank',
-            phoneNumbers: {PhoneNumber(number: '18005879106234')},
+            phoneNumbers: {PhoneNumber(number: '+81234977890')},
             emails: const {},
           ),
           Contact(
             id: 'id_9',
             displayName: 'Ivy',
-            phoneNumbers: {PhoneNumber(number: '+1 (800)-555.1234')},
+            phoneNumbers: {PhoneNumber(number: '+18005551234')},
             emails: const {},
           ),
           Contact(
             id: 'id_10',
             displayName: 'Karl',
-            phoneNumbers: {PhoneNumber(number: '18005873456')},
+            phoneNumbers: {PhoneNumber(number: '+18005873456')},
             emails: const {},
           ),
           Contact(
             id: 'id_11',
             displayName: 'Liam',
-            phoneNumbers: {PhoneNumber(number: '(212) 555-6789')},
+            phoneNumbers: {PhoneNumber(number: '+12125556789')},
             emails: const {},
           ),
           Contact(
             id: 'id_12',
             displayName: 'Mia',
-            phoneNumbers: {PhoneNumber(number: '2125556789')},
+            phoneNumbers: {PhoneNumber(number: '+12125556789')},
             emails: const {},
           ),
           Contact(

--- a/test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart
@@ -11,6 +11,7 @@ import 'package:fluffychat/domain/repository/phonebook_contact_repository.dart';
 import 'package:fluffychat/domain/usecase/contacts/twake_look_up_argument.dart';
 import 'package:fluffychat/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor.dart';
 import 'package:fluffychat/modules/federation_identity_lookup/domain/models/federation_hash_details_response.dart';
+import 'package:fluffychat/modules/federation_identity_lookup/domain/models/federation_lookup_mxid_request.dart';
 import 'package:fluffychat/modules/federation_identity_lookup/domain/models/federation_lookup_mxid_response.dart';
 import 'package:fluffychat/modules/federation_identity_lookup/manager/identity_lookup_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -63,6 +64,93 @@ void main() {
   });
 
   group('TwakeLookupPhonebookContactInteractor', () {
+    test(
+      'Lookup request should send hashes from sanitized msisdn values only',
+      () async {
+        final contacts = [
+          Contact(
+            id: 'id_valid',
+            displayName: 'Valid',
+            phoneNumbers: {PhoneNumber(number: '+1 (212) 555-6789')},
+            emails: {Email(address: 'valid@example.com')},
+          ),
+          Contact(
+            id: 'id_email_only',
+            displayName: 'Email only',
+            emails: {Email(address: 'email.only@example.com')},
+          ),
+        ];
+        const hashDetails = FederationHashDetailsResponse(
+          algorithms: {'sha256'},
+          lookupPepper: 'pepper',
+        );
+        final argument = TwakeLookUpArgument(
+          homeServerUrl: 'https://example.com',
+          withAccessToken: 'token',
+        );
+
+        when(mockRepository.fetchContacts()).thenAnswer((_) async => contacts);
+        when(
+          mockIdentityLookupManager.getHashDetails(
+            federationUrl: argument.homeServerUrl,
+            registeredToken: argument.withAccessToken,
+          ),
+        ).thenAnswer((_) async => hashDetails);
+        when(
+          mockIdentityLookupManager.lookupMxid(
+            federationUrl: argument.homeServerUrl,
+            request: anyNamed('request'),
+            registeredToken: argument.withAccessToken,
+          ),
+        ).thenAnswer(
+          (_) async => const FederationLookupMxidResponse(
+            mappings: {},
+            inactiveMappings: {},
+          ),
+        );
+
+        await interactor.execute(argument: argument).toList();
+
+        final capturedRequest =
+            verify(
+                  mockIdentityLookupManager.lookupMxid(
+                    federationUrl: argument.homeServerUrl,
+                    request: captureAnyNamed('request'),
+                    registeredToken: argument.withAccessToken,
+                  ),
+                ).captured.single
+                as FederationLookupMxidRequest;
+        final addresses = capturedRequest.addresses ?? {};
+
+        final expectedPhoneHash = PhoneNumber(number: '+1 (212) 555-6789')
+            .calculateHashUsingAllPeppers(
+              lookupPepper: hashDetails.lookupPepper,
+              altLookupPeppers: hashDetails.altLookupPeppers,
+              algorithms: hashDetails.algorithms,
+            )
+            .first;
+        final expectedEmailHash = Email(address: 'valid@example.com')
+            .calculateHashUsingAllPeppers(
+              lookupPepper: hashDetails.lookupPepper,
+              altLookupPeppers: hashDetails.altLookupPeppers,
+              algorithms: hashDetails.algorithms,
+            )
+            .first;
+        final unexpectedMsisdnWithExtensionHash =
+            PhoneNumber(number: '+1 (212) 555-6789 ext. 123')
+                .calculateHashUsingAllPeppers(
+                  lookupPepper: hashDetails.lookupPepper,
+                  altLookupPeppers: hashDetails.altLookupPeppers,
+                  algorithms: hashDetails.algorithms,
+                )
+                .first;
+
+        expect(addresses.contains(expectedPhoneHash), isTrue);
+        expect(addresses.contains(expectedEmailHash), isTrue);
+        expect(addresses.contains(unexpectedMsisdnWithExtensionHash), isFalse);
+      },
+    );
+
     test(
       'Success case - emits loading, then success states with contacs size of one chunk',
       () async {

--- a/test/utils/phone_number_normalizer_test.dart
+++ b/test/utils/phone_number_normalizer_test.dart
@@ -1,0 +1,125 @@
+import 'package:fluffychat/utils/phone_number_normalizer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('tryNormalizePhoneNumberToE164', () {
+    // --- Local numbers (require country context) ---
+
+    test('normalises local FR number to E.164', () {
+      expect(
+        tryNormalizePhoneNumberToE164('0612345678', 'FR'),
+        equals('+33612345678'),
+      );
+    });
+
+    test('normalises local FR number with spaces to E.164', () {
+      expect(
+        tryNormalizePhoneNumberToE164('06 12 34 56 78', 'FR'),
+        equals('+33612345678'),
+      );
+    });
+
+    test('normalises local US number to E.164', () {
+      expect(
+        tryNormalizePhoneNumberToE164('2125556789', 'US'),
+        equals('+12125556789'),
+      );
+    });
+
+    // --- "00" international prefix ---
+
+    test('normalises "00" prefix to E.164', () {
+      expect(
+        tryNormalizePhoneNumberToE164('0033612345678', 'FR'),
+        equals('+33612345678'),
+      );
+    });
+
+    test('normalises "00" prefix with spaces to E.164', () {
+      expect(
+        tryNormalizePhoneNumberToE164('0033 6 12 34 56 78', 'FR'),
+        equals('+33612345678'),
+      );
+    });
+
+    // --- "(0)" trunk prefix in display format ---
+
+    test('normalises "+33 (0) 6..." display format to E.164', () {
+      expect(
+        tryNormalizePhoneNumberToE164('+33 (0) 6 12 34 56 78', 'FR'),
+        equals('+33612345678'),
+      );
+    });
+
+    test('normalises compact "+33(0)6..." to E.164', () {
+      expect(
+        tryNormalizePhoneNumberToE164('+33(0)612345678', 'FR'),
+        equals('+33612345678'),
+      );
+    });
+
+    // --- Already correct E.164 formats ---
+
+    test('returns E.164 unchanged for already normalised number', () {
+      expect(
+        tryNormalizePhoneNumberToE164('+33612345678', 'FR'),
+        equals('+33612345678'),
+      );
+    });
+
+    test('returns E.164 with formatting stripped', () {
+      expect(
+        tryNormalizePhoneNumberToE164('+33 6 12 34 56 78', 'FR'),
+        equals('+33612345678'),
+      );
+    });
+
+    test('accepts lowercase ISO country code', () {
+      expect(
+        tryNormalizePhoneNumberToE164('0612345678', 'fr'),
+        equals('+33612345678'),
+      );
+    });
+
+    // --- Invalid / unparseable inputs ---
+
+    test('returns null for a non-numeric string', () {
+      expect(tryNormalizePhoneNumberToE164('not-a-number', 'FR'), isNull);
+    });
+
+    test('returns null for a number too short to be valid', () {
+      expect(tryNormalizePhoneNumberToE164('123', 'FR'), isNull);
+    });
+
+    test('returns null for an unknown country code', () {
+      expect(tryNormalizePhoneNumberToE164('0612345678', 'XX'), isNull);
+    });
+
+    test('returns null for an empty string', () {
+      expect(tryNormalizePhoneNumberToE164('', 'FR'), isNull);
+    });
+
+    // --- Without callerIsoCode ---
+
+    test(
+      'without callerIsoCode: resolves an E.164 number with explicit "+"',
+      () {
+        expect(
+          tryNormalizePhoneNumberToE164('+33612345678', null),
+          equals('+33612345678'),
+        );
+      },
+    );
+
+    test(
+      'without callerIsoCode: returns null for a local number without "+"',
+      () {
+        expect(tryNormalizePhoneNumberToE164('0612345678', null), isNull);
+      },
+    );
+
+    test('without callerIsoCode: returns null for an invalid number', () {
+      expect(tryNormalizePhoneNumberToE164('not-a-number', null), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Root cause / context
Phone numbers coming from local phonebooks can be stored in inconsistent formats (local/national formats, punctuation, spacing, extensions).  
During contact sync, hashing for Matrix lookup depended on those values being clean enough, but there was no strict normalization gate at ingestion time to guarantee a valid E.164 interpretation before MSISDN hashing. (ex: "0612345678" was valid to send for lookup as an msisdn. The same as "1234".)

## Solution
- Added phone_numbers_parser: to parse/validate raw phonebook numbers and normalize them to E.164 before hashing. (Why not flutter_libphonenumber ? Because it adds native initialization and heavier plumbing, while we only need lightweight batch E.164 normalization, which phone_numbers_parser already covers in pure Dart without startup overhead)
- Added sim_country_code_plus: to infer default country context (SIM first, locale fallback) for local numbers without +.
- Added iOS Info.plist key: NSCarrierUsageDescription: required by sim_country_code_plus to access carrier info and resolve SIM country code.
- Added strict phone normalization before creating domain `PhoneNumber` objects:
  - `tryNormalizePhoneNumberToE164(rawNumber, callerIsoCode)`
  - invalid/unresolvable numbers are dropped early to avoid surcharging server
- Added `SimCountryProvider` to provide country context for local numbers:
  - SIM country first
  - locale fallback (`fr_FR` and `fr-FR` like formats supported)
- Wired `SimCountryProvider` in DI and updated `PhonebookContactDatasourceImpl` constructor usage.
- Kept existing MSISDN sanitization in `PhoneNumber` (`msisdnSanitizer`) as a final guardrail before hash generation.
- Added/updated tests:
  - datasource tests now assert normalized E.164 output and filtering behavior
  - interactor test captures `lookupMxid` request addresses to confirm expected hashes are actually sent
  - dedicated normalizer unit tests for multiple real-world formats and edge cases

## Summarized flow changes
### Before this change:
local phone from address book
-> PhoneNumber(raw)
-> msisdnSanitizer
-> hash
-> lookup
### After this change:
local phone from address book
  **-> tryNormalizePhoneNumberToE164(raw, SIM/locale country)
         -> invalid: drop
         -> valid: PhoneNumber(E.164)**
  -> msisdnSanitizer
  -> hash
  -> lookup

## Examples
| Input | callerIsoCode | return E.164 | msisdn |
|---|---|---|---|
| `0612345678` | `FR` | `+33612345678` | `33612345678` |
| `06 12 34 56 78` | `FR` | `+33612345678` | `33612345678` |
| `2125556789` | `US` | `+12125556789` | `12125556789` |
| `0033612345678` | `FR` | `+33612345678` | `33612345678` |
| `+33 (0) 6 12 34 56 78` | `FR` | `+33612345678` | `33612345678` |
| `+33612345678` | `null` | `+33612345678` | `33612345678` |
| `0612345678` | `null` | `null` | `n/a` |
| `not-a-number` | `FR` | `null` | `n/a` |
| `+7 912 345-67-89` | `FR` | `+79123456789` | `79123456789` |
| `+7 (495) 123-45-67` | `FR` | `+74951234567` | `74951234567` |

## Impact description
- Improves reliability of local contact lookup by ensuring phone inputs are normalized and valid before hash generation.
- Reduces false negatives caused by formatting noise in phonebook entries.
- Does not change Matrix lookup protocol shape (same request fields/algorithm flow): it improves input quality.

## Test recommendations
- Run:
  - `flutter test test/data/datasource_impl/contact/phonebook_contact_datasource_impl_test.dart`
  - `flutter test test/utils/phone_number_normalizer_test.dart`
  - `flutter test test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart`
- Manual checks recommended:
  - local numbers without `+` with SIM country available
  - local numbers without `+` with SIM unavailable but locale fallback active
  - malformed numbers / extension-heavy values are not sent to lookup hashing
- Additional caution:
  - `SimCountryProvider` currently caches first resolution result (including `null`). If first call fails transiently, fallback behavior may persist for session.
 
## Demos
- N/A (backend/domain flow change, no UI behavior demo required).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone numbers are normalized to international E.164 for consistent display and deduplication.
  * Device/SIM-based country detection is used to improve normalization of local numbers (with safe web fallback).

* **Bug Fixes**
  * Contacts with unresolvable or invalid phone numbers are excluded to reduce errors and duplicates.

* **Documentation**
  * Added a carrier-usage privacy notice explaining use of carrier info to infer a default country code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->