### PR TITLE
TW-2634(feat): native browser right-click menu on chat links (web)

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -5,6 +5,7 @@ import 'package:fluffychat/pages/image_viewer/image_viewer.dart';
 import 'package:fluffychat/presentation/mixins/linkify_mixin.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
+import 'package:fluffychat/widgets/native_link_span.dart';
 import 'package:fluffychat/widgets/mentioned_user.dart';
 import 'package:flutter/material.dart';
 
@@ -80,6 +81,13 @@ class HtmlMessage extends StatelessWidget with LinkifyMixin {
         context: context,
         details: tapDownDetails,
         link: link,
+      ),
+      linkBuilder: (url, childrenSpan, linkStyle) => buildNativeLinkSpan(
+        url: url,
+        childrenSpan: childrenSpan,
+        linkStyle: linkStyle,
+        onTapDown: (_) =>
+            UrlLauncher(context, url: url, room: room).launchUrl(),
       ),
       onPillTap: !room.isDirectChat
           ? (url) {

--- a/lib/widgets/native_link_span.dart
+++ b/lib/widgets/native_link_span.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/link.dart' as url_launcher_link;
+
+/// Wraps an [InlineSpan] representing a URL into a [WidgetSpan] containing
+/// a [url_launcher_link.Link] so the browser renders a real `<a>` element
+/// overlay on Flutter web. This gives the user native right-click context
+/// menu items ("Open in new tab", "Copy link address").
+InlineSpan? buildNativeLinkSpan({
+  required String url,
+  required InlineSpan childrenSpan,
+  required TextStyle? linkStyle,
+  required GestureTapDownCallback onTapDown,
+}) {
+  if (!kIsWeb || url.isEmpty) return null;
+  final parsed = Uri.tryParse(url);
+  if (parsed == null) return null;
+  final uri = switch (parsed.scheme) {
+    'http' || 'https' => parsed,
+    '' => Uri.tryParse('https://$url'),
+    _ => null,
+  };
+  if (uri == null) return null;
+  return WidgetSpan(
+    alignment: PlaceholderAlignment.middle,
+    child: url_launcher_link.Link(
+      uri: uri,
+      target: url_launcher_link.LinkTarget.blank,
+      builder: (_, __) => GestureDetector(
+        onTapDown: onTapDown,
+        child: Text.rich(TextSpan(style: linkStyle, children: [childrenSpan])),
+      ),
+    ),
+  );
+}

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/pages/chat/events/formatted_text_widget.dart';
 import 'package:fluffychat/presentation/mixins/linkify_mixin.dart';
 import 'package:fluffychat/presentation/widget_keys/link_preview_keys.dart';
 import 'package:fluffychat/utils/string_extension.dart';
+import 'package:fluffychat/widgets/native_link_span.dart';
 import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart';
 import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_view.dart';
 import 'package:flutter/material.dart';
@@ -59,6 +60,21 @@ class TwakeLinkPreview extends StatelessWidget with LinkifyMixin {
                 details: tapDownDetails,
                 link: link,
               ),
+              linkBuilder: (link, style) {
+                if (link.type != LinkType.url) return null;
+                final url = link.value;
+                if (url == null) return null;
+                return buildNativeLinkSpan(
+                  url: url,
+                  childrenSpan: TextSpan(text: url, style: style),
+                  linkStyle: style,
+                  onTapDown: (details) => handleOnTappedLinkHtml(
+                    context: context,
+                    details: details,
+                    link: link,
+                  ),
+                );
+              },
             ),
       previewItemWidget: TwakeLinkPreviewItem(
         key: twakeLinkPreviewItemKey,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1185,7 +1185,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: c136e053a9d8c78ee81a169f4c40dba2ce76802c
+      resolved-ref: "5699fee5968acf0dac2f6bf8b053eb8abce798c8"
       url: "https://github.com/linagora/flutter_matrix_html.git"
     source: git
     version: "1.2.0"
@@ -1820,7 +1820,7 @@ packages:
     description:
       path: "."
       ref: main
-      resolved-ref: "21818487a4b701fd453a72ad3f3e0d78e3184238"
+      resolved-ref: "1e631ed763b7c9a908b5fb210d860283918cf516"
       url: "git@github.com:linagora/linkfy_text.git"
     source: git
     version: "1.1.6"

--- a/web/style.css
+++ b/web/style.css
@@ -53,3 +53,7 @@ body {
   bottom: 0;
   right: 0;
 }
+
+a[href] {
+  cursor: pointer !important;
+}


### PR DESCRIPTION
## Ticket
#2634 

## Root cause
On Flutter web, message text is painted to a canvas. The browser sees no `<a>` HTML elements for URLs detected in messages, so right-clicking a link only triggers Flutter's text-selection toolbar (selecting one word) instead of the native browser context menu. Users cannot use "Open in new tab" or "Copy link address" actions that are standard on every web app.

## Solution
Overlay a real HTML `<a>` element on top of each rendered URL using the `Link` widget from `package:url_launcher`. The browser handles the right-click natively on that element, exposing its full link context menu.

The overlay is wired in two places, one per rendering path:

1. **HTML-formatted messages** ([`html_message.dart`](lib/pages/chat/events/html_message.dart)): the `linkBuilder` callback of the `Html` widget is now provided (https://github.com/linagora/flutter_matrix_html/pull/26). It fires for explicit `<a>` tags.

2. **Plain-text messages** ([`twake_link_preview.dart`](lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart)): the `linkBuilder` callback of `MatrixLinkifyText` is now provided (https://github.com/linagora/linkfy_text/pull/4) . It fires for each URL matched by the linkify regex. Non-URL matches (phone, email, date) fall through to the default `LinkTextSpan` so existing tap handling is preserved.

3. **Shared helper** ([`lib/widgets/native_link_span.dart`](lib/widgets/native_link_span.dart)): a single `buildNativeLinkSpan` function builds the `WidgetSpan(Link(...))` overlay. It is `kIsWeb`-gated (returns `null` on mobile/desktop → caller falls back to the default `TextSpan` rendering, zero impact on non-web builds).

## Impact description
- Right-click on any link inside a chat message (on web) now opens the native browser context menu with link-specific actions (Open in new tab, Open in new window, Copy link address, Save link as…).
- Left-click behaviour unchanged: still routes through `UrlLauncher`
- Hover cursor on links is now the pointer (was the text I-beam).
- Mobile and desktop builds are untouched (helper is `kIsWeb`-gated).

## Test recommendations
**Web (primary)**
- Right-click a URL in a chat message → native browser menu shows "Open in new tab" / "Copy link address".
- Left-click a regular URL → opens in a new tab via `UrlLauncher`.
- Left-click a `matrix.to` link → in-app routing still works (joins room / opens user profile as before).
- Hover a link → cursor is `pointer`.
- Bare URL without scheme (e.g. `linagora.com`) → still clickable, the overlay falls back to `https://linagora.com`.
- Very long URL on one or multiple lines → still clickable, native menu still shows.
- HTML-formatted messages (sent from Twake compose, Element, etc.) → links work.
- Plain-text messages (no `formatted_body`) → links work.
- Non-http schemes (`mailto:`, `tel:`, `matrix:`) → fall back to existing handling, native menu does not apply.

**Mobile (Android / iOS) and Desktop**
- All link interactions unchanged. The helper returns `null` on those platforms so the default `LinkTextSpan` (tap-only) is rendered.

## Pre-merge
- [x] Merge https://github.com/linagora/linkfy_text/pull/4
- [x] Merge https://github.com/linagora/flutter_matrix_html/pull/26
- [x] Re-run `flutter pub get` and verify the lockfile.

## Demos
- Web:

https://github.com/user-attachments/assets/3e2006e1-1a3f-4680-b229-ba09e4351afc

- Android: N/A (no behaviour change, helper returns `null`)
- iOS: N/A (no behaviour change, helper returns `null`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced link handling in HTML messages with improved browser context menu support on web.
  * Improved native link styling and interaction for message previews.

* **Bug Fixes**
  * Fixed CSS structure integrity.
  * Corrected link cursor display styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->