### PR TITLE
TW-3052: UI changes

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -77,7 +77,7 @@ abstract class AppConfig {
       responsive.isMobile(context) ? 48 : 56;
   static const Color chatColor = primaryColor;
   static Color colorSchemeSeed = primaryColor;
-  static const double messageFontSize = 17.0;
+  static const double messageFontSize = 14.0;
   static const bool allowOtherHomeservers = true;
   static const bool enableRegistration = true;
   static const Color primaryColor = Color.fromARGB(255, 135, 103, 172);

--- a/lib/pages/chat/chat_view_body_style.dart
+++ b/lib/pages/chat/chat_view_body_style.dart
@@ -10,8 +10,6 @@ class ChatViewBodyStyle {
   static double bottomSheetPadding(BuildContext context) =>
       TwakeThemes.isColumnMode(context) ? 16.0 : 8.0;
 
-  static double chatScreenMaxWidth = 800.0;
-
   static double dividerSize = 1.0;
 
   static double blockedUserBannerHeight = 40.0;

--- a/lib/pages/chat/events/formatted_text_widget.dart
+++ b/lib/pages/chat/events/formatted_text_widget.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pages/chat/events/html_message.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
@@ -26,7 +27,11 @@ class FormattedTextWidget extends StatelessWidget {
 
     return HtmlMessage(
       html: html,
-      defaultTextStyle: Theme.of(context).textTheme.bodyLarge,
+      defaultTextStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+        fontSize: AppConfig.messageFontSize * AppConfig.fontSizeFactor,
+        height: 18 / AppConfig.messageFontSize,
+        fontWeight: FontWeight.w400,
+      ),
       linkStyle: linkStyle,
       room: event.room,
       emoteSize: bigEmotes ? fontSize * 3 : fontSize * 1.5,

--- a/lib/pages/chat/events/message/bubble_tail.dart
+++ b/lib/pages/chat/events/message/bubble_tail.dart
@@ -1,0 +1,132 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+enum BubbleTailDirection { none, left, right }
+
+class BubbleShape extends ShapeBorder {
+  final BorderRadius borderRadius;
+  final BorderSide side;
+  final BubbleTailDirection tailDirection;
+
+  const BubbleShape({
+    this.borderRadius = const BorderRadius.all(Radius.circular(16)),
+    this.side = BorderSide.none,
+    this.tailDirection = BubbleTailDirection.none,
+  });
+
+  @override
+  EdgeInsetsGeometry get dimensions => EdgeInsets.zero;
+
+  @override
+  ShapeBorder scale(double t) => BubbleShape(
+    borderRadius: borderRadius * t,
+    side: side.scale(t),
+    tailDirection: tailDirection,
+  );
+
+  @override
+  Path getInnerPath(Rect rect, {TextDirection? textDirection}) =>
+      _buildPath(rect.deflate(side.width));
+
+  @override
+  Path getOuterPath(Rect rect, {TextDirection? textDirection}) =>
+      _buildPath(rect);
+
+  @override
+  void paint(Canvas canvas, Rect rect, {TextDirection? textDirection}) {
+    if (side.style == BorderStyle.solid && side.width > 0) {
+      canvas.drawPath(
+        getOuterPath(rect, textDirection: textDirection),
+        side.toPaint()
+          ..strokeJoin = StrokeJoin.round
+          ..strokeCap = StrokeCap.round,
+      );
+    }
+  }
+
+  Path _buildPath(Rect rect) {
+    final hasLeft = tailDirection == BubbleTailDirection.left;
+    final hasRight = tailDirection == BubbleTailDirection.right;
+    final bubbleRect = Offset.zero & rect.size;
+    final bubblePath = Path()..addRRect(borderRadius.toRRect(bubbleRect));
+
+    if (tailDirection == BubbleTailDirection.none) {
+      return bubblePath.shift(rect.topLeft);
+    }
+
+    final tailPath = _tailPath(
+      anchorX: hasRight ? bubbleRect.right : bubbleRect.left,
+      anchorY: bubbleRect.bottom,
+      mirrored: hasLeft,
+    );
+
+    return Path.combine(
+      PathOperation.union,
+      bubblePath,
+      tailPath,
+    ).shift(rect.topLeft);
+  }
+
+  static Path _tailPath({
+    required double anchorX,
+    required double anchorY,
+    required bool mirrored,
+  }) {
+    final s = mirrored ? -1.0 : 1.0;
+    double x(double designX) => anchorX + (designX - 9) * s;
+    double y(double designY) => anchorY + (designY - 19);
+
+    final path = ui.Path()..moveTo(x(9), y(11.5166));
+    path.cubicTo(
+      x(9.75872),
+      y(13.7447), //
+      x(11.0429),
+      y(15.8486), //
+      x(13.1611),
+      y(18.1309),
+    );
+    path.cubicTo(
+      x(13.464),
+      y(18.4574), //
+      x(13.2403),
+      y(18.9997), //
+      x(12.7949),
+      y(18.9922),
+    );
+    path.cubicTo(
+      x(9.40352),
+      y(18.9347), //
+      x(3.38509),
+      y(18.4463), //
+      x(0.22168),
+      y(14.3027),
+    );
+    path.cubicTo(
+      x(0.153575),
+      y(14.2134), //
+      x(0.121483),
+      y(14.1064), //
+      x(0.125),
+      y(14),
+    );
+    path.lineTo(x(0), y(14));
+    path.lineTo(x(0), y(0));
+    path.lineTo(x(9), y(0));
+    path.close();
+    return path;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is BubbleShape &&
+        other.borderRadius == borderRadius &&
+        other.side == side &&
+        other.tailDirection == tailDirection;
+  }
+
+  @override
+  int get hashCode => Object.hash(borderRadius, side, tailDirection);
+}

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -263,6 +263,7 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
           event: widget.event,
           matrixState: widget.matrixState,
           nextEvent: widget.nextEvent,
+          previousEvent: widget.previousEvent,
           onSelect: widget.onSelect,
           scrollToEventId: widget.scrollToEventId,
           selected: widget.selected,

--- a/lib/pages/chat/events/message/message_container.dart
+++ b/lib/pages/chat/events/message/message_container.dart
@@ -1,5 +1,4 @@
 import 'package:scroll_to_index/scroll_to_index.dart';
-import 'package:fluffychat/pages/chat/chat_view_body_style.dart';
 import 'package:fluffychat/pages/chat/events/message/message.dart';
 import 'package:fluffychat/pages/chat/events/message/message_selected_widget.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
@@ -39,6 +38,20 @@ class MessageContainer extends StatelessWidget {
     this.scrollIndex,
   });
 
+  EdgeInsetsDirectional _rowPadding(BuildContext context) {
+    const double sidePadding = 16.0;
+    final isMobile = Message.responsiveUtils.isMobile(context);
+    final selectedWidgetLeftPadding = isMobile ? 8.0 : 0.0;
+
+    if (event.shouldAlignOwnMessageInDifferentSide) {
+      return const EdgeInsetsDirectional.only(end: sidePadding);
+    }
+    return EdgeInsetsDirectional.only(
+      start: sidePadding - selectedWidgetLeftPadding,
+      end: sidePadding,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final container = MultiPlatformsMessageContainer(
@@ -49,11 +62,7 @@ class MessageContainer extends StatelessWidget {
         }
       },
       child: Container(
-        constraints: BoxConstraints(
-          maxWidth: ChatViewBodyStyle.chatScreenMaxWidth,
-        ),
         padding: MessageStyle.paddingMessage,
-        alignment: Alignment.bottomCenter,
         child: SwipeableMessage(
           event: event,
           onSwipe: onSwipe,
@@ -62,15 +71,7 @@ class MessageContainer extends StatelessWidget {
             onTap: () => onSelect!(event),
             isEnabled: selectMode && event.status.isAvailable,
             child: OptionalPadding(
-              padding: EdgeInsetsDirectional.only(
-                end:
-                    event.isOwnMessage ||
-                        Message.responsiveUtils.isDesktop(context)
-                    ? 8.0
-                    : 16.0,
-                top: 1.0,
-                bottom: 1.0,
-              ),
+              padding: _rowPadding(context),
               isEnabled: !selected,
               child: MessageSelectedWidget(
                 event: event,

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/pages/chat/chat_horizontal_action_menu.dart';
+import 'package:fluffychat/pages/chat/events/message/bubble_tail.dart';
 import 'package:fluffychat/pages/chat/events/message/display_name_widget.dart';
 import 'package:fluffychat/pages/chat/events/message/message.dart';
 import 'package:fluffychat/pages/chat/events/message/message_content_builder.dart';
@@ -38,6 +39,7 @@ class MessageContentWithTimestampBuilder extends StatefulWidget {
   final Event event;
   final MatrixState? matrixState;
   final Event? nextEvent;
+  final Event? previousEvent;
   final void Function(Event)? onSelect;
   final void Function(String)? scrollToEventId;
   final void Function()? onDisplayEmojiReaction;
@@ -78,6 +80,7 @@ class MessageContentWithTimestampBuilder extends StatefulWidget {
     required this.event,
     this.matrixState,
     this.nextEvent,
+    this.previousEvent,
     this.onSelect,
     this.scrollToEventId,
     this.onDisplayEmojiReaction,
@@ -211,6 +214,11 @@ class _MessageContentWithTimestampBuilderState
               widget.nextEvent,
               widget.event,
               widget.selected,
+              nextEventHasReaction:
+                  widget.nextEvent?.hasReactionEvent(
+                    timeline: widget.timeline,
+                  ) ??
+                  false,
             ),
             child: MultiPlatformSelectionMode(
               event: widget.event,
@@ -283,7 +291,7 @@ class _MessageContentWithTimestampBuilderState
                     : _responsiveUtils.isMobile(context)
                     ? LinagoraSysColors.material().onPrimary
                     : Theme.of(context).colorScheme.surfaceContainerHighest,
-                shape: RoundedRectangleBorder(
+                shape: const RoundedRectangleBorder(
                   borderRadius: MessageStyle.bubbleBorderRadius,
                 ),
                 child: Container(
@@ -360,7 +368,7 @@ class _MessageContentWithTimestampBuilderState
                     : _responsiveUtils.isMobile(context)
                     ? LinagoraSysColors.material().onPrimary
                     : Theme.of(context).colorScheme.surfaceContainerHighest,
-                shape: RoundedRectangleBorder(
+                shape: const RoundedRectangleBorder(
                   borderRadius: MessageStyle.bubbleBorderRadius,
                 ),
                 child: Container(
@@ -517,6 +525,39 @@ class _MessageContentWithTimestampBuilderState
       timeline: widget.timeline,
     );
 
+    final isDisplayOnlyEmoji = widget.event.isDisplayOnlyEmoji(widget.timeline);
+    final Color bubbleColor = widget.event.isOwnMessage
+        ? LinagoraRefColors.material().primary[95]!
+        : _responsiveUtils.isMobile(context)
+        ? LinagoraSysColors.material().onPrimary
+        : Theme.of(context).colorScheme.surfaceContainerHighest;
+
+    final hasSameSenderBelow =
+        widget.previousEvent != null &&
+        widget.previousEvent!.senderId == widget.event.senderId;
+    final hasSameSenderAbove =
+        widget.nextEvent != null &&
+        widget.nextEvent!.senderId == widget.event.senderId;
+
+    final showTail = !isDisplayOnlyEmoji && !noBubble && !hasSameSenderBelow;
+
+    final hasReceivedBorder =
+        enableBorder &&
+        !widget.event.isOwnMessage &&
+        _responsiveUtils.isMobile(context);
+
+    final tailDirection = showTail
+        ? (widget.event.isOwnMessage
+              ? BubbleTailDirection.right
+              : BubbleTailDirection.left)
+        : BubbleTailDirection.none;
+
+    final bubbleBorderRadius = MessageStyle.groupedBubbleBorderRadius(
+      isOwnMessage: widget.event.isOwnMessage,
+      hasSameSenderAbove: hasSameSenderAbove,
+      hasSameSenderBelow: hasSameSenderBelow,
+    );
+
     return OptionalStack(
       key: key,
       alignment: widget.event.isOwnMessage
@@ -524,82 +565,82 @@ class _MessageContentWithTimestampBuilderState
           : AlignmentDirectional.bottomEnd,
       isEnabled: hasReactionEvent,
       children: [
-        Container(
-          decoration: widget.event.isDisplayOnlyEmoji(widget.timeline)
-              ? null
-              : BoxDecoration(
-                  borderRadius: MessageStyle.bubbleBorderRadius,
-                  color: widget.event.isOwnMessage
-                      ? LinagoraRefColors.material().primary[95]
-                      : _responsiveUtils.isMobile(context)
-                      ? LinagoraSysColors.material().onPrimary
-                      : Theme.of(context).colorScheme.surfaceContainerHighest,
-                  border: enableBorder
-                      ? (!widget.event.isOwnMessage &&
-                                _responsiveUtils.isMobile(context)
-                            ? Border.all(
-                                color: MessageStyle.borderColorReceivedBubble,
-                              )
-                            : null)
-                      : null,
-                ),
-          padding:
-              paddingBubble ??
-              (noBubble
-                  ? const .symmetric(horizontal: 16.0)
-                  : MessageStyle.paddingMessageContentBuilder(widget.event)),
-          constraints: BoxConstraints(
-            maxWidth: MessageStyle.messageBubbleWidth(
-              context,
-              event: widget.event,
-              maxWidthScreen: widget.maxWidth,
-            ),
-          ),
-          margin: hasReactionEvent ? const .only(bottom: 24) : null,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (!_hideDisplayName(context))
-                OptionalSelectionContainerDisabled(
-                  isEnabled: PlatformInfos.isWeb,
-                  child: DisplayNameWidget(event: widget.event),
-                ),
-              OptionalStack(
-                isEnabled: timelineText,
-                alignment: AlignmentDirectional.bottomEnd,
-                children: [
-                  MessageContentBuilder(
-                    event: widget.event,
-                    timeline: widget.timeline,
-                    onSelect: widget.onSelect,
-                    nextEvent: widget.nextEvent,
-                    scrollToEventId: widget.scrollToEventId,
-                    selectMode: widget.selectMode,
-                    onRetryTextMessage: widget.onRetryTextMessage,
+        Padding(
+          padding: hasReactionEvent
+              ? const EdgeInsets.only(bottom: 24)
+              : EdgeInsets.zero,
+          child: Container(
+            decoration: isDisplayOnlyEmoji
+                ? null
+                : ShapeDecoration(
+                    color: bubbleColor,
+                    shape: BubbleShape(
+                      borderRadius: bubbleBorderRadius,
+                      side: hasReceivedBorder
+                          ? const BorderSide(
+                              color: MessageStyle.borderColorReceivedBubble,
+                            )
+                          : BorderSide.none,
+                      tailDirection: tailDirection,
+                    ),
                   ),
-                  if (!widget.event.isReplyEventWithAudio())
-                    OptionalSelectionContainerDisabled(
-                      isEnabled: PlatformInfos.isWeb,
-                      child: Padding(
-                        padding: MessageStyle.paddingMessageTime,
-                        child: Text.rich(
-                          WidgetSpan(
-                            child: MessageTime(
-                              timelineOverlayMessage:
-                                  widget.event.timelineOverlayMessage,
-                              room: widget.event.room,
-                              event: widget.event,
-                              showSeenIcon: widget.event.isOwnMessage,
-                              timeline: widget.timeline,
-                              onRetryTextMessage: widget.onRetryTextMessage,
+            padding:
+                paddingBubble ??
+                (noBubble
+                    ? const EdgeInsets.symmetric(horizontal: 16.0)
+                    : MessageStyle.paddingMessageContentBuilder(widget.event)),
+            constraints: BoxConstraints(
+              maxWidth: MessageStyle.messageBubbleWidth(
+                context,
+                event: widget.event,
+                maxWidthScreen: widget.maxWidth,
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (!_hideDisplayName(context))
+                  OptionalSelectionContainerDisabled(
+                    isEnabled: PlatformInfos.isWeb,
+                    child: DisplayNameWidget(event: widget.event),
+                  ),
+                OptionalStack(
+                  isEnabled: timelineText,
+                  alignment: AlignmentDirectional.bottomEnd,
+                  children: [
+                    MessageContentBuilder(
+                      event: widget.event,
+                      timeline: widget.timeline,
+                      onSelect: widget.onSelect,
+                      nextEvent: widget.nextEvent,
+                      scrollToEventId: widget.scrollToEventId,
+                      selectMode: widget.selectMode,
+                      onRetryTextMessage: widget.onRetryTextMessage,
+                    ),
+                    if (!widget.event.isReplyEventWithAudio())
+                      OptionalSelectionContainerDisabled(
+                        isEnabled: PlatformInfos.isWeb,
+                        child: Padding(
+                          padding: MessageStyle.paddingMessageTime,
+                          child: Text.rich(
+                            WidgetSpan(
+                              child: MessageTime(
+                                timelineOverlayMessage:
+                                    widget.event.timelineOverlayMessage,
+                                room: widget.event.room,
+                                event: widget.event,
+                                showSeenIcon: widget.event.isOwnMessage,
+                                timeline: widget.timeline,
+                                onRetryTextMessage: widget.onRetryTextMessage,
+                              ),
                             ),
                           ),
                         ),
                       ),
-                    ),
-                ],
-              ),
-            ],
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
         PositionedDirectional(
@@ -671,7 +712,7 @@ class _MessageContentWithTimestampBuilderState
         child: Container(
           decoration: BoxDecoration(
             color: Colors.transparent,
-            borderRadius: .circular(24),
+            borderRadius: BorderRadius.circular(24),
           ),
           alignment: isReversed
               ? AlignmentDirectional.centerEnd
@@ -681,7 +722,7 @@ class _MessageContentWithTimestampBuilderState
               : const EdgeInsetsDirectional.only(start: 8),
           child: OverflowView.flexible(
             reverse: !isReversed,
-            spacing: 8,
+            spacing: 16,
             builder: (context, remainingItemCount) {
               someHorizontalActionHidden = remainingItemCount != 0;
               return const SizedBox();
@@ -707,6 +748,7 @@ class _MessageContentWithTimestampBuilderState
                 },
                 icon: item.action.getIcon(),
                 imagePath: item.action.getImagePath(),
+                paddingAll: 4,
                 tooltip: item.action.getTitle(context),
                 preferBelow: false,
               );

--- a/lib/pages/chat/events/message/message_selected_widget.dart
+++ b/lib/pages/chat/events/message/message_selected_widget.dart
@@ -1,4 +1,3 @@
-import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/pages/chat/events/message/message.dart';
 import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
 import 'package:flutter/material.dart';
@@ -26,9 +25,6 @@ class MessageSelectedWidget extends StatelessWidget {
         left: Message.responsiveUtils.isMobile(context) ? 8.0 : 0,
       ),
       color: Theme.of(context).primaryColor.withAlpha(0),
-      constraints: const BoxConstraints(
-        maxWidth: TwakeThemes.columnWidth * 2.5,
-      ),
       child: Row(
         mainAxisSize: MainAxisSize.max,
         children: [

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -14,10 +14,38 @@ class MessageStyle {
   static ResponsiveUtils responsiveUtils = getIt.get<ResponsiveUtils>();
 
   static const double heightDivider = 1.0;
-  static final bubbleBorderRadius = BorderRadius.circular(16);
+  static const Radius bubbleRadius = Radius.circular(16);
+  static const Radius bubbleGroupedRadius = Radius.circular(8);
+  static const bubbleBorderRadius = BorderRadius.all(bubbleRadius);
+
+  static BorderRadius groupedBubbleBorderRadius({
+    required bool isOwnMessage,
+    required bool hasSameSenderAbove,
+    required bool hasSameSenderBelow,
+  }) {
+    final tailSideTop = hasSameSenderAbove ? bubbleGroupedRadius : bubbleRadius;
+    final tailSideBottom = hasSameSenderBelow
+        ? bubbleGroupedRadius
+        : bubbleRadius;
+    if (isOwnMessage) {
+      return BorderRadius.only(
+        topLeft: bubbleRadius,
+        bottomLeft: bubbleRadius,
+        topRight: tailSideTop,
+        bottomRight: tailSideBottom,
+      );
+    }
+    return BorderRadius.only(
+      topRight: bubbleRadius,
+      bottomRight: bubbleRadius,
+      topLeft: tailSideTop,
+      bottomLeft: tailSideBottom,
+    );
+  }
+
   static final errorStatusPlaceHolderWidth = 16 * AppConfig.bubbleSizeFactor;
   static final errorStatusPlaceHolderHeight = 16 * AppConfig.bubbleSizeFactor;
-  static const double avatarSize = 40;
+  static const double avatarSize = 36;
   static const double fontSize = 15;
   static const notSameSenderPadding = EdgeInsets.only(left: 8.0, bottom: 4);
 
@@ -64,7 +92,7 @@ class MessageStyle {
       Theme.of(context).colorScheme.surfaceTint.withOpacity(0.08);
 
   static const double messageBubbleDesktopMaxWidth = 520.0;
-  static const double messageBubbleMobileRatioMaxWidth = 0.80;
+  static const double messageBubbleMobileRatioMaxWidth = 0.88;
   static const double messageBubbleTabletRatioMaxWidth = 0.30;
   static const double iconContextMenuSize = 40;
 
@@ -204,25 +232,32 @@ class MessageStyle {
   static double messageSpacing(
     bool displayTime,
     Event? nextEvent,
-    Event currentEvent,
-  ) {
-    // add spaces to messages only
-    if (nextEvent == null ||
-        displayTime ||
-        nextEvent.type != EventTypes.Message) {
+    Event currentEvent, {
+    bool nextEventHasReaction = false,
+  }) {
+    if (nextEvent == null || displayTime) {
       return 0;
     }
 
-    return currentEvent.senderId != nextEvent.senderId ? 8 : 4;
+    if (nextEvent.shouldHideRedactedEvent()) {
+      return nextEventHasReaction ? 8 : 6;
+    }
+
+    if (nextEvent.type != EventTypes.Message) {
+      return 0;
+    }
+
+    if (currentEvent.senderId == nextEvent.senderId) {
+      return 0;
+    }
+    return nextEventHasReaction ? 8 : 6;
   }
 
-  static EdgeInsets paddingDisplayName(Event event) => EdgeInsets.only(
-    left: event.messageType == MessageTypes.Image ? 0 : 8.0,
-    bottom: 4.0,
-  );
+  static EdgeInsets paddingDisplayName(Event event) =>
+      const EdgeInsets.only(bottom: 4.0);
 
   static EdgeInsets get paddingMessage =>
-      const EdgeInsets.symmetric(vertical: 2.0);
+      const EdgeInsets.symmetric(vertical: 1.0);
 
   static EdgeInsets get paddingTimestamp =>
       const EdgeInsets.only(left: 8.0, right: 4.0);
@@ -237,19 +272,29 @@ class MessageStyle {
     BuildContext context,
     Event? nextEvent,
     Event event,
-    bool selected,
-  ) {
+    bool selected, {
+    bool nextEventHasReaction = false,
+  }) {
+    final needsRightMenuGap =
+        responsiveUtils.isDesktop(context) &&
+        event.shouldDisplayContextMenuInRightBubble;
+    final endPadding = selected || needsRightMenuGap ? 8.0 : 0.0;
     return EdgeInsetsDirectional.only(
-      top: MessageStyle.messageSpacing(displayTime, nextEvent, event),
-      end: selected || responsiveUtils.isDesktop(context) ? 8 : 0,
+      top: MessageStyle.messageSpacing(
+        displayTime,
+        nextEvent,
+        event,
+        nextEventHasReaction: nextEventHasReaction,
+      ),
+      end: endPadding,
     );
   }
 
   static EdgeInsets paddingMessageContentBuilder(Event event) =>
       EdgeInsets.only(
-        left: 8 * AppConfig.bubbleSizeFactor,
-        right: 8 * AppConfig.bubbleSizeFactor,
-        top: 8 * AppConfig.bubbleSizeFactor,
+        left: 10 * AppConfig.bubbleSizeFactor,
+        right: 10 * AppConfig.bubbleSizeFactor,
+        top: 6 * AppConfig.bubbleSizeFactor,
         bottom: event.timelineOverlayMessage
             ? 8 * AppConfig.bubbleSizeFactor
             : 0 * AppConfig.bubbleSizeFactor,
@@ -266,7 +311,7 @@ class MessageStyle {
   static const double pushpinIconSize = 14.0;
 
   static const double paddingAllPushpin = 0;
-  static const Color borderColorReceivedBubble = Color(0xFFEBEDF0);
+  static const Color borderColorReceivedBubble = Color(0xFFE5ECF3);
 
   static MainAxisAlignment messageAlignment(
     Event event,

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -302,15 +302,10 @@ class MessageContent extends StatelessWidget
                 !event.redacted &&
                 event.isRichMessage &&
                 containedLink.isEmpty) {
-              return Padding(
-                padding: MessageContentStyle.emojiPadding,
-                child: FormattedTextWidget(
-                  event: event,
-                  linkStyle: MessageContentStyle.linkStyleMessageContent(
-                    context,
-                  ),
-                  fontSize: fontSize,
-                ),
+              return FormattedTextWidget(
+                event: event,
+                linkStyle: MessageContentStyle.linkStyleMessageContent(context),
+                fontSize: fontSize,
               );
             }
             // else we fall through to the normal message rendering

--- a/lib/pages/chat/events/message_content_style.dart
+++ b/lib/pages/chat/events/message_content_style.dart
@@ -82,8 +82,6 @@ class MessageContentStyle {
     vertical: 4,
   );
 
-  static const EdgeInsets emojiPadding = EdgeInsets.symmetric(horizontal: 8.0);
-
   static TextStyle? linkStyleMessageContent(BuildContext context) =>
       Theme.of(context).textTheme.bodyLarge?.copyWith(
         color: Theme.of(context).colorScheme.secondary,

--- a/lib/pages/chat/events/message_content_style.dart
+++ b/lib/pages/chat/events/message_content_style.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
@@ -86,6 +87,9 @@ class MessageContentStyle {
   static TextStyle? linkStyleMessageContent(BuildContext context) =>
       Theme.of(context).textTheme.bodyLarge?.copyWith(
         color: Theme.of(context).colorScheme.secondary,
+        fontSize: AppConfig.messageFontSize * AppConfig.fontSizeFactor,
+        height: 18 / AppConfig.messageFontSize,
+        fontWeight: FontWeight.w400,
       );
 
   static const blurhashSize = 32;

--- a/lib/pages/chat/events/reply_content_style.dart
+++ b/lib/pages/chat/events/reply_content_style.dart
@@ -61,10 +61,8 @@ class ReplyContentStyle {
     );
   }
 
-  static EdgeInsetsDirectional get marginReplyContent =>
-      EdgeInsetsDirectional.symmetric(
-        vertical: 4.0 * AppConfig.bubbleSizeFactor,
-      );
+  static const EdgeInsetsDirectional marginReplyContent =
+      EdgeInsetsDirectional.only(bottom: 8.0);
 
   static const double replyContainerHeight = 60;
 }

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -320,8 +320,9 @@ extension LocalizedBody on Event {
   TextStyle? getMessageTextStyle(BuildContext context, [Timeline? timeline]) {
     if (redacted) {
       return Theme.of(context).textTheme.bodyLarge?.copyWith(
-        fontSize: 17,
-        height: 24 / 17,
+        fontSize: AppConfig.messageFontSize * AppConfig.fontSizeFactor,
+        height: 18 / AppConfig.messageFontSize,
+        fontWeight: FontWeight.w400,
         color: LinagoraRefColors.material().tertiary[30],
       );
     }
@@ -332,6 +333,9 @@ extension LocalizedBody on Event {
 
     return Theme.of(context).textTheme.bodyLarge?.copyWith(
       color: Theme.of(context).colorScheme.onSurface,
+      fontSize: AppConfig.messageFontSize * AppConfig.fontSizeFactor,
+      height: 18 / AppConfig.messageFontSize,
+      fontWeight: FontWeight.w400,
     );
   }
 

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_view.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_view.dart
@@ -18,7 +18,7 @@ class TwakeLinkView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (firstValidUrl == null) {
-      return _buildMessageBody(context);
+      return body;
     }
 
     return _buildMessageWithPreview(context);
@@ -36,17 +36,8 @@ class TwakeLinkView extends StatelessWidget {
           child: previewItemWidget,
         ),
         const SizedBox(height: TwakeLinkViewStyle.previewToBodySpacing),
-        _buildMessageBody(context),
+        body,
       ],
-    );
-  }
-
-  Widget _buildMessageBody(BuildContext context) {
-    return Padding(
-      padding: isCaption
-          ? EdgeInsets.zero
-          : TwakeLinkViewStyle.paddingMessageBody,
-      child: body,
     );
   }
 }

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_view_style.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_view_style.dart
@@ -5,9 +5,6 @@ import 'package:flutter/material.dart';
 class TwakeLinkViewStyle {
   static ResponsiveUtils responsiveUtils = getIt.get<ResponsiveUtils>();
 
-  static const EdgeInsetsDirectional paddingMessageBody =
-      EdgeInsetsDirectional.symmetric(horizontal: 8.0);
-
   static const EdgeInsetsDirectional paddingCleanRichText =
       EdgeInsetsDirectional.only(start: 8.0, end: 8.0, top: 8.0);
 

--- a/test/pages/chat/events/message/message_content_builder_mixin_test.dart
+++ b/test/pages/chat/events/message/message_content_builder_mixin_test.dart
@@ -155,7 +155,7 @@ Future<void> main() async {
         expect(getSizeForEmptyTextEvent, isA<MessageMetrics>());
         expect(
           getSizeForEmptyTextEvent!.totalMessageWidth,
-          equals(expectedMetrics.totalMessageWidth),
+          closeTo(expectedMetrics.totalMessageWidth, 0.01),
         );
         expect(
           getSizeForEmptyTextEvent!.isNeedAddNewLine,
@@ -180,6 +180,7 @@ Future<void> main() async {
         'GIVEN platform is Web\n'
         'THEN maxWidth for message is 504.0\n', () {
       const messageMaxWidthWeb = 504.0;
+      const webFitsMultilineTotalWidth = 382.97;
       group('GIVEN message type does not require detailed text metrics\n', () {
         testWidgets('GIVEN message type is file\n'
             'THEN return null\n', (WidgetTester tester) async {
@@ -236,7 +237,7 @@ Future<void> main() async {
           );
 
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 421.97491455078125,
+            totalMessageWidth: webFitsMultilineTotalWidth,
             isNeedAddNewLine: false,
           );
 
@@ -256,10 +257,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with name -> Done",
+                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with original file name for media preview -> Done",
               "format": "org.matrix.custom.html",
               "formatted_body":
-                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with name -&gt; Done</p>",
+                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with original file name for media preview -&gt; Done</p>",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -304,8 +305,9 @@ Future<void> main() async {
             originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
             room: room,
           );
+          const displayNameWithPaddingWidth = 238.0;
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 238.0,
+            totalMessageWidth: displayNameWithPaddingWidth,
             isNeedAddNewLine: false,
           );
           await runTest(
@@ -339,7 +341,7 @@ Future<void> main() async {
             room: room,
           );
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 421.97491455078125,
+            totalMessageWidth: webFitsMultilineTotalWidth,
             isNeedAddNewLine: false,
           );
           await runTest(
@@ -361,10 +363,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with name -> Done",
+                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with original file name for media preview -> Done",
               "format": "org.matrix.custom.html",
               "formatted_body":
-                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with name -&gt; Done</p>",
+                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with original file name for media preview -&gt; Done</p>",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -392,6 +394,7 @@ Future<void> main() async {
         'GIVEN platform is Mobile\n'
         'THEN maxWidth for message is 412.0\n', () {
       const messageMaxWidthMobile = 412.0;
+      const mobileFitsMultilineTotalWidth = 257.88;
       group('GIVEN message type does not require detailed text metrics\n', () {
         testWidgets('GIVEN message type is file\n'
             'THEN return null\n', (WidgetTester tester) async {
@@ -439,10 +442,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with name -> Done",
+                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with original file name for media preview -> Done",
               "format": "org.matrix.custom.html",
               "formatted_body":
-                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with name -&gt; Done</p>",
+                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with original file name for media preview -&gt; Done</p>",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -452,7 +455,7 @@ Future<void> main() async {
           );
 
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 398.12469482421875,
+            totalMessageWidth: mobileFitsMultilineTotalWidth,
             isNeedAddNewLine: false,
           );
 
@@ -472,10 +475,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "- Copy/Drop text from LibreOffice files to composer\n- Download PDF file from Chrome viewer\n- Download attachment for mobile\n- Small improvement for Printing email",
+                  "- Copy/Drop text from LibreOffice files to composer\n- Download PDF file from Chrome viewer\n- Download attachment for mobile\n- Small improvement for Printing emails.",
               "format": "org.matrix.custom.html",
               "formatted_body":
-                  "- Copy/Drop text from LibreOffice files to composer<br/>- Download PDF file from Chrome viewer<br/>- Download attachment for mobile<br/>- Small improvement for Printing email",
+                  "- Copy/Drop text from LibreOffice files to composer<br/>- Download PDF file from Chrome viewer<br/>- Download attachment for mobile<br/>- Small improvement for Printing emails.",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -540,10 +543,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with name -> Done",
+                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with original file name for media preview -> Done",
               "format": "org.matrix.custom.html",
               "formatted_body":
-                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with name -&gt; Done</p>",
+                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with original file name for media preview -&gt; Done</p>",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -553,7 +556,7 @@ Future<void> main() async {
           );
 
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 398.12469482421875,
+            totalMessageWidth: mobileFitsMultilineTotalWidth,
             isNeedAddNewLine: false,
           );
 
@@ -575,10 +578,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "- Copy/Drop text from LibreOffice files to composer\n- Download PDF file from Chrome viewer\n- Download attachment for mobile\n- Small improvement for Printing email",
+                  "- Copy/Drop text from LibreOffice files to composer\n- Download PDF file from Chrome viewer\n- Download attachment for mobile\n- Small improvement for Printing emails.",
               "format": "org.matrix.custom.html",
               "formatted_body":
-                  "- Copy/Drop text from LibreOffice files to composer<br/>- Download PDF file from Chrome viewer<br/>- Download attachment for mobile<br/>- Small improvement for Printing email",
+                  "- Copy/Drop text from LibreOffice files to composer<br/>- Download PDF file from Chrome viewer<br/>- Download attachment for mobile<br/>- Small improvement for Printing emails.",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',


### PR DESCRIPTION
## Ticket
Implements #3052

## Known limitations
In some scenarios, 

## Test recommendations
- Navigate inside a timeline in web, mobile to observe changes

## Demos
| Platform | Before | After |
| :--- | :---: | ---: |
| Web | To come | To come |
| Mobile | <img width="375" alt="Capture d’écran 2026-05-20 à 11 17 43" src="https://github.com/user-attachments/assets/633faea7-3cdc-4719-bc13-d30a44d93ab6" /> | <img width="375" alt="Simulator Screenshot - iPhone 17 - 2026-05-22 at 09 06 10" src="https://github.com/user-attachments/assets/3d272d20-e44b-40cc-be3a-a7a3966c70f2" /> |
