### PR TITLE
fix: stop redundant well-known fetches post-login (#3050)

### DIFF
--- a/lib/domain/usecase/room/create_support_chat_interactor.dart
+++ b/lib/domain/usecase/room/create_support_chat_interactor.dart
@@ -14,7 +14,10 @@ import 'package:matrix/matrix.dart';
 class CreateSupportChatInteractor {
   const CreateSupportChatInteractor();
 
-  Stream<Either<Failure, Success>> execute(Client client) async* {
+  Stream<Either<Failure, Success>> execute(
+    Client client, {
+    DiscoveryInformation? cachedDiscovery,
+  }) async* {
     yield Right(CreatingSupportChat());
 
     const type = TwakeEventTypes.supportChatCreatedEventType;
@@ -22,7 +25,7 @@ class CreateSupportChatInteractor {
     String? roomId;
     String? userId;
     try {
-      final discovery = await client.getWellknown();
+      final discovery = cachedDiscovery ?? await client.getWellknown();
       final supportChatTwakeId =
           (discovery.additionalProperties[WellKnownMixin.twakeChatKey]
               as Map?)?[WellKnownMixin.supportContact];

--- a/lib/pages/contacts_tab/contacts_tab.dart
+++ b/lib/pages/contacts_tab/contacts_tab.dart
@@ -43,8 +43,9 @@ class ContactsTabController extends State<ContactsTab>
       WidgetsBinding.instance.addObserver(this);
       if (mounted) {
         listenAddressBookEvents(client);
-        discoveryInformationNotifier.value =
-            Matrix.of(context).loginHomeserverSummary?.discoveryInformation;
+        discoveryInformationNotifier.value = Matrix.of(
+          context,
+        ).loginHomeserverSummary?.discoveryInformation;
         synchronizeContactsOnContactTab(
           context: context,
           client: Matrix.of(context).client,

--- a/lib/pages/contacts_tab/contacts_tab.dart
+++ b/lib/pages/contacts_tab/contacts_tab.dart
@@ -43,7 +43,8 @@ class ContactsTabController extends State<ContactsTab>
       WidgetsBinding.instance.addObserver(this);
       if (mounted) {
         listenAddressBookEvents(client);
-        getWellKnownInformation(client);
+        discoveryInformationNotifier.value =
+            Matrix.of(context).loginHomeserverSummary?.discoveryInformation;
         synchronizeContactsOnContactTab(
           context: context,
           client: Matrix.of(context).client,

--- a/lib/presentation/mixins/wellknown_mixin.dart
+++ b/lib/presentation/mixins/wellknown_mixin.dart
@@ -15,9 +15,9 @@ mixin WellKnownMixin {
       Logs().d('WellKnownMixin::getWellKnownInformation() well-known $result');
       discoveryInformationNotifier.value = result;
     } catch (e) {
-      discoveryInformationNotifier.value = null;
       Logs().e(
-        'WellKnownMixin::getWellKnownInformation() Error checking wellknown status: $e',
+        'WellKnownMixin::getWellKnownInformation() Error checking wellknown '
+        'status (keeping previous value): $e',
       );
     }
   }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1106,9 +1106,7 @@ class MatrixState extends State<Matrix>
   }
 
   Future<void> _refreshHomeserverInformation(Client client) async {
-    if (client.homeserver == null) {
-      client.homeserver = Uri.parse(AppConfig.homeserver);
-    }
+    client.homeserver ??= Uri.parse(AppConfig.homeserver);
     await _getHomeserverInformation(client);
   }
 

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -201,7 +201,10 @@ class MatrixState extends State<Matrix>
       StreamSubscription? createSupportChatListener;
       createSupportChatListener = getIt
           .get<CreateSupportChatInteractor>()
-          .execute(client)
+          .execute(
+            client,
+            cachedDiscovery: loginHomeserverSummary?.discoveryInformation,
+          )
           .listen(
             (state) {
               createSupportChatState = state.fold(
@@ -887,7 +890,8 @@ class MatrixState extends State<Matrix>
 
   Future<void> _tryStoreFederationConfiguration() async {
     try {
-      final wellKnown = await client.getWellknown();
+      final wellKnown = loginHomeserverSummary?.discoveryInformation;
+      if (wellKnown == null) return;
 
       Logs().d('MatrixState::_tryStoreFederationConfiguration: $wellKnown');
 
@@ -1082,9 +1086,20 @@ class MatrixState extends State<Matrix>
       'Matrix::_getHomeserverInformation: client homeserver = ${newClient.homeserver}',
     );
     if (newClient.homeserver == null) return;
-    loginHomeserverSummary = await newClient
-        .checkHomeserver(newClient.homeserver!)
+    final previousDiscovery = loginHomeserverSummary?.discoveryInformation;
+    final newSummary = await newClient
+        .checkHomeserver(newClient.homeserver!, checkWellKnown: false)
         .toHomeserverSummary();
+    if (newSummary == null) return;
+    if (newSummary.discoveryInformation == null && previousDiscovery != null) {
+      loginHomeserverSummary = HomeserverSummary(
+        discoveryInformation: previousDiscovery,
+        versions: newSummary.versions,
+        loginFlows: newSummary.loginFlows,
+      );
+    } else {
+      loginHomeserverSummary = newSummary;
+    }
     Logs().d(
       'Matrix::_getHomeserverInformation: appTwakeInformation ${loginHomeserverSummary?.appTwakeInformation}',
     );
@@ -1092,9 +1107,7 @@ class MatrixState extends State<Matrix>
 
   Future<void> _refreshHomeserverInformation(Client client) async {
     if (client.homeserver == null) {
-      final domain = client.userID?.domain;
-      if (domain == null) return;
-      client.homeserver = Uri.https(domain, '');
+      client.homeserver = Uri.parse(AppConfig.homeserver);
     }
     await _getHomeserverInformation(client);
   }


### PR DESCRIPTION
## Summary
- **Fixes** #3050 — after login, `getWellknown()` uses `userID.domain` (e.g. `twake.app`) instead of `homeserver.host` (`matrix.twake.app`), causing 404s that break `common_settings`, invitations, federation config, and the profile Edit button
- Skip well-known re-fetch in `_getHomeserverInformation` (`checkWellKnown: false`), preserve pre-login discovery data across the session
- Use `AppConfig.homeserver` as reconnect fallback instead of `userID.domain`
- Use cached `loginHomeserverSummary.discoveryInformation` in `_tryStoreFederationConfiguration` and `_createSupportChat`
- Keep previous value in `WellKnownMixin` on failure instead of nulling out
- Seed contacts tab discovery from `MatrixState` cache

## Root cause
The SDK's `requestAndCache` bypasses caching when `!isLogged()`, so the successful pre-login well-known fetch is never cached. Post-login, `getWellknown()` constructs the URL from `userID.domain` with no cache fallback — hitting `twake.app` instead of `matrix.twake.app`.

## Test plan
- [x] `flutter analyze` — 0 errors
- [x] Web release build on `matrix.linagora.com` — login via SSO, rooms load, no 404 on well-known
- [x] Verify on a `twake.app` account that no request is made to `twake.app/.well-known/matrix/client` after login
- [ ] Verify profile Edit button visibility when `common_settings.enabled: true`
- [ ] Verify invitation support still works on servers with `enable_invitations: true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced redundant network requests by caching and reusing homeserver discovery information across support chat creation and contact synchronization workflows.

* **Improvements**
  * Enhanced homeserver refresh logic to better preserve existing discovery data when unavailable in refreshed information.

* **Bug Fixes**
  * Improved error logging to better communicate when cached values are retained after network failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->