### PR TITLE
TW-2705(fix): stale pending events no longer shadow confirmed message…

### DIFF
--- a/lib/domain/model/room/room_extension.dart
+++ b/lib/domain/model/room/room_extension.dart
@@ -203,7 +203,12 @@ extension RoomExtension on Room {
           }
         }
       }
-      if (bestSynced != null) return RoomPreviewFound(bestSynced);
+      if (bestSynced != null) {
+        final best = bestPending != null
+            ? _newestEvent(bestSynced, bestPending)
+            : bestSynced;
+        return RoomPreviewFound(best);
+      }
 
       final dbEvents = await client.database.getEventList(
         this,

--- a/lib/domain/model/room/room_extension.dart
+++ b/lib/domain/model/room/room_extension.dart
@@ -170,22 +170,40 @@ extension RoomExtension on Room {
   Future<RoomPreviewResult> lastEventAvailableInPreview() async {
     const previewLimit = 30;
     try {
+      Event? bestSynced;
+      Event? bestPending;
+
+      final syncCandidate = lastEvent;
+      if (syncCandidate != null &&
+          EventVisibilityResolver.isEligibleForChatListPreviewSync(
+            syncCandidate,
+          )) {
+        if (syncCandidate.status.isSent) {
+          bestSynced = syncCandidate;
+        } else {
+          bestPending = syncCandidate;
+        }
+      }
+
+      if (bestSynced != null) return RoomPreviewFound(bestSynced);
+
       final statePreviewCandidates = client.roomPreviewLastEvents
           .map(getState)
           .whereType<Event>()
           .toList();
-      Event? best;
       for (final e in statePreviewCandidates) {
         if (await EventVisibilityResolver.isEligibleForChatListPreview(
           this,
           e,
         )) {
-          best = _newestEvent(best, e);
+          if (e.status.isSent) {
+            bestSynced = _newestEvent(bestSynced, e);
+          } else {
+            bestPending = _newestEvent(bestPending, e);
+          }
         }
       }
-      if (best != null) {
-        return RoomPreviewFound(best);
-      }
+      if (bestSynced != null) return RoomPreviewFound(bestSynced);
 
       final dbEvents = await client.database.getEventList(
         this,
@@ -198,11 +216,21 @@ extension RoomExtension on Room {
           this,
           e,
         )) {
-          best = _newestEvent(best, e);
+          if (e.status.isSent) {
+            bestSynced = _newestEvent(bestSynced, e);
+          } else {
+            bestPending = _newestEvent(bestPending, e);
+          }
         }
       }
-      if (best != null) {
-        return RoomPreviewFound(best);
+      // Prefer the most recent confirmed event. A pending/failed event wins
+      // only when it is genuinely newer (e.g. a message just sent without
+      // network).
+      final dbBest = bestPending != null
+          ? _newestEvent(bestSynced, bestPending)
+          : bestSynced;
+      if (dbBest != null) {
+        return RoomPreviewFound(dbBest);
       }
       return roomFullyScanned
           ? const RoomPreviewEmpty()

--- a/lib/pages/chat_list/chat_list_item_subtitle.dart
+++ b/lib/pages/chat_list/chat_list_item_subtitle.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/domain/matrix_events/event_visibility_resolver.dart';
 import 'package:fluffychat/domain/model/room/room_preview_result.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/pages/chat/events/message_time_style.dart';
@@ -27,13 +26,6 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
     this.previewResult,
   });
 
-  static Event? _syncPreview(Event? candidate) {
-    if (candidate == null) return null;
-    return EventVisibilityResolver.isEligibleForChatListPreviewSync(candidate)
-        ? candidate
-        : null;
-  }
-
   @override
   Widget build(BuildContext context) {
     final L10n l10n = L10n.of(context)!;
@@ -44,12 +36,10 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
       room.hasNewMessages,
       room.notificationCount > 0,
     );
-    final Event? lastEvent =
-        _syncPreview(room.lastEvent) ??
-        switch (previewResult) {
-          RoomPreviewFound(:final event) => event,
-          _ => null,
-        };
+    final Event? lastEvent = switch (previewResult) {
+      RoomPreviewFound(:final event) => event,
+      _ => null,
+    };
     final bool isMediaEvent =
         lastEvent?.messageType == MessageTypes.Image ||
         lastEvent?.messageType == MessageTypes.Video;

--- a/lib/pages/chat_list/chat_list_sort_rooms.dart
+++ b/lib/pages/chat_list/chat_list_sort_rooms.dart
@@ -33,6 +33,11 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
   Map<String, StreamSubscription?> _roomSubscriptions = {};
   Future<List<Room>>? _sortFuture;
 
+  /// Rooms whose preview is stale and must be recomputed on the next sort.
+  /// We keep the last known value in [_previewByRoomId] until the new result
+  /// is ready, so the UI never flickers to an empty preview mid-scan.
+  final Set<String> _pendingRefresh = {};
+
   /// Monotonically increasing counter to invalidate stale sort futures.
   /// Each call to [_triggerSort] increments this value. When a sort future
   /// completes, it checks whether its generation matches [_sortGeneration].
@@ -71,13 +76,17 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
       // triggered while we were awaiting.
       if (!mounted || generation != _sortGeneration) return _sortCache;
 
-      if (_previewByRoomId[room.id] != null) continue;
+      if (_previewByRoomId[room.id] != null &&
+          !_pendingRefresh.contains(room.id)) {
+        continue;
+      }
 
       final result = await room.lastEventAvailableInPreview();
 
       if (!mounted || generation != _sortGeneration) return _sortCache;
 
       _previewByRoomId[room.id] = result;
+      _pendingRefresh.remove(room.id);
     }
 
     if (!mounted) return _sortCache;
@@ -103,7 +112,7 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
         (room) => MapEntry(
           room.id,
           room.onUpdate.stream.listen((roomId) {
-            _previewByRoomId[roomId] = null;
+            _pendingRefresh.add(roomId);
           }),
         ),
       ),
@@ -135,7 +144,7 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
           _roomSubscriptions.putIfAbsent(
             room.id,
             () => room.onUpdate.stream.listen((roomId) {
-              _previewByRoomId[roomId] = null;
+              _pendingRefresh.add(roomId);
             }),
           ),
         ),

--- a/lib/pages/chat_list/chat_list_sort_rooms.dart
+++ b/lib/pages/chat_list/chat_list_sort_rooms.dart
@@ -160,6 +160,7 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
       subscription?.cancel();
     }
     _roomSubscriptions.clear();
+    _pendingRefresh.clear();
     // Invalidate any in-flight sort future so its callbacks become no-ops.
     _sortGeneration++;
     super.dispose();

--- a/lib/pages/chat_list/chat_list_sort_rooms.dart
+++ b/lib/pages/chat_list/chat_list_sort_rooms.dart
@@ -81,12 +81,12 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
         continue;
       }
 
+      _pendingRefresh.remove(room.id);
       final result = await room.lastEventAvailableInPreview();
 
       if (!mounted || generation != _sortGeneration) return _sortCache;
 
       _previewByRoomId[room.id] = result;
-      _pendingRefresh.remove(room.id);
     }
 
     if (!mounted) return _sortCache;

--- a/lib/pages/chat_list/chat_list_sort_rooms.dart
+++ b/lib/pages/chat_list/chat_list_sort_rooms.dart
@@ -136,6 +136,7 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
         .toList();
     for (final room in removedRooms) {
       _roomSubscriptions[room.id]?.cancel();
+      _pendingRefresh.remove(room.id);
     }
     _roomSubscriptions = Map.fromEntries(
       widget.rooms.map(

--- a/test/domain/model/room/last_event_available_in_preview_test.dart
+++ b/test/domain/model/room/last_event_available_in_preview_test.dart
@@ -88,6 +88,16 @@ Event _reaction(Room room, String eventId, DateTime ts) => Event(
   room: room,
 );
 
+Event _pendingMessage(Room room, String eventId, DateTime ts) => Event(
+  content: {'msgtype': 'm.text', 'body': 'pending'},
+  type: EventTypes.Message,
+  eventId: eventId,
+  senderId: '@alice:test.local',
+  originServerTs: ts,
+  room: room,
+  status: EventStatus.sending,
+);
+
 Event _roomCreate(Room room, String eventId, DateTime ts) => Event(
   content: {'creator': '@alice:test.local'},
   type: EventTypes.RoomCreate,
@@ -166,6 +176,94 @@ void main() {
         expect((result as RoomPreviewFound).event.eventId, '\$m1');
       },
     );
+
+    group('pending vs confirmed priority', () {
+      test(
+        'confirmed event in DB wins over an older pending event in room.lastEvent',
+        () async {
+          final db = FixedEventListDatabase();
+          final client = await _clientWithDatabase(db);
+          final room = _room(client);
+          final base = DateTime.utc(2024, 6, 1);
+
+          room.lastEvent = _pendingMessage(
+            room,
+            '\$phantom',
+            base.subtract(const Duration(days: 7)),
+          );
+          db.events.add(_message(room, '\$confirmed', base));
+
+          final result = await room.lastEventAvailableInPreview();
+
+          expect(result, isA<RoomPreviewFound>());
+          expect((result as RoomPreviewFound).event.eventId, '\$confirmed');
+        },
+      );
+
+      test(
+        'fresh pending event in room.lastEvent wins over an older confirmed event in DB',
+        () async {
+          final db = FixedEventListDatabase();
+          final client = await _clientWithDatabase(db);
+          final room = _room(client);
+          final base = DateTime.utc(2024, 6, 1);
+
+          room.lastEvent = _pendingMessage(room, '\$sending', base);
+          db.events.add(
+            _message(
+              room,
+              '\$confirmed',
+              base.subtract(const Duration(days: 1)),
+            ),
+          );
+
+          final result = await room.lastEventAvailableInPreview();
+
+          expect(result, isA<RoomPreviewFound>());
+          expect((result as RoomPreviewFound).event.eventId, '\$sending');
+        },
+      );
+
+      test(
+        'confirmed event in room.lastEvent is returned without scanning the DB',
+        () async {
+          // DB is empty — if the fast-path did not work the result would be
+          // RoomPreviewUnavailable instead of RoomPreviewFound.
+          final db = FixedEventListDatabase();
+          final client = await _clientWithDatabase(db);
+          final room = _room(client);
+
+          room.lastEvent = _message(
+            room,
+            '\$confirmed',
+            DateTime.utc(2024, 6, 1),
+          );
+
+          final result = await room.lastEventAvailableInPreview();
+
+          expect(result, isA<RoomPreviewFound>());
+          expect((result as RoomPreviewFound).event.eventId, '\$confirmed');
+        },
+      );
+
+      test(
+        'falls back to pending event when no confirmed event exists anywhere',
+        () async {
+          final db = FixedEventListDatabase();
+          final client = await _clientWithDatabase(db);
+          final room = _room(client);
+
+          db.events.add(
+            _pendingMessage(room, '\$pending', DateTime.utc(2024, 6, 1)),
+          );
+
+          final result = await room.lastEventAvailableInPreview();
+
+          expect(result, isA<RoomPreviewFound>());
+          expect((result as RoomPreviewFound).event.eventId, '\$pending');
+        },
+      );
+    });
 
     test('returns RoomPreviewUnavailable when getEventList fails', () async {
       final client = await _clientWithDatabase(ThrowingGetEventListDatabase());


### PR DESCRIPTION
Fixes #3016 
## Root cause

`room.lastEvent` the SDK's in-memory field updated on each sync can hold a non-confirmed event (sending or error). The chat list preview had two separate sources of truth: `room.lastEvent` (in-memory, sync) and the async DB scan result (`previewResult`). Reconciliation was done inside the widget (`ChatListItemSubtitle`) without proper timestamp comparison, so a non-confirmed event in `room.lastEvent` could silently override a more recent confirmed message from the DB.

## Solution

**Single source of truth in the domain layer**: `lastEventAvailableInPreview()` now reads `this.lastEvent` as a first candidate alongside state events and DB events, removing the need for any reconciliation logic in the widget.

**Timestamp-aware priority**: two buckets (`bestSynced` / `bestPending`) are maintained throughout the scan. Confirmed events (`status.isSent`) always take priority. A pending/error event only wins if it is genuinely more recent (e.g. a message just sent with no network). This is resolved at the very end of the scan via `_newestEvent(bestSynced, bestPending)`.

**No premature early returns on pending candidates**: early returns are guarded by `bestSynced != null` only, ensuring the DB scan always runs when the best in-memory candidate is unconfirmed.

**No flicker on room updates**: `ChatListSortRooms` previously nullified `_previewByRoomId[roomId]` immediately on `onUpdate`, causing a blank preview during the async recomputation. It now adds the room to a `_pendingRefresh` set instead, keeping the last known preview visible until the new result is ready.

## Impact description

Applies only to the chat list preview. No change to the timeline view or message sending flow.

## Test recommendations

- Inject or mock a `SENDING` event with `origin_server_ts` set 7 days in the past, then verify the confirmed last
  message is shown instead.
- Send a message with network disabled and verify the pending message appears
  immediately in the preview.
- Re-enable network, let the message confirm, and verify the confirmed message is
  still shown.
- Open a room and return to the chat list: verify no flicker occurs on the
  preview.
- 4 regression tests added in
  `test/domain/model/room/last_event_available_in_preview_test.dart`.

## Other
Needs #3028 to be complete. By itself, this PR does not fix the behavior where icons are not shown on hover due to a chat list difference.

## Resolved
- Web:

https://github.com/user-attachments/assets/de4d0e74-51be-4662-8030-e78dc4a91796


- Mobile:

https://github.com/user-attachments/assets/76820a23-6ed9-41cf-9ebe-c051f14e51c6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected message-preview selection to prefer confirmed/sent messages over pending/unsent ones and handle incomplete states consistently.

* **Performance**
  * Added preview caching with targeted refresh tracking to avoid redundant recomputation and reduce database scans.

* **Tests**
  * Added test coverage for pending vs confirmed message precedence and fallback behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->