### PR TITLE
fix: decode double-encoded HTML entities in code blocks (#3089)

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4096m
+org.gradle.jvmargs=-Xmx6144m
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true

--- a/lib/domain/model/room/room_extension.dart
+++ b/lib/domain/model/room/room_extension.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/domain/model/file_info/file_info.dart';
 import 'package:fluffychat/domain/model/room/room_preview_result.dart';
 import 'package:fluffychat/domain/model/search/recent_chat_model.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/client_stories_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/markdown_fix.dart';
 import 'package:html_unescape/html_unescape.dart';
 import 'package:matrix/matrix.dart';
 // ignore: implementation_imports
@@ -371,11 +372,13 @@ extension RoomExtension on Room {
   }) {
     final event = <String, dynamic>{'msgtype': msgtype, 'body': message};
     if (parseMarkdown) {
-      final html = markdown(
+      var html = markdown(
         event['body'],
         getEmotePacks: () => getImagePacksFlat(ImagePackUsage.emoticon),
         getMention: getMention,
       );
+
+      html = fixDoubleEncodedCodeBlocks(html);
 
       final formatText = event['body']
           .toString()

--- a/lib/pages/chat/events/formatted_text_widget.dart
+++ b/lib/pages/chat/events/formatted_text_widget.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/pages/chat/events/html_message.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/markdown_fix.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 
@@ -16,7 +17,7 @@ class FormattedTextWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var html = event.formattedText;
+    var html = fixDoubleEncodedCodeBlocks(event.formattedText);
 
     if (event.messageType == MessageTypes.Emote) {
       html = '* $html';

--- a/lib/pages/chat/events/reply_content.dart
+++ b/lib/pages/chat/events/reply_content.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pages/chat/events/reply_content_style.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/markdown_fix.dart';
 import 'package:fluffychat/pages/chat/optional_selection_container_disabled.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/extension/event_info_extension.dart';
@@ -49,7 +50,9 @@ class ReplyContent extends StatelessWidget {
         !displayEvent.redacted &&
         displayEvent.content['format'] == 'org.matrix.custom.html' &&
         displayEvent.content['formatted_body'] is String) {
-      String? html = (displayEvent.content['formatted_body'] as String?);
+      String? html = fixDoubleEncodedCodeBlocks(
+        displayEvent.content['formatted_body'] as String? ?? '',
+      );
       if (displayEvent.messageType == MessageTypes.Emote) {
         html = '* $html';
       }

--- a/lib/pages/chat/events/reply_content.dart
+++ b/lib/pages/chat/events/reply_content.dart
@@ -50,14 +50,14 @@ class ReplyContent extends StatelessWidget {
         !displayEvent.redacted &&
         displayEvent.content['format'] == 'org.matrix.custom.html' &&
         displayEvent.content['formatted_body'] is String) {
-      String? html = fixDoubleEncodedCodeBlocks(
+      String html = fixDoubleEncodedCodeBlocks(
         displayEvent.content['formatted_body'] as String? ?? '',
       );
       if (displayEvent.messageType == MessageTypes.Emote) {
         html = '* $html';
       }
       replyBody = HtmlMessage(
-        html: html!,
+        html: html,
         defaultTextStyle: ReplyContentStyle.replyBodyTextStyle(context),
         maxLines: 1,
         room: displayEvent.room,

--- a/lib/utils/matrix_sdk_extensions/markdown_fix.dart
+++ b/lib/utils/matrix_sdk_extensions/markdown_fix.dart
@@ -1,21 +1,22 @@
-import 'package:html_unescape/html_unescape.dart';
-
 final _codeContentPattern = RegExp(
   r'(<code[^>]*>)(.*?)(</code>)',
   dotAll: true,
 );
 
+final _doubleEncodedEntity = RegExp(r'&amp;(#?[a-zA-Z0-9]+;)');
+
 /// Fixes double-encoded HTML entities inside `<code>` elements.
-/// See: https://github.com/linagora/twake-on-matrix/issues/3089
+///
+/// The markdown pipeline escapes `<` → `&lt;`, then the code-block renderer
+/// re-escapes → `&amp;lt;`. This collapses one layer: `&amp;lt;` → `&lt;`,
+/// leaving valid single-encoded HTML for the renderer.
 String fixDoubleEncodedCodeBlocks(String html) {
-  final unescape = HtmlUnescape();
   return html.replaceAllMapped(_codeContentPattern, (match) {
     final openTag = match.group(1)!;
-    var content = match.group(2)!;
+    final content = match
+        .group(2)!
+        .replaceAllMapped(_doubleEncodedEntity, (m) => '&${m.group(1)}');
     final closeTag = match.group(3)!;
-    // Two passes: &amp;lt; → &lt; → <
-    content = unescape.convert(content);
-    content = unescape.convert(content);
     return '$openTag$content$closeTag';
   });
 }

--- a/lib/utils/matrix_sdk_extensions/markdown_fix.dart
+++ b/lib/utils/matrix_sdk_extensions/markdown_fix.dart
@@ -1,0 +1,21 @@
+import 'package:html_unescape/html_unescape.dart';
+
+final _codeContentPattern = RegExp(
+  r'(<code[^>]*>)(.*?)(</code>)',
+  dotAll: true,
+);
+
+/// Fixes double-encoded HTML entities inside `<code>` elements.
+/// See: https://github.com/linagora/twake-on-matrix/issues/3089
+String fixDoubleEncodedCodeBlocks(String html) {
+  final unescape = HtmlUnescape();
+  return html.replaceAllMapped(_codeContentPattern, (match) {
+    final openTag = match.group(1)!;
+    var content = match.group(2)!;
+    final closeTag = match.group(3)!;
+    // Two passes: &amp;lt; → &lt; → <
+    content = unescape.convert(content);
+    content = unescape.convert(content);
+    return '$openTag$content$closeTag';
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1184,8 +1184,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: "5699fee5968acf0dac2f6bf8b053eb8abce798c8"
+      ref: "fix/double-encoded-html-entities-in-code-blocks"
+      resolved-ref: "2d0d3c3d38630d426b734dc5741e9a800218607c"
       url: "https://github.com/linagora/flutter_matrix_html.git"
     source: git
     version: "1.2.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1184,8 +1184,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "fix/double-encoded-html-entities-in-code-blocks"
-      resolved-ref: "2d0d3c3d38630d426b734dc5741e9a800218607c"
+      ref: master
+      resolved-ref: "9298119c5668246367f0c15d603cce3146b2d9a5"
       url: "https://github.com/linagora/flutter_matrix_html.git"
     source: git
     version: "1.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter_matrix_html:
     git:
       url: https://github.com/linagora/flutter_matrix_html.git
-      ref: fix/double-encoded-html-entities-in-code-blocks
+      ref: master
 
   # TODO: Remove it after this PR merged
   # https://github.com/justsoft/video_thumbnail/pull/135

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   flutter_matrix_html:
     git:
       url: https://github.com/linagora/flutter_matrix_html.git
-      ref: master
+      ref: fix/double-encoded-html-entities-in-code-blocks
 
   # TODO: Remove it after this PR merged
   # https://github.com/justsoft/video_thumbnail/pull/135

--- a/test/utils/matrix_sdk_extensions/markdown_fix_test.dart
+++ b/test/utils/matrix_sdk_extensions/markdown_fix_test.dart
@@ -1,0 +1,107 @@
+import 'package:fluffychat/utils/matrix_sdk_extensions/markdown_fix.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('fixDoubleEncodedCodeBlocks', () {
+    test('decodes double-encoded angle brackets in fenced code block', () {
+      const input = '<pre><code class="language-dart">&amp;lt;&amp;gt;\n</code></pre>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, '<pre><code class="language-dart"><>\n</code></pre>');
+    });
+
+    test('decodes double-encoded generics in inline code', () {
+      const input = '<code>&amp;lt;String&amp;gt;</code>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, '<code><String></code>');
+    });
+
+    test('decodes List<String> in code block', () {
+      const input =
+          '<pre><code class="language-dart">List&amp;lt;String&amp;gt; items = [];\n</code></pre>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(
+        result,
+        '<pre><code class="language-dart">List<String> items = [];\n</code></pre>',
+      );
+    });
+
+    test('decodes nested generics Map<String, List<int>>', () {
+      const input =
+          '<pre><code>Map&amp;lt;String, List&amp;lt;int&amp;gt;&amp;gt;</code></pre>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(
+        result,
+        '<pre><code>Map<String, List<int>></code></pre>',
+      );
+    });
+
+    test('does not modify content outside code tags', () {
+      const input = '<p>&amp;lt;div&amp;gt;hello&amp;lt;/div&amp;gt;</p>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, input);
+    });
+
+    test('does not modify plain text in code tags', () {
+      const input = '<code>hello world</code>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, input);
+    });
+
+    test('handles already-correct HTML in code tags', () {
+      const input = '<code>List&lt;String&gt;</code>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, '<code>List<String></code>');
+    });
+
+    test('handles mixed content with code and non-code', () {
+      const input =
+          '<p>See this: <code>&amp;lt;T&amp;gt;</code> in &amp;lt;div&amp;gt;</p>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(
+        result,
+        '<p>See this: <code><T></code> in &amp;lt;div&amp;gt;</p>',
+      );
+    });
+
+    test('handles multiple code blocks', () {
+      const input =
+          '<code>&amp;lt;A&amp;gt;</code> text <code>&amp;lt;B&amp;gt;</code>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, '<code><A></code> text <code><B></code>');
+    });
+
+    test('handles &amp;amp; entity in code block', () {
+      const input = '<code>a &amp;amp; b</code>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, '<code>a & b</code>');
+    });
+
+    test('returns input unchanged when no code tags present', () {
+      const input = '<p>just some text</p>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, input);
+    });
+
+    test('handles empty code tag', () {
+      const input = '<code></code>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(result, input);
+    });
+
+    test('handles code tag with language class and multiline', () {
+      const input =
+          '<pre><code class="language-dart">void main() {\n'
+          '  final list = &amp;lt;String&amp;gt;[];\n'
+          '  print(list);\n'
+          '}</code></pre>';
+      final result = fixDoubleEncodedCodeBlocks(input);
+      expect(
+        result,
+        '<pre><code class="language-dart">void main() {\n'
+        '  final list = <String>[];\n'
+        '  print(list);\n'
+        '}</code></pre>',
+      );
+    });
+  });
+}

--- a/test/utils/matrix_sdk_extensions/markdown_fix_test.dart
+++ b/test/utils/matrix_sdk_extensions/markdown_fix_test.dart
@@ -4,7 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('fixDoubleEncodedCodeBlocks', () {
     test('decodes double-encoded angle brackets in fenced code block', () {
-      const input = '<pre><code class="language-dart">&amp;lt;&amp;gt;\n</code></pre>';
+      const input =
+          '<pre><code class="language-dart">&amp;lt;&amp;gt;\n</code></pre>';
       final result = fixDoubleEncodedCodeBlocks(input);
       expect(result, '<pre><code class="language-dart"><>\n</code></pre>');
     });
@@ -29,10 +30,7 @@ void main() {
       const input =
           '<pre><code>Map&amp;lt;String, List&amp;lt;int&amp;gt;&amp;gt;</code></pre>';
       final result = fixDoubleEncodedCodeBlocks(input);
-      expect(
-        result,
-        '<pre><code>Map<String, List<int>></code></pre>',
-      );
+      expect(result, '<pre><code>Map<String, List<int>></code></pre>');
     });
 
     test('does not modify content outside code tags', () {

--- a/test/utils/matrix_sdk_extensions/markdown_fix_test.dart
+++ b/test/utils/matrix_sdk_extensions/markdown_fix_test.dart
@@ -7,13 +7,16 @@ void main() {
       const input =
           '<pre><code class="language-dart">&amp;lt;&amp;gt;\n</code></pre>';
       final result = fixDoubleEncodedCodeBlocks(input);
-      expect(result, '<pre><code class="language-dart"><>\n</code></pre>');
+      expect(
+        result,
+        '<pre><code class="language-dart">&lt;&gt;\n</code></pre>',
+      );
     });
 
     test('decodes double-encoded generics in inline code', () {
       const input = '<code>&amp;lt;String&amp;gt;</code>';
       final result = fixDoubleEncodedCodeBlocks(input);
-      expect(result, '<code><String></code>');
+      expect(result, '<code>&lt;String&gt;</code>');
     });
 
     test('decodes List<String> in code block', () {
@@ -22,7 +25,7 @@ void main() {
       final result = fixDoubleEncodedCodeBlocks(input);
       expect(
         result,
-        '<pre><code class="language-dart">List<String> items = [];\n</code></pre>',
+        '<pre><code class="language-dart">List&lt;String&gt; items = [];\n</code></pre>',
       );
     });
 
@@ -30,7 +33,10 @@ void main() {
       const input =
           '<pre><code>Map&amp;lt;String, List&amp;lt;int&amp;gt;&amp;gt;</code></pre>';
       final result = fixDoubleEncodedCodeBlocks(input);
-      expect(result, '<pre><code>Map<String, List<int>></code></pre>');
+      expect(
+        result,
+        '<pre><code>Map&lt;String, List&lt;int&gt;&gt;</code></pre>',
+      );
     });
 
     test('does not modify content outside code tags', () {
@@ -45,11 +51,14 @@ void main() {
       expect(result, input);
     });
 
-    test('handles already-correct HTML in code tags', () {
-      const input = '<code>List&lt;String&gt;</code>';
-      final result = fixDoubleEncodedCodeBlocks(input);
-      expect(result, '<code>List<String></code>');
-    });
+    test(
+      'does not modify already-correct single-encoded HTML in code tags',
+      () {
+        const input = '<code>List&lt;String&gt;</code>';
+        final result = fixDoubleEncodedCodeBlocks(input);
+        expect(result, input);
+      },
+    );
 
     test('handles mixed content with code and non-code', () {
       const input =
@@ -57,7 +66,7 @@ void main() {
       final result = fixDoubleEncodedCodeBlocks(input);
       expect(
         result,
-        '<p>See this: <code><T></code> in &amp;lt;div&amp;gt;</p>',
+        '<p>See this: <code>&lt;T&gt;</code> in &amp;lt;div&amp;gt;</p>',
       );
     });
 
@@ -65,13 +74,13 @@ void main() {
       const input =
           '<code>&amp;lt;A&amp;gt;</code> text <code>&amp;lt;B&amp;gt;</code>';
       final result = fixDoubleEncodedCodeBlocks(input);
-      expect(result, '<code><A></code> text <code><B></code>');
+      expect(result, '<code>&lt;A&gt;</code> text <code>&lt;B&gt;</code>');
     });
 
     test('handles &amp;amp; entity in code block', () {
       const input = '<code>a &amp;amp; b</code>';
       final result = fixDoubleEncodedCodeBlocks(input);
-      expect(result, '<code>a & b</code>');
+      expect(result, '<code>a &amp; b</code>');
     });
 
     test('returns input unchanged when no code tags present', () {
@@ -96,7 +105,7 @@ void main() {
       expect(
         result,
         '<pre><code class="language-dart">void main() {\n'
-        '  final list = <String>[];\n'
+        '  final list = &lt;String&gt;[];\n'
         '  print(list);\n'
         '}</code></pre>',
       );


### PR DESCRIPTION
## Summary
- Fix `<>` displaying as `&lt;&gt;` in code blocks (fenced and inline)
- Root cause: Matrix SDK pre-escapes `<>` before markdown parsing, then `markdownToHtml()` escapes again inside code blocks → double encoding
- Two-layer fix:
  - **Send side**: post-process HTML after `markdown()` to decode entities inside `<code>` tags
  - **Render side**: `flutter_matrix_html` updated to apply `HtmlUnescape` on code block text ([PR #27](https://github.com/linagora/flutter_matrix_html/pull/27))
- Increase Gradle JVM heap 4G → 6G to fix CI OOM on JetifyTransform

## Related
- Closes #3089
- Upstream issue: https://github.com/famedly/matrix-dart-sdk/issues/2356
- Render fix: https://github.com/linagora/flutter_matrix_html/pull/27

## Test plan
- [x] Send a fenced code block with `<>` → displays `<>` not `&lt;&gt;`
- [x] Send inline code `` `List<String>` `` → displays `List<String>`
- [x] Send nested generics `` `Map<String, List<int>>` `` → displays correctly
- [x] Existing messages in room history with broken encoding display correctly
- [x] Plain text with `<div>` outside code blocks is still escaped properly
- [x] 13 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved issues with HTML special characters displaying incorrectly in code blocks within chat messages and replies.

* **Chores**
  * Increased Gradle JVM heap size for improved build performance.
  * Updated message rendering library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->