### PR TITLE
bump version + update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [2.22.2] - 2026-05-21
+### Changed
+- TW-2940: Widen iOS navigation
+- TW-3047: Optimize video playback performance with hardware acceleration and improved player initialization
+- TW-3018: Highlight only message bubble, not unread divider
+- TW-1707: Update git URLs in pubspec files to use HTTPS
+
+### Fixed
+- TW-3038: Exclude edit events to prevent duplicate search results for edited messages
+- TW-3037: Actually cancel stream subscriptions in dispose()
+- TW-3037: Advance read marker past hidden trailing events
+- TW-3019: Ignore refreshing_last_event placeholder in chat list date
+- TW-3043: Fix interaction with errored messages
+
+### Performance
+- Byte budget for image cache, fix video thumbnail rebuild, mounted guards
+
+### Tests
+- Upgrade Patrol to 4.5.0 for Web support
+
 ## [2.22.1] - 2026-05-06
 ### Changed
 - TW-3020: Simplify hover handling in chat events

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.22.1+2330
+version: 2.22.2+2330
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
## Changelog v2.22.2

### Changed
- [TW-2940](https://github.com/linagora/twake-on-matrix/issues/2940): Widen iOS navigation
- [TW-3047](https://github.com/linagora/twake-on-matrix/issues/3047): Optimize video playback performance with hardware acceleration and improved player initialization
- [TW-3018](https://github.com/linagora/twake-on-matrix/issues/3018): Highlight only message bubble, not unread divider
- [TW-1707](https://github.com/linagora/twake-on-matrix/issues/1707): Update git URLs in pubspec files to use HTTPS

### Fixed
- [TW-3038](https://github.com/linagora/twake-on-matrix/issues/3038): Exclude edit events to prevent duplicate search results for edited messages
- [TW-3037](https://github.com/linagora/twake-on-matrix/issues/3037): Actually cancel stream subscriptions in dispose()
- [TW-3037](https://github.com/linagora/twake-on-matrix/issues/3037): Advance read marker past hidden trailing events
- [TW-3019](https://github.com/linagora/twake-on-matrix/issues/3019): Ignore refreshing_last_event placeholder in chat list date
- [TW-3043](https://github.com/linagora/twake-on-matrix/issues/3043): Fix interaction with errored messages

### Performance
- Byte budget for image cache, fix video thumbnail rebuild, mounted guards ([#2987](https://github.com/linagora/twake-on-matrix/pull/2987))

### Tests
- Upgrade Patrol to 4.5.0 for Web support ([#3009](https://github.com/linagora/twake-on-matrix/pull/3009))