### PR TITLE
Upgrade matrix SDK to version 7.1.2 and power level comparisons to use PowerLevel class

### DIFF
--- a/lib/domain/model/room/room_extension.dart
+++ b/lib/domain/model/room/room_extension.dart
@@ -12,8 +12,17 @@ import 'package:matrix/matrix.dart';
 // ignore: implementation_imports
 import 'package:matrix/src/utils/markdown.dart';
 
+/// In-memory store for files being sent, keyed by transaction ID.
+///
+/// Replaces `Room.sendingFilePlaceholders` which was removed in matrix SDK v7.0.
+final Map<String, MatrixFile> _globalSendingFilePlaceholders = {};
+
 extension RoomExtension on Room {
   static const _kRefreshingLastEventType = 'com.famedly.refreshing_last_event';
+
+  // ignore: library_private_types_in_public_api
+  Map<String, MatrixFile> get sendingFilePlaceholders =>
+      _globalSendingFilePlaceholders;
   RecentChatSearchModel toRecentChatSearchModel(
     MatrixLocalizations matrixLocalizations,
   ) {
@@ -73,66 +82,66 @@ extension RoomExtension on Room {
 
   bool get canPinMessage {
     final currentPowerLevelsMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (currentPowerLevelsMap == null) return 0 <= ownPowerLevel;
+    if (currentPowerLevelsMap == null) return PowerLevel(0) <= ownPowerLevel;
     return (currentPowerLevelsMap
                 .tryGetMap<String, Object?>('events')
                 ?.tryGet<int>(EventTypes.RoomPinnedEvents) ??
-            getDefaultPowerLevel(currentPowerLevelsMap)) <=
-        ownPowerLevel;
+            getDefaultPowerLevel(currentPowerLevelsMap).level) <=
+        ownPowerLevel.level;
   }
 
   bool get canSendReactions {
     final currentPowerLevelsMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (currentPowerLevelsMap == null) return 0 <= ownPowerLevel;
+    if (currentPowerLevelsMap == null) return PowerLevel(0) <= ownPowerLevel;
     return (currentPowerLevelsMap
                 .tryGetMap<String, Object?>('events')
                 ?.tryGet<int>(EventTypes.Reaction) ??
-            getDefaultPowerLevel(currentPowerLevelsMap)) <=
-        ownPowerLevel;
+            getDefaultPowerLevel(currentPowerLevelsMap).level) <=
+        ownPowerLevel.level;
   }
 
   bool get canChangeRoomName {
     final currentPowerLevelsMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (currentPowerLevelsMap == null) return 0 <= ownPowerLevel;
+    if (currentPowerLevelsMap == null) return PowerLevel(0) <= ownPowerLevel;
     return (currentPowerLevelsMap
                 .tryGetMap<String, Object?>('events')
                 ?.tryGet<int>(EventTypes.RoomName) ??
             currentPowerLevelsMap.tryGet<int>('state_default') ??
             80) <=
-        ownPowerLevel;
+        ownPowerLevel.level;
   }
 
   bool get canChangeTopic {
     final currentPowerLevelsMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (currentPowerLevelsMap == null) return 0 <= ownPowerLevel;
+    if (currentPowerLevelsMap == null) return PowerLevel(0) <= ownPowerLevel;
     return (currentPowerLevelsMap
                 .tryGetMap<String, Object?>('events')
                 ?.tryGet<int>(EventTypes.RoomTopic) ??
             currentPowerLevelsMap.tryGet<int>('state_default') ??
             80) <=
-        ownPowerLevel;
+        ownPowerLevel.level;
   }
 
   bool get canChangeRoomAvatar {
     final currentPowerLevelsMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (currentPowerLevelsMap == null) return 0 <= ownPowerLevel;
+    if (currentPowerLevelsMap == null) return PowerLevel(0) <= ownPowerLevel;
     return (currentPowerLevelsMap
                 .tryGetMap<String, Object?>('events')
                 ?.tryGet<int>(EventTypes.RoomAvatar) ??
             currentPowerLevelsMap.tryGet<int>('state_default') ??
             80) <=
-        ownPowerLevel;
+        ownPowerLevel.level;
   }
 
   bool get canEnableEncryption {
     final currentPowerLevelsMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (currentPowerLevelsMap == null) return 0 <= ownPowerLevel;
+    if (currentPowerLevelsMap == null) return PowerLevel(0) <= ownPowerLevel;
     return (currentPowerLevelsMap
                 .tryGetMap<String, Object?>('events')
                 ?.tryGet<int>(EventTypes.Encryption) ??
             currentPowerLevelsMap.tryGet<int>('state_default') ??
             80) <=
-        ownPowerLevel;
+        ownPowerLevel.level;
   }
 
   bool get canEditChatDetails {
@@ -146,12 +155,12 @@ extension RoomExtension on Room {
 
   bool get canSendRedactEvent {
     final currentPowerLevelsMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (currentPowerLevelsMap == null) return 0 <= ownPowerLevel;
+    if (currentPowerLevelsMap == null) return PowerLevel(0) <= ownPowerLevel;
     return (currentPowerLevelsMap
                 .tryGetMap<String, Object?>('events')
                 ?.tryGet<int>(EventTypes.Redaction) ??
-            getDefaultPowerLevel(currentPowerLevelsMap)) <=
-        ownPowerLevel;
+            getDefaultPowerLevel(currentPowerLevelsMap).level) <=
+        ownPowerLevel.level;
   }
 
   bool get canRedactEventSentByOther {
@@ -263,49 +272,59 @@ extension RoomExtension on Room {
 
   bool get canAssignRoles {
     final currentPowerLevelsMap = getState(EventTypes.RoomPowerLevels)?.content;
-    if (currentPowerLevelsMap == null) return 0 <= ownPowerLevel;
+    if (currentPowerLevelsMap == null) return PowerLevel(0) <= ownPowerLevel;
     return (currentPowerLevelsMap
                 .tryGetMap<String, Object?>('events')
                 ?.tryGet<int>(EventTypes.RoomPowerLevels) ??
             currentPowerLevelsMap.tryGet<int>('state_default') ??
             DefaultPowerLevelMember.admin.powerLevel) <=
-        ownPowerLevel;
+        ownPowerLevel.level;
   }
 
   List<User> getAssignRolesMember() {
     final members = getParticipants();
     if (members.isEmpty) return [];
     return members.where((final User member) {
-        final powerLevel = member.powerLevel;
-        return powerLevel >= DefaultPowerLevelMember.moderator.powerLevel &&
-            member.membership == Membership.join;
-      }).toList()
-      ..sort((small, great) => great.powerLevel.compareTo(small.powerLevel));
+      final powerLevel = member.powerLevel;
+      return powerLevel >=
+              PowerLevel(DefaultPowerLevelMember.moderator.powerLevel) &&
+          member.membership == Membership.join;
+    }).toList()..sort(
+      (small, great) =>
+          great.powerLevel.level.compareTo(small.powerLevel.level),
+    );
   }
 
   List<User> getExceptionsMember() {
     final members = getParticipants();
     if (members.isEmpty) return [];
     return members.where((final User member) {
-        final powerLevel = member.powerLevel;
-        return powerLevel < DefaultPowerLevelMember.member.powerLevel &&
-            member.membership == Membership.join;
-      }).toList()
-      ..sort((small, great) => great.powerLevel.compareTo(small.powerLevel));
+      final powerLevel = member.powerLevel;
+      return powerLevel <
+              PowerLevel(DefaultPowerLevelMember.member.powerLevel) &&
+          member.membership == Membership.join;
+    }).toList()..sort(
+      (small, great) =>
+          great.powerLevel.level.compareTo(small.powerLevel.level),
+    );
   }
 
   List<User> getBannedMembers() {
     final members = getParticipants([Membership.ban]);
     if (members.isEmpty) return [];
-    return members
-      ..sort((small, great) => great.powerLevel.compareTo(small.powerLevel));
+    return members..sort(
+      (small, great) =>
+          great.powerLevel.level.compareTo(small.powerLevel.level),
+    );
   }
 
   List<User> getCurrentMembers() {
     final members = getParticipants([Membership.invite, Membership.join]);
     if (members.isEmpty) return [];
-    return members
-      ..sort((small, great) => great.powerLevel.compareTo(small.powerLevel));
+    return members..sort(
+      (small, great) =>
+          great.powerLevel.level.compareTo(small.powerLevel.level),
+    );
   }
 
   bool canUpdateRoleInRoom(User user) {
@@ -341,7 +360,8 @@ extension RoomExtension on Room {
   }
 
   bool get canTransferOwnership {
-    return ownPowerLevel >= DefaultPowerLevelMember.owner.powerLevel &&
+    return ownPowerLevel >=
+            PowerLevel(DefaultPowerLevelMember.owner.powerLevel) &&
         canAssignRoles;
   }
 
@@ -406,7 +426,7 @@ extension NullableRoomExtension on Room? {
 extension SortByPowerLevel on List<User> {
   List<User> sortByPowerLevel() {
     final newList = [...this];
-    newList.sort((a, b) => b.powerLevel.compareTo(a.powerLevel));
+    newList.sort((a, b) => b.powerLevel.level.compareTo(a.powerLevel.level));
     return newList;
   }
 }

--- a/lib/domain/usecase/room/ban_user_interactor.dart
+++ b/lib/domain/usecase/room/ban_user_interactor.dart
@@ -37,7 +37,8 @@ class BanUserInteractor {
   /// but the ban operation continues. This prevents issues when banning
   /// users with elevated privileges.
   Future<void> _reducePowerLevelIfNeeded(User user) async {
-    if (user.powerLevel <= DefaultPowerLevelMember.member.powerLevel) {
+    if (user.powerLevel <=
+        PowerLevel(DefaultPowerLevelMember.member.powerLevel)) {
       return;
     }
 

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -902,6 +902,7 @@ class ChatController extends State<Chat>
           extraContent: extraContent,
         )
         .catchError((e) {
+          room?.sendingFilePlaceholders.remove(txid);
           TwakeSnackBar.show(
             context,
             L10n.of(context)!.audioMessageFailedToSend,
@@ -956,7 +957,7 @@ class ChatController extends State<Chat>
           inReplyTo: replyEventNotifier.value,
           extraContent: extraContent,
         )
-        .then((_) {
+        .whenComplete(() {
           room?.sendingFilePlaceholders.remove(txid);
         })
         .catchError((e) {

--- a/lib/pages/chat_details/assign_roles_role_picker/quick_role_picker_mixin.dart
+++ b/lib/pages/chat_details/assign_roles_role_picker/quick_role_picker_mixin.dart
@@ -37,7 +37,7 @@ mixin QuickRolePickerMixin on TwakeContextMenuMixin {
     return quickRolePicker.map((action) {
       return ContextMenuAction(
         name: action.displayName(context),
-        icon: action.powerLevel == user.powerLevel ? Icons.check : null,
+        icon: action.powerLevel == user.powerLevel.level ? Icons.check : null,
         colorIcon: LinagoraRefColors.material().neutral[30],
       );
     }).toList();
@@ -135,7 +135,7 @@ mixin QuickRolePickerMixin on TwakeContextMenuMixin {
                 ),
               ),
             ),
-            if (role.powerLevel == user.powerLevel)
+            if (role.powerLevel == user.powerLevel.level)
               SizedBox(
                 width: 36,
                 height: 36,

--- a/lib/pages/chat_draft/draft_chat.dart
+++ b/lib/pages/chat_draft/draft_chat.dart
@@ -39,6 +39,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dar
 import 'package:fluffychat/utils/network_connection_service.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
+import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/mixins/drag_drog_file_mixin.dart';
 import 'package:flutter/material.dart';

--- a/lib/pages/profile_info/profile_info_body/profile_info_body.dart
+++ b/lib/pages/profile_info/profile_info_body/profile_info_body.dart
@@ -278,7 +278,7 @@ class ProfileInfoBodyController extends State<ProfileInfoBody>
           .execute(
             room: room,
             userPermissionLevels: {
-              user!: room.ownUser.powerLevel,
+              user!: room.ownUser.powerLevel.level,
               room.ownUser: room.getUserDefaultLevel(),
             },
           )

--- a/lib/pages/story/story_page.dart
+++ b/lib/pages/story/story_page.dart
@@ -193,7 +193,7 @@ class StoryPageController extends State<StoryPage> {
     final client = Matrix.of(context).client;
     final room = client.getRoomById(roomId);
     if (room == null) return false;
-    return room.ownPowerLevel >= 100;
+    return room.ownPowerLevel >= PowerLevel(100);
   }
 
   String get roomId => GoRouterState.of(context).pathParameters['roomid'] ?? '';

--- a/lib/presentation/mixins/chat_details_tab_mixin.dart
+++ b/lib/presentation/mixins/chat_details_tab_mixin.dart
@@ -130,7 +130,8 @@ mixin ChatDetailsTabMixin<T extends StatefulWidget>
           if (event.isMemberChangedEvent && room?.id == event.roomID) {
             _membersNotifier.value = room?.getParticipants().toList()
               ?..sort(
-                (small, great) => great.powerLevel.compareTo(small.powerLevel),
+                (small, great) =>
+                    great.powerLevel.level.compareTo(small.powerLevel.level),
               );
             // Log only when summary count disagrees with actual participants list.
             final summaryCount = room?.summary.actualMembersCount ?? 0;
@@ -211,7 +212,10 @@ mixin ChatDetailsTabMixin<T extends StatefulWidget>
 
   Future<void> onUpdateMembers() async {
     final members = room!.getParticipants([Membership.join, Membership.invite])
-      ..sort((small, great) => great.powerLevel.compareTo(small.powerLevel));
+      ..sort(
+        (small, great) =>
+            great.powerLevel.level.compareTo(small.powerLevel.level),
+      );
     // Log only when summary count disagrees with actual filtered participants.
     final summaryCount = room?.summary.actualMembersCount ?? 0;
     if (summaryCount != members.length) {
@@ -250,7 +254,10 @@ mixin ChatDetailsTabMixin<T extends StatefulWidget>
   void _initMembers() {
     if (chatType == ChatDetailsScreenEnum.group) {
       _membersNotifier.value = room?.getParticipants().toList()
-        ?..sort((small, great) => great.powerLevel.compareTo(small.powerLevel));
+        ?..sort(
+          (small, great) =>
+              great.powerLevel.level.compareTo(small.powerLevel.level),
+        );
       // Log only when summary count disagrees with actual participants list.
       final summaryCount = room?.summary.actualMembersCount ?? 0;
       final participantsCount = _membersNotifier.value?.length ?? 0;

--- a/lib/utils/manager/upload_manager/upload_manager.dart
+++ b/lib/utils/manager/upload_manager/upload_manager.dart
@@ -60,6 +60,7 @@ class UploadManager {
     final cancelToken = _eventIdMapUploadFileInfo[event.eventId]?.cancelToken;
     if (cancelToken != null) {
       Logs().d('Remove eventid: ${event.eventId}');
+      event.room.sendingFilePlaceholders.remove(event.eventId);
       _clearFileTask(event.eventId);
       event.remove();
       cancelToken.cancel();
@@ -527,8 +528,8 @@ class UploadManager {
           }
         },
         onTaskCompleted: () async {
+          room.sendingFilePlaceholders.remove(txid);
           if (info?.isFailed != true) {
-            room.sendingFilePlaceholders.remove(txid);
             await _clearFileTask(txid);
           }
         },
@@ -585,8 +586,8 @@ class UploadManager {
           }
         },
         onTaskCompleted: () async {
+          room.sendingFilePlaceholders.remove(txid);
           if (info?.isFailed != true) {
-            room.sendingFilePlaceholders.remove(txid);
             await _clearFileTask(txid);
           }
         },

--- a/lib/utils/matrix_sdk_extensions/client_stories_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/client_stories_extension.dart
@@ -81,7 +81,7 @@ extension ClientStoriesExtension on Client {
                   ?.content
                   .tryGet<String>('type') ==
               storiesRoomType &&
-          room.ownPowerLevel >= 100,
+          room.ownPowerLevel >= PowerLevel(100),
     );
     if (candidates.isEmpty) return null;
     if (candidates.length == 1) return candidates.single;

--- a/lib/utils/matrix_sdk_extensions/download_file_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/download_file_extension.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/domain/model/file_info/file_info.dart';
 import 'package:fluffychat/utils/manager/download_manager/download_file_state.dart';
 import 'package:fluffychat/utils/manager/storage_directory_manager.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
+import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:matrix/matrix.dart';
 
 extension DownloadFileExtension on Event {

--- a/lib/utils/matrix_sdk_extensions/download_file_web_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/download_file_web_extension.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/utils/manager/download_manager/download_file_state.da
 import 'package:fluffychat/utils/matrix_sdk_extensions/download_file_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/stream_list_int_extension.dart';
+import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:matrix/matrix.dart';
 
 extension DownloadFileWebExtension on Event {

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -542,16 +542,18 @@ extension LocalizedBody on Event {
 
       // Update formatted_body if it exists in the new content
       if (newContent[MatrixEventFields.formattedBody] != null) {
-        originalEventJson[MatrixEventFields.content]
-            [MatrixEventFields.formattedBody] =
+        originalEventJson[MatrixEventFields.content][MatrixEventFields
+                .formattedBody] =
             newContent[MatrixEventFields.formattedBody];
         originalEventJson[MatrixEventFields.content][MatrixEventFields.format] =
             newContent[MatrixEventFields.format];
       } else {
-        originalEventJson[MatrixEventFields.content]
-            .remove(MatrixEventFields.formattedBody);
-        originalEventJson[MatrixEventFields.content]
-            .remove(MatrixEventFields.format);
+        originalEventJson[MatrixEventFields.content].remove(
+          MatrixEventFields.formattedBody,
+        );
+        originalEventJson[MatrixEventFields.content].remove(
+          MatrixEventFields.format,
+        );
       }
 
       return Event.fromJson(originalEventJson, room);

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -522,8 +522,9 @@ extension LocalizedBody on Event {
     );
 
     final editEventJson = latestEdit.toJson();
-    final newContent =
-        editEventJson[MatrixEventFields.content][MatrixEventFields.newContent];
+    final editContent =
+        editEventJson[MatrixEventFields.content] as Map<String, Object?>?;
+    final newContent = editContent?[MatrixEventFields.newContent];
 
     if (newContent is! Map) {
       return this;
@@ -536,17 +537,21 @@ extension LocalizedBody on Event {
       originalEventJson[MatrixEventFields.content][MatrixEventFields
               .newContent] =
           newContent;
-      originalEventJson[MatrixEventFields.content]['body'] = newContent['body'];
+      originalEventJson[MatrixEventFields.content][MatrixEventFields.body] =
+          newContent[MatrixEventFields.body];
 
       // Update formatted_body if it exists in the new content
-      if (newContent['formatted_body'] != null) {
-        originalEventJson[MatrixEventFields.content]['formatted_body'] =
-            newContent['formatted_body'];
-        originalEventJson[MatrixEventFields.content]['format'] =
-            newContent['format'];
+      if (newContent[MatrixEventFields.formattedBody] != null) {
+        originalEventJson[MatrixEventFields.content]
+            [MatrixEventFields.formattedBody] =
+            newContent[MatrixEventFields.formattedBody];
+        originalEventJson[MatrixEventFields.content][MatrixEventFields.format] =
+            newContent[MatrixEventFields.format];
       } else {
-        originalEventJson[MatrixEventFields.content].remove('formatted_body');
-        originalEventJson[MatrixEventFields.content].remove('format');
+        originalEventJson[MatrixEventFields.content]
+            .remove(MatrixEventFields.formattedBody);
+        originalEventJson[MatrixEventFields.content]
+            .remove(MatrixEventFields.format);
       }
 
       return Event.fromJson(originalEventJson, room);

--- a/lib/utils/matrix_sdk_extensions/matrix_event_fields.dart
+++ b/lib/utils/matrix_sdk_extensions/matrix_event_fields.dart
@@ -14,4 +14,13 @@ abstract class MatrixEventFields {
   ///
   /// Edit events carry the replacement body under `content['m.new_content']`.
   static const String newContent = 'm.new_content';
+
+  /// Key for the plain-text message body in event content.
+  static const String body = 'body';
+
+  /// Key for the HTML-formatted body in event content.
+  static const String formattedBody = 'formatted_body';
+
+  /// Key for the format identifier (e.g. `org.matrix.custom.html`) in event content.
+  static const String format = 'format';
 }

--- a/lib/utils/user_extension.dart
+++ b/lib/utils/user_extension.dart
@@ -15,7 +15,7 @@ extension UserExtension on User {
 
   DefaultPowerLevelMember get getDefaultPowerLevelMember {
     return DefaultPowerLevelMember.getDefaultPowerLevelByUsersDefault(
-      usersDefault: powerLevel,
+      usersDefault: powerLevel.level,
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1916,10 +1916,10 @@ packages:
     dependency: "direct main"
     description:
       name: matrix
-      sha256: "5bb38e98212bc4c3244c762a1af787f7239a38d2cfdf44488258283ff899f77c"
+      sha256: d170e4dc31d0d99e8a181388ff1d06c48f9b9163586a3867f23041fb220a79d3
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.0"
+    version: "7.2.2"
   matrix_api_lite:
     dependency: "direct overridden"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   sentry_flutter: ^9.10.0
   ### Dependencies from git ###
-  matrix: ^6.2.0
+  matrix: ^7.1.2
 
   receive_sharing_intent:
     git:

--- a/test/domain/model/room/room_extension_test.dart
+++ b/test/domain/model/room/room_extension_test.dart
@@ -72,7 +72,7 @@ void main() {
       final sortedUsers = users.sortByPowerLevel();
 
       // Assert
-      expect(sortedUsers.map((u) => u.powerLevel), [100, 100, 50]);
+      expect(sortedUsers.map((u) => u.powerLevel.level), [100, 100, 50]);
     });
   });
 

--- a/test/domain/model/room/room_extension_test.dart
+++ b/test/domain/model/room/room_extension_test.dart
@@ -13,7 +13,7 @@ class MockUser extends Mock implements User {
   MockUser(this._powerLevel, {String id = ''}) : _id = id;
 
   @override
-  int get powerLevel => _powerLevel;
+  PowerLevel get powerLevel => PowerLevel(_powerLevel);
 
   @override
   String get id => _id;
@@ -33,7 +33,7 @@ void main() {
       final sortedUsers = users.sortByPowerLevel();
 
       // Assert
-      expect(sortedUsers.map((u) => u.powerLevel), [100, 50, 0]);
+      expect(sortedUsers.map((u) => u.powerLevel.level), [100, 50, 0]);
     });
 
     test('sortByPowerLevel with empty list', () {
@@ -58,7 +58,7 @@ void main() {
       final sortedUsers = users.sortByPowerLevel();
 
       // Assert
-      expect(sortedUsers.map((u) => u.powerLevel), [100, 50, 0]);
+      expect(sortedUsers.map((u) => u.powerLevel.level), [100, 50, 0]);
     });
 
     test('sortByPowerLevel with users with same power level', () {

--- a/test/domain/usecase/room/ban_user_interactor_test.dart
+++ b/test/domain/usecase/room/ban_user_interactor_test.dart
@@ -213,9 +213,9 @@ void main() {
           };
 
           when(mockUser.canBan).thenReturn(true);
-          when(
-            mockUser.powerLevel,
-          ).thenReturn(PowerLevel(DefaultPowerLevelMember.moderator.powerLevel));
+          when(mockUser.powerLevel).thenReturn(
+            PowerLevel(DefaultPowerLevelMember.moderator.powerLevel),
+          );
           when(mockUser.id).thenReturn('@user:server.com');
           when(mockUser.room).thenReturn(mockRoom);
           when(mockUser.ban()).thenAnswer((_) async {});
@@ -343,9 +343,9 @@ void main() {
         () async {
           // Arrange
           when(mockUser.canBan).thenReturn(true);
-          when(
-            mockUser.powerLevel,
-          ).thenReturn(PowerLevel(DefaultPowerLevelMember.moderator.powerLevel));
+          when(mockUser.powerLevel).thenReturn(
+            PowerLevel(DefaultPowerLevelMember.moderator.powerLevel),
+          );
           when(mockUser.id).thenReturn('@mod:server.com');
           when(mockUser.room).thenReturn(mockRoom);
           when(mockUser.ban()).thenAnswer((_) async {});
@@ -469,9 +469,9 @@ void main() {
           when(mockException.error).thenReturn(MatrixError.M_FORBIDDEN);
 
           when(mockUser.canBan).thenReturn(true);
-          when(
-            mockUser.powerLevel,
-          ).thenReturn(PowerLevel(DefaultPowerLevelMember.moderator.powerLevel));
+          when(mockUser.powerLevel).thenReturn(
+            PowerLevel(DefaultPowerLevelMember.moderator.powerLevel),
+          );
           when(mockUser.id).thenReturn('@mod:server.com');
           when(mockUser.room).thenReturn(mockRoom);
           when(mockUser.ban()).thenAnswer((_) async {});

--- a/test/domain/usecase/room/ban_user_interactor_test.dart
+++ b/test/domain/usecase/room/ban_user_interactor_test.dart
@@ -67,7 +67,7 @@ void main() {
         when(mockUser.canBan).thenReturn(true);
         when(
           mockUser.powerLevel,
-        ).thenReturn(DefaultPowerLevelMember.member.powerLevel);
+        ).thenReturn(PowerLevel(DefaultPowerLevelMember.member.powerLevel));
         when(mockUser.ban()).thenAnswer((_) async {});
 
         // Act
@@ -101,7 +101,7 @@ void main() {
         when(mockUser.canBan).thenReturn(true);
         when(
           mockUser.powerLevel,
-        ).thenReturn(DefaultPowerLevelMember.member.powerLevel);
+        ).thenReturn(PowerLevel(DefaultPowerLevelMember.member.powerLevel));
         final mockException = MockMatrixException();
         when(mockException.error).thenReturn(MatrixError.M_FORBIDDEN);
         when(mockUser.ban()).thenThrow(mockException);
@@ -136,7 +136,7 @@ void main() {
         when(mockUser.canBan).thenReturn(true);
         when(
           mockUser.powerLevel,
-        ).thenReturn(DefaultPowerLevelMember.member.powerLevel);
+        ).thenReturn(PowerLevel(DefaultPowerLevelMember.member.powerLevel));
         final mockException = MockMatrixException();
         when(mockException.error).thenReturn(MatrixError.M_UNKNOWN);
         when(mockUser.ban()).thenThrow(mockException);
@@ -169,7 +169,7 @@ void main() {
       when(mockUser.canBan).thenReturn(true);
       when(
         mockUser.powerLevel,
-      ).thenReturn(DefaultPowerLevelMember.member.powerLevel);
+      ).thenReturn(PowerLevel(DefaultPowerLevelMember.member.powerLevel));
       final exception = Exception('Something went wrong');
       when(mockUser.ban()).thenThrow(exception);
 
@@ -215,7 +215,7 @@ void main() {
           when(mockUser.canBan).thenReturn(true);
           when(
             mockUser.powerLevel,
-          ).thenReturn(DefaultPowerLevelMember.moderator.powerLevel);
+          ).thenReturn(PowerLevel(DefaultPowerLevelMember.moderator.powerLevel));
           when(mockUser.id).thenReturn('@user:server.com');
           when(mockUser.room).thenReturn(mockRoom);
           when(mockUser.ban()).thenAnswer((_) async {});
@@ -283,7 +283,7 @@ void main() {
           when(mockUser.canBan).thenReturn(true);
           when(
             mockUser.powerLevel,
-          ).thenReturn(DefaultPowerLevelMember.admin.powerLevel);
+          ).thenReturn(PowerLevel(DefaultPowerLevelMember.admin.powerLevel));
           when(mockUser.id).thenReturn('@admin:server.com');
           when(mockUser.room).thenReturn(mockRoom);
           when(mockUser.ban()).thenAnswer((_) async {});
@@ -345,7 +345,7 @@ void main() {
           when(mockUser.canBan).thenReturn(true);
           when(
             mockUser.powerLevel,
-          ).thenReturn(DefaultPowerLevelMember.moderator.powerLevel);
+          ).thenReturn(PowerLevel(DefaultPowerLevelMember.moderator.powerLevel));
           when(mockUser.id).thenReturn('@mod:server.com');
           when(mockUser.room).thenReturn(mockRoom);
           when(mockUser.ban()).thenAnswer((_) async {});
@@ -387,7 +387,7 @@ void main() {
           when(mockUser.canBan).thenReturn(true);
           when(
             mockUser.powerLevel,
-          ).thenReturn(DefaultPowerLevelMember.member.powerLevel);
+          ).thenReturn(PowerLevel(DefaultPowerLevelMember.member.powerLevel));
           when(mockUser.ban()).thenAnswer((_) async {});
 
           // Act
@@ -425,7 +425,7 @@ void main() {
           when(mockUser.canBan).thenReturn(true);
           when(
             mockUser.powerLevel,
-          ).thenReturn(DefaultPowerLevelMember.guest.powerLevel);
+          ).thenReturn(PowerLevel(DefaultPowerLevelMember.guest.powerLevel));
           when(mockUser.ban()).thenAnswer((_) async {});
 
           // Act
@@ -471,7 +471,7 @@ void main() {
           when(mockUser.canBan).thenReturn(true);
           when(
             mockUser.powerLevel,
-          ).thenReturn(DefaultPowerLevelMember.moderator.powerLevel);
+          ).thenReturn(PowerLevel(DefaultPowerLevelMember.moderator.powerLevel));
           when(mockUser.id).thenReturn('@mod:server.com');
           when(mockUser.room).thenReturn(mockRoom);
           when(mockUser.ban()).thenAnswer((_) async {});

--- a/test/utils/test_client.dart
+++ b/test/utils/test_client.dart
@@ -9,7 +9,7 @@ Future<Client> prepareTestClient({
 }) async {
   homeserver ??= Uri.parse('https://fakeserver.notexisting');
   final client = await getClient();
-  await client.checkHomeserver(homeserver);
+  await client.checkHomeserver(homeserver, checkWellKnown: false);
   if (loggedIn) {
     await client.login(
       LoginType.mLoginToken,


### PR DESCRIPTION
Upgrades Matrix Dart SDK v6.0.0 → v7.1.2 and flutter_vodozemac v0.4.0 → v0.5.0. 

##Key Changes
- PowerLevel type — SDK changed power levels from int to a PowerLevel class. All comparisons and sorts updated throughout the app.
- sendingFilePlaceholders removed — Replaced with a self-managed global map in room_extension.dart; affected files re-import from there.
- New oidcClientId param — DatabaseApi.insertClient gained an OIDC client ID field; Hive databases and mock updated accordingly.
- Search result fix — Search now applies the latest edit to original events and filters out duplicate edit events from results.
- Test fix — Added checkWellKnown: false to prepareTestClient() to prevent JSON parse crash against the fake server. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file upload placeholder tracking for improved upload state management.

* **Bug Fixes**
  * Fixed voice message placeholder not being removed on send failure.
  * Improved handling of edited message content extraction and display.

* **Chores**
  * Updated Matrix SDK dependency to 7.1.2.
  * Updated encryption library to 0.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->