### PR TITLE
TW-3019(fix): ignore refreshing_last_event placeholder in chat list date

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @hoangdat @dab246 @nqhhdev @tddang-linagora @9clg6
+*       @hoangdat @dab246 @nqhhdev @tddang-linagora @9clg6 @jbrnzl

--- a/lib/domain/model/room/room_extension.dart
+++ b/lib/domain/model/room/room_extension.dart
@@ -13,6 +13,7 @@ import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/markdown.dart';
 
 extension RoomExtension on Room {
+  static const _kRefreshingLastEventType = 'com.famedly.refreshing_last_event';
   RecentChatSearchModel toRecentChatSearchModel(
     MatrixLocalizations matrixLocalizations,
   ) {
@@ -349,6 +350,19 @@ extension RoomExtension on Room {
   }
 
   bool get canReportContent => membership.isJoin;
+
+  /// Latest real event timestamp, ignoring the SDK's internal
+  /// `com.famedly.refreshing_last_event` placeholder which carries a synthetic
+  /// date (the sync date) that has no meaning for users.
+  DateTime get realLatestEventTime {
+    final last = lastEvent;
+    if (last == null || last.type == _kRefreshingLastEventType) {
+      final createEvent = getState(EventTypes.RoomCreate);
+      if (createEvent is Event) return createEvent.originServerTs;
+      return latestEventReceivedTime;
+    }
+    return last.originServerTs;
+  }
 
   Map<String, dynamic> getEventContentFromMsgText({
     required String message,

--- a/lib/pages/chat_list/chat_list_item_title.dart
+++ b/lib/pages/chat_list/chat_list_item_title.dart
@@ -92,7 +92,7 @@ class ChatListItemTitle extends StatelessWidget with ChatListItemMixin {
               Padding(
                 padding: ChatListItemTitleStyle.paddingLeftIcon,
                 child: Text(
-                  (originServerTs ?? room.latestEventReceivedTime)
+                  (originServerTs ?? room.realLatestEventTime)
                       .localizedTimeShort(context),
                   style: Theme.of(context).textTheme.labelMedium?.copyWith(
                     color: LinagoraRefColors.material().tertiary[30],

--- a/lib/pages/chat_list/chat_list_sort_rooms.dart
+++ b/lib/pages/chat_list/chat_list_sort_rooms.dart
@@ -49,6 +49,9 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
     return result is RoomPreviewFound ? result.event.originServerTs : null;
   }
 
+  DateTime _effectiveSortTs(String roomId, DateTime realLatestEventTime) =>
+      _previewTs(roomId) ?? realLatestEventTime;
+
   RoomSorter sortRoomsBy(Client client) => (a, b) {
     if (client.pinInvitedRooms &&
         a.membership != b.membership &&
@@ -61,12 +64,12 @@ class _ChatListSortRoomsState extends State<ChatListSortRooms> {
     if (client.pinUnreadRooms && a.notificationCount != b.notificationCount) {
       return b.notificationCount.compareTo(a.notificationCount);
     }
-    return (_previewTs(b.id) ?? b.latestEventReceivedTime)
-        .millisecondsSinceEpoch
-        .compareTo(
-          (_previewTs(a.id) ?? a.latestEventReceivedTime)
-              .millisecondsSinceEpoch,
-        );
+    return _effectiveSortTs(
+      b.id,
+      b.realLatestEventTime,
+    ).millisecondsSinceEpoch.compareTo(
+      _effectiveSortTs(a.id, a.realLatestEventTime).millisecondsSinceEpoch,
+    );
   };
 
   Future<List<Room>> _sortRooms(int generation) async {

--- a/lib/presentation/extensions/client_extension.dart
+++ b/lib/presentation/extensions/client_extension.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:fluffychat/config/app_constants.dart';
+import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/presentation/enum/chat_list/chat_list_enum.dart';
 import 'package:fluffychat/utils/string_extension.dart';
 import 'package:flutter/material.dart';
@@ -15,9 +16,7 @@ extension ClientExtension on Client {
     if (room1.isFavourite ^ room2.isFavourite) {
       return room1.isFavourite ? newerChat : olderChat;
     }
-    return room2.latestEventReceivedTime.compareTo(
-      room1.latestEventReceivedTime,
-    );
+    return room2.realLatestEventTime.compareTo(room1.realLatestEventTime);
   }
 
   List<Room> filteredRoomsForAll(ActiveFilter activeFilter) {


### PR DESCRIPTION
## Ticket
Fix #3019

## Root cause
After a limited sync, the Matrix SDK assigns a synthetic placeholder event (`com.famedly.refreshing_last_event`) as `Room.lastEvent`. This placeholder carries the sync timestamp (not a real message timestamp), so `Room.latestEventReceivedTime` which the chat list reads for both date display and sort key returns that synthetic date (in bellow exemple: 6 Feb 2026) for rooms that have never had an eligible preview message.
<img width="256" height="66" alt="Capture d’écran 2026-05-07 à 16 18 54" src="https://github.com/user-attachments/assets/4e220bb7-fc8a-4d72-84d4-6a3bf1b0a66d" />


When the user opens such a room, `refreshLastEvent()` runs, the placeholder is cleared, `lastEvent` becomes `null`, and `latestEventReceivedTime` then falls back to `m.room.create.originServerTs`. The visible date jumps and the room moves in the sorted list.

## Solution
- Add `Room.realLatestEventTime` extension getter that filters the `com.famedly.refreshing_last_event` placeholder and uses `m.room.create.originServerTs` as a fallback when `lastEvent` is the placeholder or `null`.
- Use the new getter as the fallback in chat list date display (`ChatListItemTitle`) and sort key (`_effectiveSortTs` in `ChatListSortRooms`).
- Extract the duplicated `(_previewTs ?? fallback)` expression in the sort comparator into the `_effectiveSortTs` helper so display and sort stay in sync.

## Known limitation

Due to the actual 30 events scan window limit on DB, a room with an old message and then 30+ events not eligible for preview will be flagged as "Click to see the latest messages" with the date of the Room Creation event instead od the last real message date. This behavior was pre-existing but this is to highlight things so everyone knows. cc @tprudentova

## Test recommendations
- Sign in on an account that has old "Click to load the latest messages" rooms (rooms with no eligible preview message in the synced window).
- Verify that the date shown in the chat list is the room's creation date (or the real last event date), **not** the sync date.
- Click such a room and return to the chat list: the date and the room's position must not change.
- Verify normal rooms (with regular messages) are unaffected: same date, same sort position as before.
- Verify favourite/pinned-invited/unread sort precedence still applies.

## Demos
No videos as nothing interesting
- Web - Before: 
<img width="1728" height="956" alt="Capture d’écran 2026-05-07 à 16 27 57" src="https://github.com/user-attachments/assets/d1ef0824-07b9-49ac-95ab-73551ed40f82" />

- Web - After:
<img width="1728" height="956" alt="Capture d’écran 2026-05-07 à 16 30 04" src="https://github.com/user-attachments/assets/bf06b233-c052-47ed-bd11-6c204449478b" />

## Other
- Added @jbrnzl as code owner. Not related but included because no needs to have a seperated PR for that little change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Display a more meaningful "latest event" time when the last event is missing (falls back to room creation or other reliable timestamps).
  * Use the improved timestamp as the tie-breaker for chat ordering so conversations sort more predictably.

* **Chores**
  * Updated repository default CODEOWNERS entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->