### PR TITLE
TW-3043: Fix can't interract with errored messages

### DIFF
--- a/lib/domain/usecase/room/delete_event_interactor.dart
+++ b/lib/domain/usecase/room/delete_event_interactor.dart
@@ -7,8 +7,15 @@ import 'package:matrix/matrix.dart';
 
 class DeleteEventInteractor {
   Stream<Either<Failure, Success>> execute(Event event) async* {
+    // Error-status events never reached the server — remove locally only.
+    if (event.status.isError) {
+      yield* _removeLocalEvent(event);
+      return;
+    }
+
     if (!event.canDelete) {
       yield Left(NoPermissionToDeleteEvent());
+      return;
     }
 
     try {
@@ -18,6 +25,10 @@ class DeleteEventInteractor {
       return;
     }
 
+    yield* _removeLocalEvent(event);
+  }
+
+  Stream<Either<Failure, Success>> _removeLocalEvent(Event event) async* {
     try {
       await event.remove();
       yield Right(DeleteEventSuccess());

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -2493,12 +2493,9 @@ class ChatController extends State<Chat>
   }
 
   List<ContextMenuItemChatAction> listHorizontalActionMenuBuilder(Event event) {
-    final listAction = [
-      if (event.room.canSendReactions) ChatHorizontalActionMenu.reaction,
-      if (event.status.isAvailable && event.room.canSendDefaultMessages)
-        ChatHorizontalActionMenu.reply,
-      ChatHorizontalActionMenu.more,
-    ];
+    final listAction = event.status.isError
+        ? _errorMessageHorizontalActions()
+        : _availableMessageHorizontalActions(event);
     return listAction
         .map(
           (action) => ContextMenuItemChatAction(
@@ -2508,6 +2505,18 @@ class ChatController extends State<Chat>
         )
         .toList();
   }
+
+  List<ChatHorizontalActionMenu> _errorMessageHorizontalActions() => [
+    ChatHorizontalActionMenu.more,
+  ];
+
+  List<ChatHorizontalActionMenu> _availableMessageHorizontalActions(
+    Event event,
+  ) => [
+    if (event.room.canSendReactions) ChatHorizontalActionMenu.reaction,
+    if (event.room.canSendDefaultMessages) ChatHorizontalActionMenu.reply,
+    ChatHorizontalActionMenu.more,
+  ];
 
   void handleHorizontalActionMenu(
     BuildContext context,
@@ -2531,20 +2540,28 @@ class ChatController extends State<Chat>
     }
   }
 
-  List<ChatContextMenuActions> _getListPopupMenuActions(Event event) {
-    final listAction = [
-      if (event.status.isAvailable) ChatContextMenuActions.forward,
-      if (event.isCopyable) ChatContextMenuActions.copyMessage,
-      if (event.canEditEvents(matrix)) ...[ChatContextMenuActions.edit],
-      if (event.room.canReportContent) ChatContextMenuActions.report,
-      if (event.room.canPinMessage) ChatContextMenuActions.pinChat,
-      if (PlatformInfos.isWeb && event.hasAttachment)
-        ChatContextMenuActions.downloadFile,
-      ChatContextMenuActions.select,
-      if (event.canDelete) ChatContextMenuActions.delete,
-    ];
-    return listAction;
-  }
+  List<ChatContextMenuActions> _getListPopupMenuActions(Event event) =>
+      event.status.isError
+      ? _errorMessagePopupMenuActions(event)
+      : _availableMessagePopupMenuActions(event);
+
+  List<ChatContextMenuActions> _errorMessagePopupMenuActions(Event event) => [
+    if (event.isCopyable) ChatContextMenuActions.copyMessage,
+    if (event.canDelete) ChatContextMenuActions.delete,
+  ];
+
+  List<ChatContextMenuActions> _availableMessagePopupMenuActions(Event event) =>
+      [
+        ChatContextMenuActions.forward,
+        if (event.isCopyable) ChatContextMenuActions.copyMessage,
+        if (event.canEditEvents(matrix)) ChatContextMenuActions.edit,
+        if (event.room.canReportContent) ChatContextMenuActions.report,
+        if (event.room.canPinMessage) ChatContextMenuActions.pinChat,
+        if (PlatformInfos.isWeb && event.hasAttachment)
+          ChatContextMenuActions.downloadFile,
+        ChatContextMenuActions.select,
+        if (event.canDelete) ChatContextMenuActions.delete,
+      ];
 
   List<ContextMenuAction> _mapPopupMenuActionsToContextMenuActions(
     List<ChatContextMenuActions> listActions,

--- a/lib/pages/chat/events/message/message_container.dart
+++ b/lib/pages/chat/events/message/message_container.dart
@@ -44,8 +44,9 @@ class MessageContainer extends StatelessWidget {
     final container = MultiPlatformsMessageContainer(
       onTap: hideKeyboardChatScreen,
       onHover: (hover) {
-        if (!event.status.isAvailable) return;
-        onHover?.call(hover, event);
+        if (event.status.isAvailable || event.status.isError) {
+          onHover?.call(hover, event);
+        }
       },
       child: Container(
         constraints: BoxConstraints(

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -15,13 +15,13 @@ import 'package:fluffychat/pages/chat/optional_stack.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
-import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action_item.dart';
 import 'package:fluffychat/widgets/context_menu/twake_context_menu_area.dart';
+import 'package:fluffychat/widgets/mixins/twake_context_menu_mixin.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:flutter/material.dart';
@@ -115,7 +115,8 @@ class MessageContentWithTimestampBuilder extends StatefulWidget {
 }
 
 class _MessageContentWithTimestampBuilderState
-    extends State<MessageContentWithTimestampBuilder> {
+    extends State<MessageContentWithTimestampBuilder>
+    with TwakeContextMenuMixin {
   final ValueNotifier<bool> _displayEmojiPicker = ValueNotifier(false);
   final ResponsiveUtils _responsiveUtils = getIt.get<ResponsiveUtils>();
   bool someHorizontalActionHidden = false;
@@ -136,6 +137,11 @@ class _MessageContentWithTimestampBuilderState
     ],
     if (event.isVideoOrImage && !PlatformInfos.isWeb)
       MessageContextMenuAction.saveToGallery,
+    if (event.canDelete) MessageContextMenuAction.delete,
+  ];
+
+  List<MessageContextMenuAction> _errorMessageContextMenu(Event event) => [
+    if (event.isCopyable) MessageContextMenuAction.copy,
     if (event.canDelete) MessageContextMenuAction.delete,
   ];
 
@@ -188,7 +194,6 @@ class _MessageContentWithTimestampBuilderState
       children: [
         if (widget.event.shouldDisplayContextMenuInLeftBubble &&
             !_responsiveUtils.isMobile(context) &&
-            widget.event.status.isAvailable &&
             !widget.event.redacted)
           _menuActionsRowBuilder(context, isReversed: true),
         TwakeContextMenuArea(
@@ -210,90 +215,23 @@ class _MessageContentWithTimestampBuilderState
             child: MultiPlatformSelectionMode(
               event: widget.event,
               isClickable: _responsiveUtils.isMobile(context),
-              onLongPress: widget.event.status.isAvailable
-                  ? (event) async {
-                      if (event.redacted) return;
-
-                      // for pin screen
-                      if (widget.onLongPressMessage != null) {
-                        widget.onLongPressMessage?.call(event);
-                        return;
-                      }
-                      // for chat screen
-                      widget.onDisplayEmojiReaction?.call();
-                      _displayEmojiPicker.value = false;
-                      await Navigator.of(context)
-                          .push(
-                            HeroDialogRoute(
-                              builder: (context) => MessageReactionDialog(
-                                event: event,
-                                timeline: widget.timeline,
-                                displayEmojiPicker: _displayEmojiPicker,
-                                dialogSafeAreaKey:
-                                    MessageContentWithTimestampBuilder
-                                        .dialogSafeAreaKey,
-                                messageWidget: Material(
-                                  color: widget.event.isOwnMessage
-                                      ? LinagoraRefColors.material().primary[95]
-                                      : _responsiveUtils.isMobile(context)
-                                      ? LinagoraSysColors.material().onPrimary
-                                      : Theme.of(
-                                          context,
-                                        ).colorScheme.surfaceContainerHighest,
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius:
-                                        MessageStyle.bubbleBorderRadius,
-                                  ),
-                                  child: Container(
-                                    padding: const .symmetric(
-                                      horizontal: 4,
-                                      vertical: 4,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      borderRadius:
-                                          MessageStyle.bubbleBorderRadius,
-                                      border:
-                                          !widget.event.isOwnMessage &&
-                                              _responsiveUtils.isMobile(context)
-                                          ? Border.all(
-                                              color: MessageStyle
-                                                  .borderColorReceivedBubble,
-                                            )
-                                          : null,
-                                    ),
-                                    child: SelectionArea(
-                                      child: SingleChildScrollView(
-                                        primary: true,
-                                        physics: const ClampingScrollPhysics(),
-                                        child: _messageBuilder(
-                                          key: ValueKey(
-                                            'PreviewReactionWidgetKey%${DateTime.now().millisecondsSinceEpoch}',
-                                          ),
-                                          context: context,
-                                          timelineText: timelineText,
-                                          noBubble: noBubble,
-                                          displayTime: displayTime,
-                                          paddingBubble: .zero,
-                                          enableBorder: false,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                emojiPickerBuilder: _emojiPickerBuilder,
-                                messageContextMenu: _messageContextMenu,
-                                themeContextMenu: _themeContextMenu,
-                                iconContextMenu: _iconContextMenu,
-                                onSendEmojiReaction: widget.onSendEmojiReaction,
-                              ),
-                            ),
-                          )
-                          .then((result) {
-                            _handleResultFromHeroPage(context, result);
-                            widget.onHideEmojiReaction?.call();
-                          });
-                    }
-                  : null,
+              onLongPress: widget.event.redacted
+                  ? null
+                  : widget.event.status.isError
+                  ? (event) => _handleErrorMessageLongPress(
+                      context,
+                      event,
+                      timelineText: timelineText,
+                      noBubble: noBubble,
+                      displayTime: displayTime,
+                    )
+                  : (event) => _handleAvailableMessageLongPress(
+                      context,
+                      event,
+                      timelineText: timelineText,
+                      noBubble: noBubble,
+                      displayTime: displayTime,
+                    ),
               child: _messageBuilder(
                 context: context,
                 timelineText: timelineText,
@@ -305,11 +243,168 @@ class _MessageContentWithTimestampBuilderState
         ),
         if (widget.event.shouldDisplayContextMenuInRightBubble &&
             !_responsiveUtils.isMobile(context) &&
-            widget.event.status.isAvailable &&
             !widget.event.redacted)
           _menuActionsRowBuilder(context),
       ],
     );
+  }
+
+  /// Opens the hero emoji reaction dialog for available messages.
+  Future<void> _handleAvailableMessageLongPress(
+    BuildContext context,
+    Event event, {
+    required bool timelineText,
+    required bool noBubble,
+    required bool displayTime,
+  }) async {
+    // for pin screen
+    if (widget.onLongPressMessage != null) {
+      widget.onLongPressMessage?.call(event);
+      return;
+    }
+    // for chat screen
+    widget.onDisplayEmojiReaction?.call();
+    _displayEmojiPicker.value = false;
+    await Navigator.of(context)
+        .push(
+          HeroDialogRoute(
+            builder: (context) => MessageReactionDialog(
+              event: event,
+              timeline: widget.timeline,
+              displayEmojiPicker: _displayEmojiPicker,
+              dialogSafeAreaKey:
+                  MessageContentWithTimestampBuilder.dialogSafeAreaKey,
+              messageWidget: Material(
+                color: widget.event.isOwnMessage
+                    ? LinagoraRefColors.material().primary[95]
+                    : _responsiveUtils.isMobile(context)
+                    ? LinagoraSysColors.material().onPrimary
+                    : Theme.of(context).colorScheme.surfaceContainerHighest,
+                shape: RoundedRectangleBorder(
+                  borderRadius: MessageStyle.bubbleBorderRadius,
+                ),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 4,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    borderRadius: MessageStyle.bubbleBorderRadius,
+                    border:
+                        !widget.event.isOwnMessage &&
+                            _responsiveUtils.isMobile(context)
+                        ? Border.all(
+                            color: MessageStyle.borderColorReceivedBubble,
+                          )
+                        : null,
+                  ),
+                  child: SelectionArea(
+                    child: SingleChildScrollView(
+                      primary: true,
+                      physics: const ClampingScrollPhysics(),
+                      child: _messageBuilder(
+                        key: ValueKey(
+                          'PreviewReactionWidgetKey%${DateTime.now().millisecondsSinceEpoch}',
+                        ),
+                        context: context,
+                        timelineText: timelineText,
+                        noBubble: noBubble,
+                        displayTime: displayTime,
+                        paddingBubble: EdgeInsets.zero,
+                        enableBorder: false,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              emojiPickerBuilder: _emojiPickerBuilder,
+              messageContextMenu: _messageContextMenu,
+              themeContextMenu: _themeContextMenu,
+              iconContextMenu: _iconContextMenu,
+              onSendEmojiReaction: widget.onSendEmojiReaction,
+            ),
+          ),
+        )
+        .then((result) {
+          _handleResultFromHeroPage(context, result);
+          widget.onHideEmojiReaction?.call();
+        });
+  }
+
+  /// Opens the hero dialog for error messages (no emoji reactions).
+  Future<void> _handleErrorMessageLongPress(
+    BuildContext context,
+    Event event, {
+    required bool timelineText,
+    required bool noBubble,
+    required bool displayTime,
+  }) async {
+    widget.onDisplayEmojiReaction?.call();
+    _displayEmojiPicker.value = false;
+    await Navigator.of(context)
+        .push(
+          HeroDialogRoute(
+            builder: (context) => MessageReactionDialog(
+              event: event,
+              timeline: widget.timeline,
+              displayEmojiPicker: _displayEmojiPicker,
+              dialogSafeAreaKey:
+                  MessageContentWithTimestampBuilder.dialogSafeAreaKey,
+              showReactions: false,
+              messageWidget: Material(
+                color: widget.event.isOwnMessage
+                    ? LinagoraRefColors.material().primary[95]
+                    : _responsiveUtils.isMobile(context)
+                    ? LinagoraSysColors.material().onPrimary
+                    : Theme.of(context).colorScheme.surfaceContainerHighest,
+                shape: RoundedRectangleBorder(
+                  borderRadius: MessageStyle.bubbleBorderRadius,
+                ),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 4,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    borderRadius: MessageStyle.bubbleBorderRadius,
+                    border:
+                        !widget.event.isOwnMessage &&
+                            _responsiveUtils.isMobile(context)
+                        ? Border.all(
+                            color: MessageStyle.borderColorReceivedBubble,
+                          )
+                        : null,
+                  ),
+                  child: SelectionArea(
+                    child: SingleChildScrollView(
+                      primary: true,
+                      physics: const ClampingScrollPhysics(),
+                      child: _messageBuilder(
+                        key: ValueKey(
+                          'PreviewErrorWidgetKey%${DateTime.now().millisecondsSinceEpoch}',
+                        ),
+                        context: context,
+                        timelineText: timelineText,
+                        noBubble: noBubble,
+                        displayTime: displayTime,
+                        paddingBubble: EdgeInsets.zero,
+                        enableBorder: false,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              emojiPickerBuilder: _emojiPickerBuilder,
+              messageContextMenu: _errorMessageContextMenu,
+              themeContextMenu: _themeContextMenu,
+              iconContextMenu: _iconContextMenu,
+            ),
+          ),
+        )
+        .then((result) {
+          _handleResultFromHeroPage(context, result);
+          widget.onHideEmojiReaction?.call();
+        });
   }
 
   void _handleResultFromHeroPage(BuildContext context, dynamic result) {

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -225,13 +225,16 @@ class _MessageContentWithTimestampBuilderState
                       noBubble: noBubble,
                       displayTime: displayTime,
                     )
-                  : (event) => _handleAvailableMessageLongPress(
+                  : !widget.event.status.isError &&
+                        !widget.event.status.isSending
+                  ? (event) => _handleAvailableMessageLongPress(
                       context,
                       event,
                       timelineText: timelineText,
                       noBubble: noBubble,
                       displayTime: displayTime,
-                    ),
+                    )
+                  : null,
               child: _messageBuilder(
                 context: context,
                 timelineText: timelineText,

--- a/lib/pages/chat/events/message/message_reaction_dialog.dart
+++ b/lib/pages/chat/events/message/message_reaction_dialog.dart
@@ -30,6 +30,7 @@ class MessageReactionDialog extends StatelessWidget {
   final Widget? Function(Event, MessageContextMenuAction) iconContextMenu;
   final OnSendEmojiReactionAction? onSendEmojiReaction;
   final Key dialogSafeAreaKey;
+  final bool showReactions;
 
   const MessageReactionDialog({
     super.key,
@@ -43,6 +44,7 @@ class MessageReactionDialog extends StatelessWidget {
     required this.iconContextMenu,
     required this.dialogSafeAreaKey,
     this.onSendEmojiReaction,
+    this.showReactions = true,
   });
 
   @override
@@ -79,7 +81,8 @@ class MessageReactionDialog extends StatelessWidget {
                   builder: (context, display, child) {
                     return ReactionsDialogWidget(
                       messageWidget: messageWidget,
-                      reactionWidget: !event.room.canSendReactions
+                      reactionWidget:
+                          !showReactions || !event.room.canSendReactions
                           ? const SizedBox.shrink()
                           : display
                           ? emojiPickerBuilder(

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -375,6 +375,8 @@ extension LocalizedBody on Event {
   }
 
   bool get canDelete {
+    // Error-status events are local-only — always removable by their sender.
+    if (status.isError) return isOwnMessage;
     if (isOwnMessage) {
       return room.canSendRedactEvent;
     }


### PR DESCRIPTION
## Ticket
**Related issue**

- #3043 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

https://github.com/user-attachments/assets/caccdafe-73fe-458d-9b81-52901bbbc8fe


https://github.com/user-attachments/assets/13ca3770-c3e3-48d7-844a-f51c71b36040



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error event handling: messages with error status now support local deletion without server communication and display limited context menu options (copy/delete only).
  * Enhanced error message interactions: hover and long-press behaviors now work correctly for failed messages.

* **New Features**
  * Added option to control reaction visibility in the message reaction dialog.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3046)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->