### PR TITLE
TW-3018: Highlight only message bubble, not unread divider

### DIFF
--- a/lib/pages/chat/chat_event_list_item.dart
+++ b/lib/pages/chat/chat_event_list_item.dart
@@ -5,7 +5,6 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extensi
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
-import 'package:scroll_to_index/scroll_to_index.dart';
 
 class ChatEventListItem extends StatelessWidget {
   const ChatEventListItem({
@@ -29,81 +28,77 @@ class ChatEventListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     if (!event.isVisibleInGui) return const SizedBox();
 
-    return AutoScrollTag(
-      key: ValueKey(event.eventId),
-      index: index,
-      controller: controller.scrollController,
-      highlightColor: Theme.of(context).highlightColor,
-      child: Message(
-        key: GlobalObjectKey(event.eventId),
-        event,
-        matrixState: controller.matrix!,
-        onSwipe: (direction) => controller.replyAction(replyTo: event),
-        onAvatarTap: (Event event) => controller.onContactTap(
-          contactPresentationSearch: event.senderFromMemoryOrFallback
-              .toContactPresentationSearch(),
-          context: context,
-          path: 'rooms',
-        ),
-        onSelect: controller.onSelectMessage,
-        selectMode: controller.selectMode,
-        maxWidth: constraints.maxWidth,
-        scrollToEventId: (String eventId) =>
-            controller.scrollToEventId(eventId, highlight: true),
-        selected: controller.selectedEvents.any(
-          (e) => e.eventId == event.eventId,
-        ),
-        timeline: controller.timeline!,
-        previousEvent: previousEvent,
-        nextEvent: nextEvent,
-        onHover: (isHover, event) => controller.onHover(isHover, event),
-        isHoverNotifier: controller.focusHover,
-        listHorizontalActionMenu: controller.listHorizontalActionMenuBuilder(
-          event,
-        ),
-        onMenuAction: controller.handleHorizontalActionMenu,
-        hideKeyboardChatScreen: controller.onHideKeyboardAndEmoji,
-        markedUnreadLocation: controller.unreadReceivedMessageLocation,
-        timestampCallback: (event) {
-          controller.handleDisplayStickyTimestamp(event.originServerTs);
-        },
-        onEventVisible: controller.onEventVisible,
-        onDisplayEmojiReaction: controller.onDisplayEmojiReaction,
-        onHideEmojiReaction: controller.onHideEmojiReaction,
-        listAction: controller.listHorizontalActionMenuBuilder(event).map((
-          action,
-        ) {
-          return ContextMenuAction(name: action.action.name);
-        }).toList(),
-        onPickEmojiReaction: () {},
-        onSelectEmojiReaction: (emoji, event) {
-          controller.sendEmojiAction(emoji: emoji, event: event);
-        },
-        onForward: (event) {
-          controller.forwardEventsAction(event: event);
-        },
-        onReply: (event) {
-          controller.replyAction(replyTo: event);
-        },
-        onCopy: controller.copyEventsAction,
-        onPin: (event) {
-          controller.pinEventAction(event);
-        },
-        onSaveToDownload: (event) =>
-            controller.saveSelectedEventToDownloadAndroid(context, event),
-        onSaveToGallery: (event) =>
-            controller.saveSelectedEventToGallery(context, event),
-        onTapMoreButton: controller.handleOnTapMoreButtonOnWeb,
-        onEdit: (event) {
-          controller.editAction(editEvent: event);
-        },
-        onDelete: (context, event) {
-          controller.deleteEventAction(context, event);
-        },
-        recentEmojiFuture: controller.getRecentReactionsInteractor.execute(),
-        onReport: controller.reportEventAction,
-        onRetryTextMessage: controller.retryTextMessage,
+    return Message(
+      key: GlobalObjectKey(event.eventId),
+      event,
+      autoScrollController: controller.scrollController,
+      scrollIndex: index,
+      matrixState: controller.matrix!,
+      onSwipe: (direction) => controller.replyAction(replyTo: event),
+      onAvatarTap: (Event event) => controller.onContactTap(
+        contactPresentationSearch: event.senderFromMemoryOrFallback
+            .toContactPresentationSearch(),
+        context: context,
+        path: 'rooms',
       ),
+      onSelect: controller.onSelectMessage,
+      selectMode: controller.selectMode,
+      maxWidth: constraints.maxWidth,
+      scrollToEventId: (String eventId) =>
+          controller.scrollToEventId(eventId, highlight: true),
+      selected: controller.selectedEvents.any(
+        (e) => e.eventId == event.eventId,
+      ),
+      timeline: controller.timeline!,
+      previousEvent: previousEvent,
+      nextEvent: nextEvent,
+      onHover: (isHover, event) => controller.onHover(isHover, event),
+      isHoverNotifier: controller.focusHover,
+      listHorizontalActionMenu: controller.listHorizontalActionMenuBuilder(
+        event,
+      ),
+      onMenuAction: controller.handleHorizontalActionMenu,
+      hideKeyboardChatScreen: controller.onHideKeyboardAndEmoji,
+      markedUnreadLocation: controller.unreadReceivedMessageLocation,
+      timestampCallback: (event) {
+        controller.handleDisplayStickyTimestamp(event.originServerTs);
+      },
+      onEventVisible: controller.onEventVisible,
+      onDisplayEmojiReaction: controller.onDisplayEmojiReaction,
+      onHideEmojiReaction: controller.onHideEmojiReaction,
+      listAction: controller.listHorizontalActionMenuBuilder(event).map((
+        action,
+      ) {
+        return ContextMenuAction(name: action.action.name);
+      }).toList(),
+      onPickEmojiReaction: () {},
+      onSelectEmojiReaction: (emoji, event) {
+        controller.sendEmojiAction(emoji: emoji, event: event);
+      },
+      onForward: (event) {
+        controller.forwardEventsAction(event: event);
+      },
+      onReply: (event) {
+        controller.replyAction(replyTo: event);
+      },
+      onCopy: controller.copyEventsAction,
+      onPin: (event) {
+        controller.pinEventAction(event);
+      },
+      onSaveToDownload: (event) =>
+          controller.saveSelectedEventToDownloadAndroid(context, event),
+      onSaveToGallery: (event) =>
+          controller.saveSelectedEventToGallery(context, event),
+      onTapMoreButton: controller.handleOnTapMoreButtonOnWeb,
+      onEdit: (event) {
+        controller.editAction(editEvent: event);
+      },
+      onDelete: (context, event) {
+        controller.deleteEventAction(context, event);
+      },
+      recentEmojiFuture: controller.getRecentReactionsInteractor.execute(),
+      onReport: controller.reportEventAction,
+      onRetryTextMessage: controller.retryTextMessage,
     );
   }
 }

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -1,23 +1,17 @@
 import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:fluffychat/domain/matrix_events/event_type_rules.dart';
-import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/chat_horizontal_action_menu.dart';
-import 'package:fluffychat/pages/chat/chat_view_body_style.dart';
 import 'package:fluffychat/pages/chat/context_item_chat_action.dart';
+import 'package:fluffychat/pages/chat/events/message/message_container.dart';
 import 'package:fluffychat/pages/chat/events/message/message_content_with_timestamp_builder.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
-import 'package:fluffychat/pages/chat/events/message/multi_platform_message_container.dart';
-import 'package:fluffychat/pages/chat/events/message/swipeable_message.dart';
 import 'package:fluffychat/pages/chat/events/state_message.dart';
 import 'package:fluffychat/pages/chat/events/verification_request_content.dart';
-import 'package:fluffychat/pages/chat/optional_gesture_detector.dart';
-import 'package:fluffychat/pages/chat/optional_padding.dart';
 import 'package:fluffychat/pages/chat/optional_selection_container_disabled.dart';
 import 'package:fluffychat/pages/chat/sticky_timestamp_widget.dart';
 import 'package:fluffychat/presentation/mixins/message_avatar_mixin.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
-import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -344,7 +338,18 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
             ),
           ),
         ],
-        _buildMessageContainer(context, row),
+        MessageContainer(
+          event: widget.event,
+          row: row,
+          selected: widget.selected,
+          selectMode: widget.selectMode,
+          onHover: widget.onHover,
+          onSwipe: widget.onSwipe,
+          onSelect: widget.onSelect,
+          hideKeyboardChatScreen: widget.hideKeyboardChatScreen,
+          autoScrollController: widget.autoScrollController,
+          scrollIndex: widget.scrollIndex,
+        ),
       ],
     );
 
@@ -354,105 +359,5 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
       child: column,
     );
   }
-
-  Widget _buildMessageContainer(BuildContext context, Widget row) {
-    final container = MultiPlatformsMessageContainer(
-      onTap: widget.hideKeyboardChatScreen,
-      onHover: (hover) {
-        if (!widget.event.status.isAvailable) {
-          return;
-        }
-        if (widget.onHover != null) {
-          widget.onHover!(hover, widget.event);
-        }
-      },
-      child: Container(
-        constraints: BoxConstraints(
-          maxWidth: ChatViewBodyStyle.chatScreenMaxWidth,
-        ),
-        padding: MessageStyle.paddingMessage,
-        alignment: Alignment.bottomCenter,
-        child: SwipeableMessage(
-          event: widget.event,
-          onSwipe: widget.onSwipe,
-          child: OptionalGestureDetector(
-            onLongPress: () => widget.onSelect!(widget.event),
-            onTap: () => widget.onSelect!(widget.event),
-            isEnabled: widget.selectMode && widget.event.status.isAvailable,
-            child: OptionalPadding(
-              padding: EdgeInsetsDirectional.only(
-                end:
-                    widget.event.isOwnMessage ||
-                        Message.responsiveUtils.isDesktop(context)
-                    ? 8.0
-                    : 16.0,
-                top: 1.0,
-                bottom: 1.0,
-              ),
-              isEnabled: !widget.selected,
-              child: _messageSelectedWidget(context, row, widget.event),
-            ),
-          ),
-        ),
-      ),
-    );
-
-    final controller = widget.autoScrollController;
-    final scrollIdx = widget.scrollIndex;
-    if (controller != null && scrollIdx != null) {
-      return AutoScrollTag(
-        key: ValueKey(widget.event.eventId),
-        index: scrollIdx,
-        controller: controller,
-        highlightColor: Theme.of(context).highlightColor,
-        child: container,
-      );
-    }
-    return container;
-  }
-
-  Widget _messageSelectedWidget(
-    BuildContext context,
-    Widget child,
-    Event event,
-  ) {
-    return Container(
-      padding: EdgeInsets.only(
-        left: Message.responsiveUtils.isMobile(context) ? 8.0 : 0,
-      ),
-      color: widget.selected
-          ? LinagoraSysColors.material().secondaryContainer
-          : Theme.of(context).primaryColor.withAlpha(0),
-      constraints: const BoxConstraints(
-        maxWidth: TwakeThemes.columnWidth * 2.5,
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.max,
-        children: [
-          if (widget.selectMode && event.redacted)
-            const SizedBox(width: 20)
-          else if (widget.selectMode && event.status.isAvailable)
-            Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: Icon(
-                widget.selected
-                    ? Icons.check_circle_rounded
-                    : Icons.circle_outlined,
-                color: widget.selected
-                    ? LinagoraSysColors.material().primary
-                    : Colors.black,
-                size: 20,
-              ),
-            ),
-          Expanded(
-            flex: 9,
-            child: Align(
-              alignment: AlignmentDirectional.centerEnd,
-              child: child,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
 }
+

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -1,3 +1,4 @@
+import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:fluffychat/domain/matrix_events/event_type_rules.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
@@ -93,6 +94,8 @@ class Message extends StatefulWidget {
   onTapMoreButton;
   final Future<Category?>? recentEmojiFuture;
   final Future<void> Function(Event)? onRetryTextMessage;
+  final AutoScrollController? autoScrollController;
+  final int? scrollIndex;
 
   const Message(
     this.event, {
@@ -136,6 +139,8 @@ class Message extends StatefulWidget {
     this.onTapMoreButton,
     this.recentEmojiFuture,
     this.onRetryTextMessage,
+    this.autoScrollController,
+    this.scrollIndex,
   });
 
   /// Indicates wheither the user may use a mouse instead
@@ -339,46 +344,7 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
             ),
           ),
         ],
-        MultiPlatformsMessageContainer(
-          onTap: widget.hideKeyboardChatScreen,
-          onHover: (hover) {
-            if (!widget.event.status.isAvailable) {
-              return;
-            }
-            if (widget.onHover != null) {
-              widget.onHover!(hover, widget.event);
-            }
-          },
-          child: Container(
-            constraints: BoxConstraints(
-              maxWidth: ChatViewBodyStyle.chatScreenMaxWidth,
-            ),
-            padding: MessageStyle.paddingMessage,
-            alignment: Alignment.bottomCenter,
-            child: SwipeableMessage(
-              event: widget.event,
-              onSwipe: widget.onSwipe,
-              child: OptionalGestureDetector(
-                onLongPress: () => widget.onSelect!(widget.event),
-                onTap: () => widget.onSelect!(widget.event),
-                isEnabled: widget.selectMode && widget.event.status.isAvailable,
-                child: OptionalPadding(
-                  padding: EdgeInsetsDirectional.only(
-                    end:
-                        widget.event.isOwnMessage ||
-                            Message.responsiveUtils.isDesktop(context)
-                        ? 8.0
-                        : 16.0,
-                    top: 1.0,
-                    bottom: 1.0,
-                  ),
-                  isEnabled: !widget.selected,
-                  child: _messageSelectedWidget(context, row, widget.event),
-                ),
-              ),
-            ),
-          ),
-        ),
+        _buildMessageContainer(context, row),
       ],
     );
 
@@ -387,6 +353,62 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
       onVisibilityChanged: _onVisibilityChangedForMarkAsRead,
       child: column,
     );
+  }
+
+  Widget _buildMessageContainer(BuildContext context, Widget row) {
+    final container = MultiPlatformsMessageContainer(
+      onTap: widget.hideKeyboardChatScreen,
+      onHover: (hover) {
+        if (!widget.event.status.isAvailable) {
+          return;
+        }
+        if (widget.onHover != null) {
+          widget.onHover!(hover, widget.event);
+        }
+      },
+      child: Container(
+        constraints: BoxConstraints(
+          maxWidth: ChatViewBodyStyle.chatScreenMaxWidth,
+        ),
+        padding: MessageStyle.paddingMessage,
+        alignment: Alignment.bottomCenter,
+        child: SwipeableMessage(
+          event: widget.event,
+          onSwipe: widget.onSwipe,
+          child: OptionalGestureDetector(
+            onLongPress: () => widget.onSelect!(widget.event),
+            onTap: () => widget.onSelect!(widget.event),
+            isEnabled: widget.selectMode && widget.event.status.isAvailable,
+            child: OptionalPadding(
+              padding: EdgeInsetsDirectional.only(
+                end:
+                    widget.event.isOwnMessage ||
+                        Message.responsiveUtils.isDesktop(context)
+                    ? 8.0
+                    : 16.0,
+                top: 1.0,
+                bottom: 1.0,
+              ),
+              isEnabled: !widget.selected,
+              child: _messageSelectedWidget(context, row, widget.event),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final controller = widget.autoScrollController;
+    final scrollIdx = widget.scrollIndex;
+    if (controller != null && scrollIdx != null) {
+      return AutoScrollTag(
+        key: ValueKey(widget.event.eventId),
+        index: scrollIdx,
+        controller: controller,
+        highlightColor: Theme.of(context).highlightColor,
+        child: container,
+      );
+    }
+    return container;
   }
 
   Widget _messageSelectedWidget(

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -360,4 +360,3 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
     );
   }
 }
-

--- a/lib/pages/chat/events/message/message_container.dart
+++ b/lib/pages/chat/events/message/message_container.dart
@@ -1,0 +1,117 @@
+import 'package:scroll_to_index/scroll_to_index.dart';
+import 'package:fluffychat/pages/chat/chat_view_body_style.dart';
+import 'package:fluffychat/pages/chat/events/message/message.dart';
+import 'package:fluffychat/pages/chat/events/message/message_selected_widget.dart';
+import 'package:fluffychat/pages/chat/events/message/message_style.dart';
+import 'package:fluffychat/pages/chat/events/message/multi_platform_message_container.dart';
+import 'package:fluffychat/pages/chat/events/message/swipeable_message.dart';
+import 'package:fluffychat/pages/chat/optional_gesture_detector.dart';
+import 'package:fluffychat/pages/chat/optional_padding.dart';
+import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+import 'package:matrix/matrix.dart';
+
+class MessageContainer extends StatelessWidget {
+  final Event event;
+  final Widget row;
+  final bool selected;
+  final bool selectMode;
+  final OnHover? onHover;
+  final OnSwipe? onSwipe;
+  final OnSelect? onSelect;
+  final VoidCallback? hideKeyboardChatScreen;
+  final AutoScrollController? autoScrollController;
+  final int? scrollIndex;
+
+  const MessageContainer({
+    super.key,
+    required this.event,
+    required this.row,
+    required this.selected,
+    required this.selectMode,
+    this.onHover,
+    this.onSwipe,
+    this.onSelect,
+    this.hideKeyboardChatScreen,
+    this.autoScrollController,
+    this.scrollIndex,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final container = MultiPlatformsMessageContainer(
+      onTap: hideKeyboardChatScreen,
+      onHover: (hover) {
+        if (!event.status.isAvailable) return;
+        onHover?.call(hover, event);
+      },
+      child: Container(
+        constraints: BoxConstraints(
+          maxWidth: ChatViewBodyStyle.chatScreenMaxWidth,
+        ),
+        padding: MessageStyle.paddingMessage,
+        alignment: Alignment.bottomCenter,
+        child: SwipeableMessage(
+          event: event,
+          onSwipe: onSwipe,
+          child: OptionalGestureDetector(
+            onLongPress: () => onSelect!(event),
+            onTap: () => onSelect!(event),
+            isEnabled: selectMode && event.status.isAvailable,
+            child: OptionalPadding(
+              padding: EdgeInsetsDirectional.only(
+                end:
+                    event.isOwnMessage ||
+                        Message.responsiveUtils.isDesktop(context)
+                    ? 8.0
+                    : 16.0,
+                top: 1.0,
+                bottom: 1.0,
+              ),
+              isEnabled: !selected,
+              child: MessageSelectedWidget(
+                event: event,
+                selected: selected,
+                selectMode: selectMode,
+                child: row,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // SizedBox forces the Stack to fill the full row width so the highlight
+    // color spans the screen. Positioned.fill paints behind the content
+    // without affecting the message layout.
+    final highlighted = SizedBox(
+      width: double.infinity,
+      child: Stack(
+        children: [
+          if (selected)
+            Positioned.fill(
+              child: ColoredBox(
+                color: LinagoraSysColors.material().secondaryContainer,
+              ),
+            ),
+          container,
+        ],
+      ),
+    );
+
+    final controller = autoScrollController;
+    final scrollIdx = scrollIndex;
+    if (controller != null && scrollIdx != null) {
+      return AutoScrollTag(
+        key: ValueKey(event.eventId),
+        index: scrollIdx,
+        controller: controller,
+        highlightColor: Theme.of(context).highlightColor,
+        child: highlighted,
+      );
+    }
+    return highlighted;
+  }
+}

--- a/lib/pages/chat/events/message/message_selected_widget.dart
+++ b/lib/pages/chat/events/message/message_selected_widget.dart
@@ -25,9 +25,7 @@ class MessageSelectedWidget extends StatelessWidget {
       padding: EdgeInsets.only(
         left: Message.responsiveUtils.isMobile(context) ? 8.0 : 0,
       ),
-      color: selected
-          ? LinagoraSysColors.material().secondaryContainer
-          : Theme.of(context).primaryColor.withAlpha(0),
+      color: Theme.of(context).primaryColor.withAlpha(0),
       constraints: const BoxConstraints(
         maxWidth: TwakeThemes.columnWidth * 2.5,
       ),
@@ -40,9 +38,7 @@ class MessageSelectedWidget extends StatelessWidget {
             Align(
               alignment: AlignmentDirectional.centerStart,
               child: Icon(
-                selected
-                    ? Icons.check_circle_rounded
-                    : Icons.circle_outlined,
+                selected ? Icons.check_circle_rounded : Icons.circle_outlined,
                 color: selected
                     ? LinagoraSysColors.material().primary
                     : Colors.black,

--- a/lib/pages/chat/events/message/message_selected_widget.dart
+++ b/lib/pages/chat/events/message/message_selected_widget.dart
@@ -1,0 +1,63 @@
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/pages/chat/events/message/message.dart';
+import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+import 'package:matrix/matrix.dart';
+
+class MessageSelectedWidget extends StatelessWidget {
+  final Event event;
+  final bool selected;
+  final bool selectMode;
+  final Widget child;
+
+  const MessageSelectedWidget({
+    super.key,
+    required this.event,
+    required this.selected,
+    required this.selectMode,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.only(
+        left: Message.responsiveUtils.isMobile(context) ? 8.0 : 0,
+      ),
+      color: selected
+          ? LinagoraSysColors.material().secondaryContainer
+          : Theme.of(context).primaryColor.withAlpha(0),
+      constraints: const BoxConstraints(
+        maxWidth: TwakeThemes.columnWidth * 2.5,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          if (selectMode && event.redacted)
+            const SizedBox(width: 20)
+          else if (selectMode && event.status.isAvailable)
+            Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: Icon(
+                selected
+                    ? Icons.check_circle_rounded
+                    : Icons.circle_outlined,
+                color: selected
+                    ? LinagoraSysColors.material().primary
+                    : Colors.black,
+                size: 20,
+              ),
+            ),
+          Expanded(
+            flex: 9,
+            child: Align(
+              alignment: AlignmentDirectional.centerEnd,
+              child: child,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Ticket
**Related issue**

- #3018 
-
## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

https://github.com/user-attachments/assets/c3c2fdd1-1a43-46f9-bb07-d38c8dda6980




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clearer selection UI with a left-side indicator and distinct selected background.
  * Improved swipe and gesture handling for message rows.
  * Consistent horizontal padding on desktop for message alignment.
* **Refactor**
  * Message rendering reorganized to ensure reliable scroll-to-message highlighting and overlays when present.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3035)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->