### PR TITLE
fix: infinite loader when connecting to custom homeserver

### DIFF
--- a/lib/pages/auto_homeserver_picker/auto_homeserver_picker.dart
+++ b/lib/pages/auto_homeserver_picker/auto_homeserver_picker.dart
@@ -55,7 +55,7 @@ class AutoHomeserverPickerController extends State<AutoHomeserverPicker>
       final ssoSupported = matrix.loginHomeserverSummary.supportSSOLogin;
 
       try {
-        await client.register().timeout(
+        await client.register(inhibitLogin: true).timeout(
           autoHomeserverPickerTimeout,
           onTimeout: () {
             throw CheckHomeserverTimeoutException();
@@ -64,10 +64,13 @@ class AutoHomeserverPickerController extends State<AutoHomeserverPicker>
         matrix.loginRegistrationSupported = true;
       } on MatrixException catch (e) {
         matrix.loginRegistrationSupported = e.requireAdditionalAuthentication;
+      } catch (e) {
+        Logs().w('Registration check failed', e);
+        matrix.loginRegistrationSupported = false;
       }
 
-      if (!ssoSupported && matrix.loginRegistrationSupported == false) {
-        // Server does not support SSO or registration. We can skip to login page:
+      if (!ssoSupported) {
+        // No SSO: go straight to password login page
         const HomeLoginRoute().push(context);
       } else if (ssoSupported && matrix.loginRegistrationSupported == false) {
         Map<String, dynamic>? rawLoginTypes;

--- a/lib/pages/auto_homeserver_picker/auto_homeserver_picker.dart
+++ b/lib/pages/auto_homeserver_picker/auto_homeserver_picker.dart
@@ -55,12 +55,14 @@ class AutoHomeserverPickerController extends State<AutoHomeserverPicker>
       final ssoSupported = matrix.loginHomeserverSummary.supportSSOLogin;
 
       try {
-        await client.register(inhibitLogin: true).timeout(
-          autoHomeserverPickerTimeout,
-          onTimeout: () {
-            throw CheckHomeserverTimeoutException();
-          },
-        );
+        await client
+            .register(inhibitLogin: true)
+            .timeout(
+              autoHomeserverPickerTimeout,
+              onTimeout: () {
+                throw CheckHomeserverTimeoutException();
+              },
+            );
         matrix.loginRegistrationSupported = true;
       } on MatrixException catch (e) {
         matrix.loginRegistrationSupported = e.requireAdditionalAuthentication;

--- a/lib/pages/homeserver_picker/homeserver_picker.dart
+++ b/lib/pages/homeserver_picker/homeserver_picker.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
+import 'package:fluffychat/domain/model/homeserver_summary.dart';
 import 'package:fluffychat/presentation/mixins/connect_page_mixin.dart';
 import 'package:fluffychat/pages/connect/sso_login_state.dart';
 import 'package:fluffychat/pages/homeserver_picker/homeserver_state.dart';
@@ -185,19 +186,27 @@ class HomeserverPickerController extends State<HomeserverPicker>
         return;
       }
 
-      matrix.loginHomeserverSummary = await client
-          .checkHomeserver(homeserver)
-          .toHomeserverSummary();
+      matrix.loginHomeserverSummary = HomeserverSummary(
+        discoveryInformation: homeserverSummary.$1,
+        versions: homeserverSummary.$2,
+        loginFlows: homeserverSummary.$3,
+      );
       final ssoSupported = matrix.loginHomeserverSummary.supportSSOLogin;
 
       try {
-        await client.register();
+        await client
+            .register(inhibitLogin: true)
+            .timeout(const Duration(seconds: 30));
         matrix.loginRegistrationSupported = true;
       } on MatrixException catch (e) {
         matrix.loginRegistrationSupported = e.requireAdditionalAuthentication;
+      } catch (e) {
+        Logs().w('Registration check failed', e);
+        matrix.loginRegistrationSupported = false;
       }
 
-      if (!ssoSupported && matrix.loginRegistrationSupported == false) {
+      if (!ssoSupported) {
+        // No SSO: go straight to password login page
         handlePasswordLogin();
       } else if (ssoSupported && matrix.loginRegistrationSupported == false) {
         Map<String, dynamic>? rawLoginTypes;

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1382,7 +1382,7 @@ extension HomeserverSummaryConversion
             GetAuthMetadataResponse?,
           )
         > {
-  Future<HomeserverSummary?> toHomeserverSummary() async {
+  Future<HomeserverSummary> toHomeserverSummary() async {
     try {
       final result = await this;
       return HomeserverSummary(
@@ -1392,7 +1392,7 @@ extension HomeserverSummaryConversion
       );
     } catch (e, s) {
       Logs().wtf('HomeserverSummaryConversion::toHomeserverSummary', e, s);
-      return null;
+      rethrow;
     }
   }
 }


### PR DESCRIPTION
## Summary
- **Fixes #2836** — Infinite loading when connecting to a Matrix server with registration enabled and no SSO
- `client.register()` now uses `inhibitLogin: true` to avoid accidentally registering an account during the probe
- Added timeout (30s) + generic catch to prevent indefinite hangs
- Simplified routing: servers without SSO always go to password login page instead of ConnectRoute (which shows an SSO spinner)
- `toHomeserverSummary()` now rethrows errors instead of silently returning `null`

## Root cause
Two issues combined:
1. `client.register()` without `inhibitLogin` could start a full sync loop when the server allows open registration
2. The routing logic sent `!ssoSupported && registrationSupported` servers to `ConnectRoute`, which only renders SSO identity providers — showing an infinite spinner when there are none
3. 
<img width="1312" height="956" alt="image" src="https://github.com/user-attachments/assets/70acdd0d-2a1a-45e0-8a30-0016d775f27d" />

## Test plan
- [ ] Connect to `https://matrix.mathieu-raisin.fr` (registration enabled, no SSO, no well-known) → should show password login page
- [ ] Connect to default Twake homeserver (SSO) → should redirect to SSO as before
- [ ] Connect to a server with registration disabled + password login → should show password login page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved homeserver registration capability detection with timeout handling and enhanced error propagation during authentication flow.

* **Refactor**
  * Updated login routing logic to more reliably determine password-based authentication paths when SSO is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->