### PR TITLE
fix: remove redundant null check for homeserver summary

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -56,6 +56,7 @@ import 'package:future_loading_dialog/future_loading_dialog.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:matrix/encryption.dart';
 import 'package:matrix/matrix.dart';
+
 // ignore: implementation_imports
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:provider/provider.dart';
@@ -232,6 +233,7 @@ class MatrixState extends State<Matrix>
   final CachedStreamController<CachedPresence> onLatestPresenceChanged =
       CachedStreamController();
   StreamSubscription? _presenceSubscription;
+
   void _listenSyncPresence(Client client) {
     _presenceSubscription?.cancel();
     _presenceSubscription = client.onSync.stream.listen((sync) {
@@ -1092,7 +1094,6 @@ class MatrixState extends State<Matrix>
     final newSummary = await newClient
         .checkHomeserver(newClient.homeserver!, checkWellKnown: false)
         .toHomeserverSummary();
-    if (newSummary == null) return;
     if (newSummary.discoveryInformation == null && previousDiscovery != null) {
       loginHomeserverSummary = HomeserverSummary(
         discoveryInformation: previousDiscovery,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved homeserver information handling to ensure consistent population of server configuration data with appropriate fallbacks when discovery information is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->