### PR TITLE
TW-3084: fix broken 'Enable right/left message alignment' option

### DIFF
--- a/lib/pages/chat/events/message/message_container.dart
+++ b/lib/pages/chat/events/message/message_container.dart
@@ -84,9 +84,10 @@ class MessageContainer extends StatelessWidget {
       ),
     );
 
-    // SizedBox forces the Stack to fill the full row width so the highlight
-    // color spans the screen. Positioned.fill paints behind the content
-    // without affecting the message layout.
+    // Outer SizedBox(∞) gives the Stack a bounded width.
+    // Inner SizedBox(∞) wrapping container forces it to fill that width,
+    // overriding Container's tendency to shrink-wrap to its child.
+    // Being non-positioned, it also determines the Stack's height.
     final highlighted = SizedBox(
       width: double.infinity,
       child: Stack(
@@ -97,7 +98,7 @@ class MessageContainer extends StatelessWidget {
                 color: LinagoraSysColors.material().secondaryContainer,
               ),
             ),
-          container,
+          SizedBox(width: double.infinity, child: container),
         ],
       ),
     );

--- a/lib/pages/chat/events/message/message_selected_widget.dart
+++ b/lib/pages/chat/events/message/message_selected_widget.dart
@@ -20,16 +20,18 @@ class MessageSelectedWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // In normal mode, render the message row directly — no wrapper that would
-    // constrain width (maxWidth) or misalign via Align(centerEnd).
+    final bool isMobile = Message.responsiveUtils.isMobile(context);
     final bool showSelectionUI =
         selectMode && (event.redacted || event.status.isAvailable);
-    if (!showSelectionUI) return child;
+    // In normal mode on mobile, preserve the left 8px padding but skip
+    // the selection UI (checkbox + row wrapper).
+    if (!showSelectionUI) {
+      if (!isMobile) return child;
+      return Padding(padding: const EdgeInsets.only(left: 8.0), child: child);
+    }
 
     return Padding(
-      padding: EdgeInsets.only(
-        left: Message.responsiveUtils.isMobile(context) ? 8.0 : 0,
-      ),
+      padding: EdgeInsets.only(left: isMobile ? 8.0 : 0),
       child: Row(
         mainAxisSize: MainAxisSize.max,
         children: [

--- a/lib/pages/chat/events/message/message_selected_widget.dart
+++ b/lib/pages/chat/events/message/message_selected_widget.dart
@@ -1,4 +1,3 @@
-import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/pages/chat/events/message/message.dart';
 import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
 import 'package:flutter/material.dart';
@@ -21,37 +20,34 @@ class MessageSelectedWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    // In normal mode, render the message row directly — no wrapper that would
+    // constrain width (maxWidth) or misalign via Align(centerEnd).
+    final bool showSelectionUI =
+        selectMode && (event.redacted || event.status.isAvailable);
+    if (!showSelectionUI) return child;
+
+    return Padding(
       padding: EdgeInsets.only(
         left: Message.responsiveUtils.isMobile(context) ? 8.0 : 0,
-      ),
-      color: Theme.of(context).primaryColor.withAlpha(0),
-      constraints: const BoxConstraints(
-        maxWidth: TwakeThemes.columnWidth * 2.5,
       ),
       child: Row(
         mainAxisSize: MainAxisSize.max,
         children: [
-          if (selectMode && event.redacted)
-            const SizedBox(width: 20)
-          else if (selectMode && event.status.isAvailable)
-            Align(
-              alignment: AlignmentDirectional.centerStart,
-              child: Icon(
-                selected ? Icons.check_circle_rounded : Icons.circle_outlined,
-                color: selected
-                    ? LinagoraSysColors.material().primary
-                    : Colors.black,
-                size: 20,
-              ),
-            ),
-          Expanded(
-            flex: 9,
-            child: Align(
-              alignment: AlignmentDirectional.centerEnd,
-              child: child,
-            ),
+          SizedBox(
+            width: 20,
+            child: event.redacted
+                ? null
+                : Icon(
+                    selected
+                        ? Icons.check_circle_rounded
+                        : Icons.circle_outlined,
+                    color: selected
+                        ? LinagoraSysColors.material().primary
+                        : Colors.black,
+                    size: 20,
+                  ),
           ),
+          Expanded(child: child),
         ],
       ),
     );

--- a/lib/pages/chat/optional_gesture_detector.dart
+++ b/lib/pages/chat/optional_gesture_detector.dart
@@ -18,6 +18,7 @@ class OptionalGestureDetector extends StatelessWidget {
   Widget build(BuildContext context) {
     if (isEnabled) {
       return GestureDetector(
+        behavior: HitTestBehavior.opaque,
         onTap: onTap,
         onLongPress: onLongPress,
         child: child,


### PR DESCRIPTION
## Ticket
**Related issue**

- #3084

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/7c6b1dc8-65b5-40df-b351-6e9ebc83d2c5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message layout so message bubbles reliably fill available width and align visually.
  * Simplified and improved message selection UI: consistent display logic, reserved leading space for selection, no icon for redacted items, and preserved small left padding on mobile.
  * Improved gesture detection so interactive message areas respond more reliably across the full touch/click bounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->