### PR TITLE
TW-3029: Hide app download banner on desktop

### DIFF
--- a/web/worker_service/worker_service.js
+++ b/web/worker_service/worker_service.js
@@ -21,9 +21,18 @@ const universalLinkBase = "https://links.twake.app/chat";
 
 function getPlatform() {
   const ua = navigator.userAgent || navigator.vendor || window.opera;
-  const isMobileUa =
-    platformConfig.ios.pattern.test(ua) ||
-    platformConfig.android.pattern.test(ua);
+
+  // Store pattern results once to avoid redundant regex evaluations.
+  const isIOS = platformConfig.ios.pattern.test(ua);
+  const isAndroid = platformConfig.android.pattern.test(ua);
+
+  // iPadOS 13+ defaults to a macOS user agent ("Macintosh") to request the
+  // desktop version of websites, so the iOS pattern above will miss it.
+  // Fall back to checking maxTouchPoints: real Macs have 0, iPads have > 1.
+  // See: https://developer.apple.com/forums/thread/119186
+  const isIPad = !isIOS && /Macintosh/i.test(ua) && navigator.maxTouchPoints > 1;
+
+  const isMobileUa = isIOS || isIPad || isAndroid;
 
   // Require both a mobile UA and a coarse pointer (touch-primary device).
   // This prevents the banner from appearing in desktop DevTools when a mobile
@@ -33,7 +42,7 @@ function getPlatform() {
     navigator.maxTouchPoints > 0;
 
   if (!isMobileUa || !hasTouchPrimary) return "other";
-  if (platformConfig.ios.pattern.test(ua)) return platformConfig.ios.name;
+  if (isIOS || isIPad) return platformConfig.ios.name;
   return platformConfig.android.name;
 }
 

--- a/web/worker_service/worker_service.js
+++ b/web/worker_service/worker_service.js
@@ -21,9 +21,20 @@ const universalLinkBase = "https://links.twake.app/chat";
 
 function getPlatform() {
   const ua = navigator.userAgent || navigator.vendor || window.opera;
+  const isMobileUa =
+    platformConfig.ios.pattern.test(ua) ||
+    platformConfig.android.pattern.test(ua);
+
+  // Require both a mobile UA and a coarse pointer (touch-primary device).
+  // This prevents the banner from appearing in desktop DevTools when a mobile
+  // UA is emulated but no real touch input is present.
+  const hasTouchPrimary =
+    window.matchMedia("(pointer: coarse)").matches ||
+    navigator.maxTouchPoints > 0;
+
+  if (!isMobileUa || !hasTouchPrimary) return "other";
   if (platformConfig.ios.pattern.test(ua)) return platformConfig.ios.name;
-  if (platformConfig.android.pattern.test(ua)) return platformConfig.android.name;
-  return "other";
+  return platformConfig.android.name;
 }
 
 function getStoreUrl(platform) {


### PR DESCRIPTION
## Ticket
**Related issue**
- #3029 

**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/9178be40-4cb2-46cc-95aa-1b80c48fbfa5


https://github.com/user-attachments/assets/6c02e45b-b5d4-4d69-b0b1-aeb1ac4f2fa9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile and tablet device detection logic to more accurately identify iOS, iPadOS, and Android devices. The app now combines multiple detection methods to determine whether to display platform-specific banners, resulting in better accuracy across different devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->