### PR TITLE
fix: eliminate post-login well-known 404s

### DIFF
--- a/lib/domain/usecase/room/create_support_chat_interactor.dart
+++ b/lib/domain/usecase/room/create_support_chat_interactor.dart
@@ -25,7 +25,10 @@ class CreateSupportChatInteractor {
     String? roomId;
     String? userId;
     try {
-      final discovery = cachedDiscovery ?? await client.getWellknown();
+      if (cachedDiscovery == null) {
+        throw Exception('No cached discovery information available');
+      }
+      final discovery = cachedDiscovery;
       final supportChatTwakeId =
           (discovery.additionalProperties[WellKnownMixin.twakeChatKey]
               as Map?)?[WellKnownMixin.supportContact];

--- a/lib/pages/login/login.dart
+++ b/lib/pages/login/login.dart
@@ -170,18 +170,27 @@ class LoginController extends State<Login> {
     final oldHomeserver = client.homeserver;
     try {
       var newDomain = Uri.https(userId.domain!, '');
-      client.homeserver = newDomain;
-      DiscoveryInformation? wellKnownInformation;
-      try {
-        wellKnownInformation = await client.getWellknown();
-        if (wellKnownInformation.mHomeserver.baseUrl.toString().isNotEmpty) {
-          newDomain = wellKnownInformation.mHomeserver.baseUrl;
-        }
-      } catch (_) {
-        // do nothing, newDomain is already set to a reasonable fallback
+
+      // Use cached discovery from loginHomeserverSummary instead of
+      // re-fetching well-known (which fails on domains like twake.app
+      // that don't serve .well-known/matrix/client).
+      // Only apply when the MXID domain matches the current homeserver
+      // (e.g. twake.app ↔ matrix.twake.app), so users entering an MXID
+      // from a different server are not silently redirected.
+      final mxidDomain = userId.domain!;
+      final currentHost = oldHomeserver?.host ?? '';
+      final cachedDiscovery = Matrix.of(
+        context,
+      ).loginHomeserverSummary?.discoveryInformation;
+      final cachedBaseUrl =
+          cachedDiscovery?.mHomeserver.baseUrl.toString() ?? '';
+      if (currentHost.endsWith(mxidDomain) && cachedBaseUrl.isNotEmpty) {
+        newDomain = cachedDiscovery!.mHomeserver.baseUrl;
       }
+
       if (newDomain != oldHomeserver) {
-        await client.checkHomeserver(newDomain);
+        client.homeserver = newDomain;
+        await client.checkHomeserver(newDomain, checkWellKnown: false);
 
         if (client.homeserver == null) {
           client.homeserver = oldHomeserver;

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:fluffychat/config/go_routes/app_routes.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/hive_collections_database.dart';
 import 'package:fluffychat/config/localizations/localization_service.dart';
 import 'package:fluffychat/data/model/federation_server/federation_configuration.dart';
 import 'package:fluffychat/data/model/federation_server/federation_server_information.dart';
@@ -1090,7 +1091,10 @@ class MatrixState extends State<Matrix>
       'Matrix::_getHomeserverInformation: client homeserver = ${newClient.homeserver}',
     );
     if (newClient.homeserver == null) return;
-    final previousDiscovery = loginHomeserverSummary?.discoveryInformation;
+    final db = newClient.database;
+    final previousDiscovery =
+        loginHomeserverSummary?.discoveryInformation ??
+        (db is HiveCollectionsDatabase ? await db.getWellKnown() : null);
     final newSummary = await newClient
         .checkHomeserver(newClient.homeserver!, checkWellKnown: false)
         .toHomeserverSummary();

--- a/test/domain/usecase/room/create_support_chat_interactor_test.dart
+++ b/test/domain/usecase/room/create_support_chat_interactor_test.dart
@@ -58,9 +58,6 @@ void main() {
         'should create new support chat successfully when no existing room found',
         () async {
           when(mockClient.userID).thenReturn(testUserId);
-          when(
-            mockClient.getWellknown(),
-          ).thenAnswer((_) async => mockDiscovery);
           when(mockDiscovery.additionalProperties).thenReturn({
             WellKnownMixin.twakeChatKey: {
               WellKnownMixin.supportContact: testSupportContactId,
@@ -97,7 +94,10 @@ void main() {
             ),
           ).thenAnswer((_) async => {});
 
-          final result = interactor.execute(mockClient);
+          final result = interactor.execute(
+            mockClient,
+            cachedDiscovery: mockDiscovery,
+          );
 
           await expectLater(
             result,
@@ -110,7 +110,6 @@ void main() {
             ]),
           );
 
-          verify(mockClient.getWellknown()).called(1);
           verify(
             mockClient.getAccountData(testUserId, 'app.twake.support_room'),
           ).called(1);
@@ -137,9 +136,6 @@ void main() {
         'should return existing support chat when room already exists',
         () async {
           when(mockClient.userID).thenReturn(testUserId);
-          when(
-            mockClient.getWellknown(),
-          ).thenAnswer((_) async => mockDiscovery);
           when(mockDiscovery.additionalProperties).thenReturn({
             WellKnownMixin.twakeChatKey: {
               WellKnownMixin.supportContact: testSupportContactId,
@@ -150,7 +146,10 @@ void main() {
           ).thenAnswer((_) async => {'createdSupportChat': testRoomId});
           when(mockClient.getRoomById(testRoomId)).thenReturn(mockRoom);
 
-          final result = interactor.execute(mockClient);
+          final result = interactor.execute(
+            mockClient,
+            cachedDiscovery: mockDiscovery,
+          );
 
           await expectLater(
             result,
@@ -163,7 +162,6 @@ void main() {
             ]),
           );
 
-          verify(mockClient.getWellknown()).called(1);
           verify(
             mockClient.getAccountData(testUserId, 'app.twake.support_room'),
           ).called(1);
@@ -183,9 +181,6 @@ void main() {
         'should continue when account data throws exception but room does not exist',
         () async {
           when(mockClient.userID).thenReturn(testUserId);
-          when(
-            mockClient.getWellknown(),
-          ).thenAnswer((_) async => mockDiscovery);
           when(mockDiscovery.additionalProperties).thenReturn({
             WellKnownMixin.twakeChatKey: {
               WellKnownMixin.supportContact: testSupportContactId,
@@ -222,7 +217,10 @@ void main() {
             ),
           ).thenAnswer((_) async => {});
 
-          final result = interactor.execute(mockClient);
+          final result = interactor.execute(
+            mockClient,
+            cachedDiscovery: mockDiscovery,
+          );
 
           await expectLater(
             result,
@@ -253,17 +251,35 @@ void main() {
     });
 
     group('execute - failure cases', () {
+      test('should fail when cachedDiscovery is null', () async {
+        final result = interactor.execute(mockClient);
+
+        await expectLater(
+          result,
+          emitsInOrder([
+            predicate(
+              (dynamic value) =>
+                  value is Right && value.value is CreatingSupportChat,
+            ),
+            predicate(
+              (dynamic value) =>
+                  value is Left && value.value is CreateSupportChatFailed,
+            ),
+          ]),
+        );
+      });
+
       test(
         'should fail when support contact is not found in well-known',
         () async {
           when(
-            mockClient.getWellknown(),
-          ).thenAnswer((_) async => mockDiscovery);
-          when(
             mockDiscovery.additionalProperties,
           ).thenReturn({WellKnownMixin.twakeChatKey: {}});
 
-          final result = interactor.execute(mockClient);
+          final result = interactor.execute(
+            mockClient,
+            cachedDiscovery: mockDiscovery,
+          );
 
           await expectLater(
             result,
@@ -279,7 +295,6 @@ void main() {
             ]),
           );
 
-          verify(mockClient.getWellknown()).called(1);
           verifyNever(
             mockClient.createGroupChat(
               groupName: anyNamed('groupName'),
@@ -292,12 +307,14 @@ void main() {
       );
 
       test('should fail when support contact is not a string', () async {
-        when(mockClient.getWellknown()).thenAnswer((_) async => mockDiscovery);
         when(mockDiscovery.additionalProperties).thenReturn({
           WellKnownMixin.twakeChatKey: {WellKnownMixin.supportContact: 123},
         });
 
-        final result = interactor.execute(mockClient);
+        final result = interactor.execute(
+          mockClient,
+          cachedDiscovery: mockDiscovery,
+        );
 
         await expectLater(
           result,
@@ -312,20 +329,20 @@ void main() {
             ),
           ]),
         );
-
-        verify(mockClient.getWellknown()).called(1);
       });
 
       test('should fail when user ID is null', () async {
         when(mockClient.userID).thenReturn(null);
-        when(mockClient.getWellknown()).thenAnswer((_) async => mockDiscovery);
         when(mockDiscovery.additionalProperties).thenReturn({
           WellKnownMixin.twakeChatKey: {
             WellKnownMixin.supportContact: testSupportContactId,
           },
         });
 
-        final result = interactor.execute(mockClient);
+        final result = interactor.execute(
+          mockClient,
+          cachedDiscovery: mockDiscovery,
+        );
 
         await expectLater(
           result,
@@ -341,7 +358,6 @@ void main() {
           ]),
         );
 
-        verify(mockClient.getWellknown()).called(1);
         verifyNever(
           mockClient.createGroupChat(
             groupName: anyNamed('groupName'),
@@ -354,7 +370,6 @@ void main() {
 
       test('should fail when avatar upload fails', () async {
         when(mockClient.userID).thenReturn(testUserId);
-        when(mockClient.getWellknown()).thenAnswer((_) async => mockDiscovery);
         when(mockDiscovery.additionalProperties).thenReturn({
           WellKnownMixin.twakeChatKey: {
             WellKnownMixin.supportContact: testSupportContactId,
@@ -367,7 +382,10 @@ void main() {
           mockMediaAPI.uploadFileWeb(file: anyNamed('file')),
         ).thenThrow(Exception('Upload failed'));
 
-        final result = interactor.execute(mockClient);
+        final result = interactor.execute(
+          mockClient,
+          cachedDiscovery: mockDiscovery,
+        );
 
         await expectLater(
           result,
@@ -396,7 +414,6 @@ void main() {
 
       test('should fail when room creation fails', () async {
         when(mockClient.userID).thenReturn(testUserId);
-        when(mockClient.getWellknown()).thenAnswer((_) async => mockDiscovery);
         when(mockDiscovery.additionalProperties).thenReturn({
           WellKnownMixin.twakeChatKey: {
             WellKnownMixin.supportContact: testSupportContactId,
@@ -418,7 +435,10 @@ void main() {
           ),
         ).thenThrow(Exception('Room creation failed'));
 
-        final result = interactor.execute(mockClient);
+        final result = interactor.execute(
+          mockClient,
+          cachedDiscovery: mockDiscovery,
+        );
 
         await expectLater(
           result,
@@ -446,7 +466,6 @@ void main() {
 
       test('should fail when room is not found after creation', () async {
         when(mockClient.userID).thenReturn(testUserId);
-        when(mockClient.getWellknown()).thenAnswer((_) async => mockDiscovery);
         when(mockDiscovery.additionalProperties).thenReturn({
           WellKnownMixin.twakeChatKey: {
             WellKnownMixin.supportContact: testSupportContactId,
@@ -469,7 +488,10 @@ void main() {
         ).thenAnswer((_) async => testRoomId);
         when(mockClient.getRoomById(testRoomId)).thenReturn(null);
 
-        final result = interactor.execute(mockClient);
+        final result = interactor.execute(
+          mockClient,
+          cachedDiscovery: mockDiscovery,
+        );
 
         await expectLater(
           result,
@@ -490,7 +512,6 @@ void main() {
 
       test('should fail when setFavourite fails', () async {
         when(mockClient.userID).thenReturn(testUserId);
-        when(mockClient.getWellknown()).thenAnswer((_) async => mockDiscovery);
         when(mockDiscovery.additionalProperties).thenReturn({
           WellKnownMixin.twakeChatKey: {
             WellKnownMixin.supportContact: testSupportContactId,
@@ -520,7 +541,10 @@ void main() {
           mockRoom.setFavourite(true),
         ).thenThrow(Exception('setFavourite failed'));
 
-        final result = interactor.execute(mockClient);
+        final result = interactor.execute(
+          mockClient,
+          cachedDiscovery: mockDiscovery,
+        );
 
         await expectLater(
           result,
@@ -546,9 +570,6 @@ void main() {
         'should leave room and clear account data when creation fails',
         () async {
           when(mockClient.userID).thenReturn(testUserId);
-          when(
-            mockClient.getWellknown(),
-          ).thenAnswer((_) async => mockDiscovery);
           when(mockDiscovery.additionalProperties).thenReturn({
             WellKnownMixin.twakeChatKey: {
               WellKnownMixin.supportContact: testSupportContactId,
@@ -590,7 +611,10 @@ void main() {
             }),
           ).thenAnswer((_) async => {});
 
-          final result = interactor.execute(mockClient);
+          final result = interactor.execute(
+            mockClient,
+            cachedDiscovery: mockDiscovery,
+          );
 
           await expectLater(
             result,
@@ -617,7 +641,6 @@ void main() {
 
       test('should handle cleanup failure gracefully', () async {
         when(mockClient.userID).thenReturn(testUserId);
-        when(mockClient.getWellknown()).thenAnswer((_) async => mockDiscovery);
         when(mockDiscovery.additionalProperties).thenReturn({
           WellKnownMixin.twakeChatKey: {
             WellKnownMixin.supportContact: testSupportContactId,
@@ -655,7 +678,10 @@ void main() {
           }),
         ).thenThrow(Exception('Set account data failed'));
 
-        final result = interactor.execute(mockClient);
+        final result = interactor.execute(
+          mockClient,
+          cachedDiscovery: mockDiscovery,
+        );
 
         await expectLater(
           result,


### PR DESCRIPTION
## Summary

- **Root cause**: SDK `getWellknown()` (v6.2.0) uses `userID.domain` (`twake.app`) over `homeserver.host` (`matrix.twake.app`). Since `twake.app` doesn't serve `.well-known/matrix/client`, every post-login call returns 404.
- Well-known is now fetched **once** during `checkHomeserverAction` (against `matrix.twake.app`), all subsequent reads use cached value.
- On app restart, falls back to Hive-cached well-known when in-memory `loginHomeserverSummary` is lost.

### Changes
- **`lib/widgets/matrix.dart`** — `_getHomeserverInformation`: fall back to `HiveCollectionsDatabase.getWellKnown()` when `loginHomeserverSummary` is null (restart case)
- **`lib/pages/login/login.dart`** — `_checkWellKnown`: use cached discovery from `loginHomeserverSummary` + `checkWellKnown: false` instead of re-fetching
- **`lib/domain/usecase/room/create_support_chat_interactor.dart`** — require `cachedDiscovery` instead of falling back to `client.getWellknown()`

## Test plan

- [ ] Login via SSO on Twake SaaS (`matrix.twake.app`) — no 404 on `twake.app/.well-known/matrix/client` in Network tab
- [ ] "Inviter un ami" button visible in Contacts tab
- [ ] App restart preserves well-known data (buttons still visible)
- [ ] Support chat creation still works with cached discovery

Closes #3044 #3045 #3050

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Login now prioritizes locally cached homeserver discovery to reduce network checks and speed sign-in.
  * Support chat flows use cached discovery when available, improving responsiveness and offline behavior.
* **Bug Fixes**
  * Support chat creation now fails fast if cached discovery is missing, avoiding unexpected background network fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->