### PR TITLE
TW-3077: Fix app crashes if you click Send message in profile info

### DIFF
--- a/lib/pages/profile_info/profile_info_body/profile_info_body.dart
+++ b/lib/pages/profile_info/profile_info_body/profile_info_body.dart
@@ -118,9 +118,9 @@ class ProfileInfoBodyController extends State<ProfileInfoBody>
       );
     } else {
       if (PlatformInfos.isMobile) {
-        Navigator.of(
-          context,
-        ).popUntil((route) => route.settings.name == "/rooms/room");
+        Navigator.of(context).popUntil(
+          (Route route) => route.settings.name?.startsWith('/rooms/') ?? false,
+        );
       } else {
         if (widget.onNewChatOpen != null) widget.onNewChatOpen!();
       }


### PR DESCRIPTION
## Ticket
**Related issue**

- #3077 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/918e1f3a-c199-4b2b-99b0-d3d2db095243


https://github.com/user-attachments/assets/672c9d81-8094-4420-ad2e-16b7fd6abf39



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation behavior when opening existing direct chat rooms, ensuring the navigation stack is properly cleared before displaying the chat.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/linagora/twake-on-matrix/pull/3087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->