### PR TITLE
TW-3038: Exclude edit events to prevent duplicate search results for edited messages

### DIFF
--- a/lib/pages/search/server_search_view.dart
+++ b/lib/pages/search/server_search_view.dart
@@ -4,14 +4,13 @@ import 'package:fluffychat/presentation/decorators/chat_list/subtitle_text_style
 import 'package:fluffychat/presentation/model/search/presentation_server_side_empty_search.dart';
 import 'package:fluffychat/presentation/model/search/presentation_server_side_search.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/result_extension.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
 import 'package:fluffychat/widgets/highlight_text.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_item_title.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/search/empty_search_widget.dart';
 import 'package:flutter/material.dart' hide SearchController;
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
-import 'package:matrix/matrix.dart';
 
 class ServerSearchMessagesList extends StatelessWidget {
   final SearchController searchController;
@@ -44,17 +43,14 @@ class ServerSearchMessagesList extends StatelessWidget {
               itemCount: serverSearchNotifier.searchResults.length,
               padding: ServerSearchViewStyle.paddingListItem,
               itemBuilder: ((context, index) {
-                final searchResult =
-                    serverSearchNotifier.searchResults[index].result;
-                final room = Matrix.of(
-                  context,
-                ).client.getRoomById(searchResult?.roomId ?? '');
-                if (room == null || searchResult == null) {
+                final result = serverSearchNotifier.searchResults[index];
+                final event = result.getEvent(context);
+                if (event == null) {
                   return const SizedBox.shrink();
                 }
+                final room = event.room;
                 final searchWord = searchController.searchWord;
-                final event = Event.fromMatrixEvent(searchResult, room);
-                final originServerTs = searchResult.originServerTs;
+                final originServerTs = result.result?.originServerTs;
 
                 return TwakeInkWell(
                   onTap: () =>

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -520,8 +520,8 @@ extension LocalizedBody on Event {
     );
 
     final editEventJson = latestEdit.toJson();
-    final newContent = editEventJson[MatrixEventFields.content]
-        [MatrixEventFields.newContent];
+    final newContent =
+        editEventJson[MatrixEventFields.content][MatrixEventFields.newContent];
 
     if (newContent is! Map) {
       return this;
@@ -531,8 +531,9 @@ extension LocalizedBody on Event {
       // For media/files with caption, preserve original event structure
       // and add the edited content
       final originalEventJson = toJson();
-      originalEventJson[MatrixEventFields.content]
-          [MatrixEventFields.newContent] = newContent;
+      originalEventJson[MatrixEventFields.content][MatrixEventFields
+              .newContent] =
+          newContent;
       originalEventJson[MatrixEventFields.content]['body'] = newContent['body'];
 
       // Update formatted_body if it exists in the new content

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/extension/event_info_extension.dart';
 import 'package:fluffychat/utils/extension/mime_type_extension.dart';
 import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_event_fields.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/size_string.dart';
@@ -519,7 +520,8 @@ extension LocalizedBody on Event {
     );
 
     final editEventJson = latestEdit.toJson();
-    final newContent = editEventJson['content']['m.new_content'];
+    final newContent = editEventJson[MatrixEventFields.content]
+        [MatrixEventFields.newContent];
 
     if (newContent is! Map) {
       return this;
@@ -529,24 +531,26 @@ extension LocalizedBody on Event {
       // For media/files with caption, preserve original event structure
       // and add the edited content
       final originalEventJson = toJson();
-      originalEventJson['content']['m.new_content'] = newContent;
-      originalEventJson['content']['body'] = newContent['body'];
+      originalEventJson[MatrixEventFields.content]
+          [MatrixEventFields.newContent] = newContent;
+      originalEventJson[MatrixEventFields.content]['body'] = newContent['body'];
 
       // Update formatted_body if it exists in the new content
       if (newContent['formatted_body'] != null) {
-        originalEventJson['content']['formatted_body'] =
+        originalEventJson[MatrixEventFields.content]['formatted_body'] =
             newContent['formatted_body'];
-        originalEventJson['content']['format'] = newContent['format'];
+        originalEventJson[MatrixEventFields.content]['format'] =
+            newContent['format'];
       } else {
-        originalEventJson['content'].remove('formatted_body');
-        originalEventJson['content'].remove('format');
+        originalEventJson[MatrixEventFields.content].remove('formatted_body');
+        originalEventJson[MatrixEventFields.content].remove('format');
       }
 
       return Event.fromJson(originalEventJson, room);
     }
 
     // For regular text messages, use the edited event structure
-    editEventJson['content'] = newContent;
+    editEventJson[MatrixEventFields.content] = newContent;
     return Event.fromJson(editEventJson, room);
   }
 

--- a/lib/utils/matrix_sdk_extensions/matrix_event_fields.dart
+++ b/lib/utils/matrix_sdk_extensions/matrix_event_fields.dart
@@ -1,0 +1,17 @@
+/// Matrix spec field name constants for event content and unsigned data.
+///
+/// Follows the same pattern as [RelationshipTypes] in the Matrix SDK.
+abstract class MatrixEventFields {
+  /// Key for the relations map inside `unsigned` data.
+  ///
+  /// Synapse places the latest edit under `unsigned['m.relations']['m.replace']`.
+  static const String relations = 'm.relations';
+
+  /// Key for the event content map in raw JSON.
+  static const String content = 'content';
+
+  /// Key for the new content inside an edit event's `content`.
+  ///
+  /// Edit events carry the replacement body under `content['m.new_content']`.
+  static const String newContent = 'm.new_content';
+}

--- a/lib/utils/matrix_sdk_extensions/result_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/result_extension.dart
@@ -1,5 +1,3 @@
-import 'dart:developer' as developer;
-
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
@@ -28,41 +26,21 @@ extension ResultExtension on Result {
   /// Synapse stores the edit event under unsigned.m.relations.m.replace as:
   /// `{ "content": { "m.new_content": { ... } }, ... }`
   Event _resolveEditedContent(Event event) {
-    developer.log(
-      'ResultExtension::_resolveEditedContent(): '
-      'eventId=${event.eventId} unsigned=${event.unsigned}',
-      name: 'ResultExtension',
-    );
-    final relations = event.unsigned?.tryGetMap<String, Object?>('m.relations');
-    developer.log(
-      'ResultExtension::_resolveEditedContent(): relations=$relations',
-      name: 'ResultExtension',
-    );
+    final relations = event.unsigned
+        ?.tryGetMap<String, Object?>('m.relations');
     if (relations == null) return event;
 
     // unsigned.m.relations.m.replace is the latest edit event object
     final latestEditEvent = relations.tryGetMap<String, Object?>(
       RelationshipTypes.edit,
     );
-    developer.log(
-      'ResultExtension::_resolveEditedContent(): latestEditEvent=$latestEditEvent',
-      name: 'ResultExtension',
-    );
     if (latestEditEvent == null) return event;
 
     // m.new_content is nested inside the edit event's content field
     final editContent = latestEditEvent.tryGetMap<String, Object?>('content');
-    developer.log(
-      'ResultExtension::_resolveEditedContent(): editContent=$editContent',
-      name: 'ResultExtension',
-    );
     if (editContent == null) return event;
 
     final newContent = editContent.tryGetMap<String, Object?>('m.new_content');
-    developer.log(
-      'ResultExtension::_resolveEditedContent(): newContent=$newContent',
-      name: 'ResultExtension',
-    );
     if (newContent == null) return event;
 
     final rawEvent = event.toJson();

--- a/lib/utils/matrix_sdk_extensions/result_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/result_extension.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_event_fields.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
@@ -26,7 +27,9 @@ extension ResultExtension on Result {
   /// Synapse stores the edit event under unsigned.m.relations.m.replace as:
   /// `{ "content": { "m.new_content": { ... } }, ... }`
   Event _resolveEditedContent(Event event) {
-    final relations = event.unsigned?.tryGetMap<String, Object?>('m.relations');
+    final relations = event.unsigned?.tryGetMap<String, Object?>(
+      MatrixEventFields.relations,
+    );
     if (relations == null) return event;
 
     // unsigned.m.relations.m.replace is the latest edit event object
@@ -36,14 +39,18 @@ extension ResultExtension on Result {
     if (latestEditEvent == null) return event;
 
     // m.new_content is nested inside the edit event's content field
-    final editContent = latestEditEvent.tryGetMap<String, Object?>('content');
+    final editContent = latestEditEvent.tryGetMap<String, Object?>(
+      MatrixEventFields.content,
+    );
     if (editContent == null) return event;
 
-    final newContent = editContent.tryGetMap<String, Object?>('m.new_content');
+    final newContent = editContent.tryGetMap<String, Object?>(
+      MatrixEventFields.newContent,
+    );
     if (newContent == null) return event;
 
     final rawEvent = event.toJson();
-    rawEvent['content'] = newContent;
+    rawEvent[MatrixEventFields.content] = newContent;
     return Event.fromJson(rawEvent, event.room);
   }
 

--- a/lib/utils/matrix_sdk_extensions/result_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/result_extension.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
@@ -14,7 +16,58 @@ extension ResultExtension on Result {
     if (room == null) {
       return null;
     }
-    return Event.fromMatrixEvent(result!, room);
+    final event = Event.fromMatrixEvent(result!, room);
+    return _resolveEditedContent(event);
+  }
+
+  /// Resolves the latest edited content from `unsigned.m.relations.m.replace`
+  /// if present. The Matrix search API returns original events, not their
+  /// edited versions, so we must apply the edit ourselves since there is no
+  /// timeline available.
+  ///
+  /// Synapse stores the edit event under unsigned.m.relations.m.replace as:
+  /// `{ "content": { "m.new_content": { ... } }, ... }`
+  Event _resolveEditedContent(Event event) {
+    developer.log(
+      'ResultExtension::_resolveEditedContent(): '
+      'eventId=${event.eventId} unsigned=${event.unsigned}',
+      name: 'ResultExtension',
+    );
+    final relations = event.unsigned?.tryGetMap<String, Object?>('m.relations');
+    developer.log(
+      'ResultExtension::_resolveEditedContent(): relations=$relations',
+      name: 'ResultExtension',
+    );
+    if (relations == null) return event;
+
+    // unsigned.m.relations.m.replace is the latest edit event object
+    final latestEditEvent = relations.tryGetMap<String, Object?>(
+      RelationshipTypes.edit,
+    );
+    developer.log(
+      'ResultExtension::_resolveEditedContent(): latestEditEvent=$latestEditEvent',
+      name: 'ResultExtension',
+    );
+    if (latestEditEvent == null) return event;
+
+    // m.new_content is nested inside the edit event's content field
+    final editContent = latestEditEvent.tryGetMap<String, Object?>('content');
+    developer.log(
+      'ResultExtension::_resolveEditedContent(): editContent=$editContent',
+      name: 'ResultExtension',
+    );
+    if (editContent == null) return event;
+
+    final newContent = editContent.tryGetMap<String, Object?>('m.new_content');
+    developer.log(
+      'ResultExtension::_resolveEditedContent(): newContent=$newContent',
+      name: 'ResultExtension',
+    );
+    if (newContent == null) return event;
+
+    final rawEvent = event.toJson();
+    rawEvent['content'] = newContent;
+    return Event.fromJson(rawEvent, event.room);
   }
 
   bool isDisplayableResult({

--- a/lib/utils/matrix_sdk_extensions/result_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/result_extension.dart
@@ -26,8 +26,7 @@ extension ResultExtension on Result {
   /// Synapse stores the edit event under unsigned.m.relations.m.replace as:
   /// `{ "content": { "m.new_content": { ... } }, ... }`
   Event _resolveEditedContent(Event event) {
-    final relations = event.unsigned
-        ?.tryGetMap<String, Object?>('m.relations');
+    final relations = event.unsigned?.tryGetMap<String, Object?>('m.relations');
     if (relations == null) return event;
 
     // unsigned.m.relations.m.replace is the latest edit event object

--- a/lib/utils/matrix_sdk_extensions/result_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/result_extension.dart
@@ -29,6 +29,11 @@ extension ResultExtension on Result {
     if (event == null) {
       return false;
     }
+    // Exclude edit events (m.replace) — the server returns both the original
+    // and the edit event; showing edit events causes duplicate results.
+    if (event.relationshipType == RelationshipTypes.edit) {
+      return false;
+    }
     final bodyContent = event.calcLocalizedBodyFallback(
       matrixLocalizations,
       hideEdit: true,

--- a/test/utils/search_result_extension_test.dart
+++ b/test/utils/search_result_extension_test.dart
@@ -170,6 +170,91 @@ Future<void> main() async {
       expect(isDisplayable, false);
     });
 
+    test('Given original message was edited\n'
+        'AND keyword only exists in the edited content\n'
+        'When isDisplayableResult is called with event using edited content\n'
+        'Then return available search result\n', () {
+      // Simulates the event returned after _resolveEditedContent applies
+      // unsigned.m.relations.m.replace -> m.new_content to the event content.
+      final editedEvent = Event(
+        content: {
+          "body": "Edited: Quisque rutrum updated content",
+          "msgtype": "m.text",
+        },
+        type: 'm.room.message',
+        eventId: '\$original:example.org',
+        senderId: '@exampleabcdh:example.org',
+        originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
+        room: room,
+      );
+      final result = Result.fromJson({
+        "result": {
+          "content": {
+            "body": "Original message without the keyword",
+            "msgtype": "m.text",
+          },
+          "origin_server_ts": 1733711220820,
+          "room_id": "!room:example.abc",
+          "sender": "@exampleabcdh:example.org",
+          "type": "m.room.message",
+          "unsigned": {"membership": "join"},
+          "event_id": "\$original:example.org",
+          "user_id": "@devtest:lin-saas.dev",
+        },
+      });
+      const keyword = 'Quisque';
+
+      final isDisplayable = result.isDisplayableResult(
+        context: context,
+        event: editedEvent,
+        matrixLocalizations: const MatrixDefaultLocalizations(),
+        searchWord: keyword,
+      );
+
+      expect(isDisplayable, true);
+    });
+
+    test('Given original message was edited\n'
+        'AND keyword only exists in original content (not in edit)\n'
+        'When isDisplayableResult is called with event using edited content\n'
+        'Then return not available search result\n', () {
+      // The edit replaced "Quisque" with different text; the resolved event
+      // should show the edited body, so the keyword no longer matches.
+      final editedEvent = Event(
+        content: {
+          "body": "Edited: no longer contains the search term",
+          "msgtype": "m.text",
+        },
+        type: 'm.room.message',
+        eventId: '\$original2:example.org',
+        senderId: '@exampleabcdh:example.org',
+        originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
+        room: room,
+      );
+      final result = Result.fromJson({
+        "result": {
+          "content": {"body": "Quisque original content", "msgtype": "m.text"},
+          "origin_server_ts": 1733711220820,
+          "room_id": "!room:example.abc",
+          "sender": "@exampleabcdh:example.org",
+          "type": "m.room.message",
+          "unsigned": {"membership": "join"},
+          "event_id": "\$original2:example.org",
+          "user_id": "@devtest:lin-saas.dev",
+        },
+      });
+      const keyword = 'Quisque';
+
+      final isDisplayable = result.isDisplayableResult(
+        context: context,
+        event: editedEvent,
+        matrixLocalizations: const MatrixDefaultLocalizations(),
+        searchWord: keyword,
+      );
+
+      expect(isDisplayable, false);
+    });
+
     test('Give search result is not empty\n'
         'AND keyword is Quisque\n'
         'AND body has the reply tag'


### PR DESCRIPTION
## Ticket
**Related issue**

- #3038 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/183ef821-a7f4-4784-928d-202d15be4bb4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now shows the latest edited content for messages and avoids duplicate original/edited entries.
* **Refactor**
  * Internal event handling unified to reliably resolve and apply edit contents using standardized field names.
* **Tests**
  * Added tests verifying search matching behavior for edited vs. original message content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3039?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->