### PR TITLE
fix: replace global image cache clear with room-scoped eviction

### DIFF
--- a/lib/data/memory/mxc_image_cache_manager.dart
+++ b/lib/data/memory/mxc_image_cache_manager.dart
@@ -44,6 +44,23 @@ class MxcImageCacheManager {
     return data;
   }
 
+  static String roomScopedKey(String roomId, String key) => '$roomId/$key';
+
+  void evictRoom(String roomId) {
+    final prefix = '$roomId/';
+    final toRemove = _imageCache.keys
+        .where((k) => k.startsWith(prefix))
+        .toList(growable: false);
+    for (final key in toRemove) {
+      _totalBytes -= _imageCache[key]!.length;
+      _imageCache.remove(key);
+    }
+    assert(
+      _totalBytes == _imageCache.values.fold<int>(0, (s, e) => s + e.length),
+      'MxcImageCacheManager: _totalBytes drifted after evictRoom',
+    );
+  }
+
   void clear() {
     _imageCache.clear();
     _totalBytes = 0;

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -3813,9 +3813,7 @@ class ChatController extends State<Chat>
     // once MXC image providers are tracked at the room level.
     PaintingBinding.instance.imageCache.clear();
     PaintingBinding.instance.imageCache.clearLiveImages();
-    // Global clear is acceptable: only one ChatController is active at a time.
-    // TODO: replace with room-scoped eviction if multi-room layout is added.
-    MxcImageCacheManager.instance.clear();
+    MxcImageCacheManager.instance.evictRoom(widget.roomId);
 
     inputFocus.dispose();
     searchEmojiFocusNode.dispose();

--- a/test/data/memory/mxc_image_cache_manager_test.dart
+++ b/test/data/memory/mxc_image_cache_manager_test.dart
@@ -188,21 +188,15 @@ void main() {
 
       expect(manager.getImage('mxc://server/avatar'), equals(avatar));
       expect(
-        manager.getImage(
-          MxcImageCacheManager.roomScopedKey('!roomA', 'ev1'),
-        ),
+        manager.getImage(MxcImageCacheManager.roomScopedKey('!roomA', 'ev1')),
         isNull,
       );
       expect(
-        manager.getImage(
-          MxcImageCacheManager.roomScopedKey('!roomA', 'ev2'),
-        ),
+        manager.getImage(MxcImageCacheManager.roomScopedKey('!roomA', 'ev2')),
         isNull,
       );
       expect(
-        manager.getImage(
-          MxcImageCacheManager.roomScopedKey('!roomB', 'ev3'),
-        ),
+        manager.getImage(MxcImageCacheManager.roomScopedKey('!roomB', 'ev3')),
         equals(img3),
       );
     });

--- a/test/data/memory/mxc_image_cache_manager_test.dart
+++ b/test/data/memory/mxc_image_cache_manager_test.dart
@@ -163,5 +163,48 @@ void main() {
       final cachedImage = manager.getImage(eventId);
       expect(cachedImage, equals(imageData3));
     });
+
+    test('evictRoom removes only room-scoped entries', () {
+      final avatar = Uint8List.fromList([1, 2]);
+      final img1 = Uint8List.fromList([3, 4]);
+      final img2 = Uint8List.fromList([5, 6]);
+      final img3 = Uint8List.fromList([7, 8]);
+
+      manager.cacheImage('mxc://server/avatar', avatar);
+      manager.cacheImage(
+        MxcImageCacheManager.roomScopedKey('!roomA', 'ev1'),
+        img1,
+      );
+      manager.cacheImage(
+        MxcImageCacheManager.roomScopedKey('!roomA', 'ev2'),
+        img2,
+      );
+      manager.cacheImage(
+        MxcImageCacheManager.roomScopedKey('!roomB', 'ev3'),
+        img3,
+      );
+
+      manager.evictRoom('!roomA');
+
+      expect(manager.getImage('mxc://server/avatar'), equals(avatar));
+      expect(
+        manager.getImage(
+          MxcImageCacheManager.roomScopedKey('!roomA', 'ev1'),
+        ),
+        isNull,
+      );
+      expect(
+        manager.getImage(
+          MxcImageCacheManager.roomScopedKey('!roomA', 'ev2'),
+        ),
+        isNull,
+      );
+      expect(
+        manager.getImage(
+          MxcImageCacheManager.roomScopedKey('!roomB', 'ev3'),
+        ),
+        equals(img3),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #3061 — chat avatars disappear in chat list after navigating back from a room.

- **Root cause**: `MxcImageCacheManager.instance.clear()` in `ChatController.dispose()` wiped the entire global byte cache, including avatars (`mxc://` keys) and chat-list preview images (`eventId` keys) that were not loaded by the chat timeline.
- **Fix**: Replace `clear()` with `evictRoom(widget.roomId)` which only removes entries keyed with a `roomId/` prefix. Since no call sites currently use room-scoped keys, this is effectively a no-op (no entries match), preserving all cached avatars and previews. The `roomScopedKey()` helper is available for future use if timeline images are cached globally.
- Added `_totalBytes` drift assertion in `evictRoom()` for consistency with `cacheImage()`.

## Test plan

- [x] `evictRoom` unit test: verifies only room-prefixed entries are removed while avatars and other rooms are preserved
- [ ] Manual: open app → enter a room → navigate back → verify avatars remain visible in chat list
- [ ] Manual: scroll through a media-heavy room → navigate back → verify no OOM regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced image cache management when navigating between chats. Cached images from other rooms are now preserved instead of being globally cleared, reducing unnecessary memory operations and improving app responsiveness when switching between conversations.

* **Tests**
  * Added comprehensive test coverage for room-specific image cache eviction to ensure cached images are properly managed per room.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3062?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->