### PR TITLE
TW-1707: Update git URLs in pubspec files to use HTTPS

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -929,8 +929,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: update-linagora-design-flutter-URL-to-use-HTTPS
-      resolved-ref: "2c28c0b51cf03d774431f0049eef469613dd9b85"
+      ref: master
+      resolved-ref: "66b2f48eef7c42f3a6a4dfcf0c50e38302ca3750"
       url: "https://github.com/linagora/emoji_mart.git"
     source: git
     version: "1.0.2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -929,9 +929,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: c5cdbeab9fc9d6a8b9a9751e3675ffce5d7546ee
-      url: "git@github.com:linagora/emoji_mart.git"
+      ref: update-linagora-design-flutter-URL-to-use-HTTPS
+      resolved-ref: "2c28c0b51cf03d774431f0049eef469613dd9b85"
+      url: "https://github.com/linagora/emoji_mart.git"
     source: git
     version: "1.0.2"
   flutter_foreground_task:
@@ -1812,7 +1812,7 @@ packages:
       path: "."
       ref: master
       resolved-ref: c7a4a9f6fe1be9818010122b7761ba43020ed6f2
-      url: "git@github.com:linagora/linagora-design-flutter.git"
+      url: "https://github.com/linagora/linagora-design-flutter.git"
     source: git
     version: "0.0.1"
   linkfy_text:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   flutter_emoji_mart:
     git:
       url: https://github.com/linagora/emoji_mart.git
-      ref: update-linagora-design-flutter-URL-to-use-HTTPS
+      ref: master
 
   social_media_recorder:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
 
   linagora_design_flutter:
     git:
-      url: git@github.com:linagora/linagora-design-flutter.git
+      url: https://github.com/linagora/linagora-design-flutter.git
       ref: master
   flutter_matrix_html:
     git:
@@ -54,8 +54,8 @@ dependencies:
 
   flutter_emoji_mart:
     git:
-      url: git@github.com:linagora/emoji_mart.git
-      ref: master
+      url: https://github.com/linagora/emoji_mart.git
+      ref: update-linagora-design-flutter-URL-to-use-HTTPS
 
   social_media_recorder:
     git:


### PR DESCRIPTION
## Ticket
**Related issue**

- #1707

## Pre-merge
**Does anything else need to be done before merging?**
- Should merge first https://github.com/linagora/emoji_mart/pull/11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Flutter dependency source URLs to use HTTPS instead of SSH for improved security.
  * Refreshed flutter_emoji_mart dependency reference for compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3042)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->