### PR TITLE
TW-3037(fix): send read receipts for hidden events

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/data/memory/mxc_image_cache_manager.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/domain/matrix_events/event_type_rules.dart';
+import 'package:fluffychat/domain/matrix_events/event_visibility_resolver.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/domain/app_state/room/report_content_state.dart';
@@ -730,8 +731,20 @@ class ChatController extends State<Chat>
       final timeline = this.timeline;
       if (timeline == null || timeline.events.isEmpty) return;
 
-      final currentEventId = _pendingReadMarkerEventId;
+      var currentEventId = _pendingReadMarkerEventId;
       _pendingReadMarkerEventId = null;
+
+      // If the event being marked is the last visible event of the room,
+      // advance the read marker to room.lastEvent so that hidden trailing
+      // events don't leave a stale badge.
+      if (timeline.allowNewEvent) {
+        final lastVisibleEventId = timeline.events
+            .firstWhereOrNull(EventVisibilityResolver.isVisibleInTimeline)
+            ?.eventId;
+        if (currentEventId == lastVisibleEventId) {
+          currentEventId = room!.lastEvent!.eventId;
+        }
+      }
 
       Logs().d('Set read marker...', currentEventId);
 

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -666,8 +666,8 @@ class MatrixState extends State<Matrix>
     onLoginStateChanged.remove(name);
     await onNotification[name]?.cancel();
     onNotification.remove(name);
-    await onAutoReadReceipt[name]?.cancel();
-    onAutoReadReceipt.remove(name);
+    await onUiaRequest[name]?.cancel();
+    onUiaRequest.remove(name);
   }
 
   Future<void> initMatrix() async {
@@ -1316,11 +1316,21 @@ class MatrixState extends State<Matrix>
     }
     intentFileStreamSubscription?.cancel();
     intentUriStreamSubscription?.cancel();
-    onRoomKeyRequestSub.values.map((s) => s.cancel());
-    onKeyVerificationRequestSub.values.map((s) => s.cancel());
-    onLoginStateChanged.values.map((s) => s.cancel());
-    onNotification.values.map((s) => s.cancel());
-    onAutoReadReceipt.values.map((s) => s.cancel());
+    for (final s in onRoomKeyRequestSub.values) {
+      s.cancel();
+    }
+    for (final s in onKeyVerificationRequestSub.values) {
+      s.cancel();
+    }
+    for (final s in onLoginStateChanged.values) {
+      s.cancel();
+    }
+    for (final s in onNotification.values) {
+      s.cancel();
+    }
+    for (final s in onUiaRequest.values) {
+      s.cancel();
+    }
     onClientLoginStateChanged.close();
     client.httpClient.close();
     onFocusSub?.cancel();

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -666,6 +666,8 @@ class MatrixState extends State<Matrix>
     onLoginStateChanged.remove(name);
     await onNotification[name]?.cancel();
     onNotification.remove(name);
+    await onAutoReadReceipt[name]?.cancel();
+    onAutoReadReceipt.remove(name);
   }
 
   Future<void> initMatrix() async {
@@ -1318,6 +1320,7 @@ class MatrixState extends State<Matrix>
     onKeyVerificationRequestSub.values.map((s) => s.cancel());
     onLoginStateChanged.values.map((s) => s.cancel());
     onNotification.values.map((s) => s.cancel());
+    onAutoReadReceipt.values.map((s) => s.cancel());
     onClientLoginStateChanged.close();
     client.httpClient.close();
     onFocusSub?.cancel();


### PR DESCRIPTION
## Ticket
Fixes #3037

## Root cause
When a room member deletes a message, the homeserver does not decrement
`notificationCount` in subsequent sync responses. The app correctly hides
redacted events from the timeline, but the notification badge keeps reading
the stale server-side count. Because hidden events (redactions, state changes)
never trigger the visibility callback that places a read marker, the badge
becomes impossible to dismiss: there is nothing visible to read.

## Solution
In `_processReadMarker` (`chat.dart`), when the user opens a room and a read
marker is about to be sent for an event:

1. Look up `room.lastEvent` (the true latest event, which may be hidden).
2. Confirm that `room.lastEvent` is present in `timeline.events`: this proves
   the user is at the live end of the conversation, not mid-conversation from
   a search jump.
3. Find the most recent visible event in the timeline
   (`EventVisibilityResolver.isVisibleInTimeline`).
4. If the event being marked **is** that last visible event, advance
   `currentEventId` to `room.lastEvent` before calling `setReadMarker`.

The homeserver then recomputes `notificationCount` to 0 and the phantom badge
disappears on the next sync.

## Known limitation
If a user preference hides deleted messages, the chat-list badge may temporarily show a higher unread count than visible messages. The badge is correctly reset when the chat is opened.

## Test recommendations
1. **Simple case**: receive a message (badge = 1), do not open the room,
   have the sender delete it. Open the room: badge should disappear.
2. **Edit + delete**: receive a message, sender edits it, then deletes it.
   Open the room: badge should disappear.
3. **False-positive guard**: receive a message, do not delete it. Opening the
   room must not clear the badge until the message is actually visible.
4. **Mid-conversation guard**: jump to an old event via search, scroll around.
   No phantom read markers should be sent for recent hidden events.

## Demos
- Before:

https://github.com/user-attachments/assets/66b60ba4-4ace-4370-8f26-c90f2fa0507b

- After:

https://github.com/user-attachments/assets/f0a3a5b6-7b1f-48a8-b4bb-171ca7e508de


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription cleanup to ensure all active connections are properly terminated, preventing potential resource leaks.
  * Enhanced read marker positioning in chat to more accurately track message read status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3041?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->