### PR TITLE
TW-3048(feat): visio link integration

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3209,5 +3209,25 @@
       "totalCount": {}
     }
   },
-  "gifAutoplay": "GIF autoplay"
+  "gifAutoplay": "GIF autoplay",
+  "videoCallStartedTitle": "Has started a video call",
+  "@videoCallStartedTitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "startVideoCall": "Start video call",
+  "@startVideoCall": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "videoCallCopyLink": "Copy link",
+  "@videoCallCopyLink": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "videoCallJoinCall": "Join call",
+  "@videoCallJoinCall": {
+    "type": "text",
+    "placeholders": {}
+  }
 }

--- a/lib/domain/model/extensions/homeserver_summary_extensions.dart
+++ b/lib/domain/model/extensions/homeserver_summary_extensions.dart
@@ -2,6 +2,7 @@ import 'package:fluffychat/config/app_constants.dart';
 import 'package:fluffychat/data/model/federation_server/federation_server_information.dart';
 import 'package:fluffychat/domain/model/app_twake_information.dart';
 import 'package:fluffychat/domain/model/homeserver_summary.dart';
+import 'package:fluffychat/domain/model/rtc_focus.dart';
 import 'package:fluffychat/domain/model/tom_server_information.dart';
 import 'package:matrix/matrix.dart';
 
@@ -69,6 +70,35 @@ extension HomeserverSummaryExtensions on HomeserverSummary {
       );
       return null;
     }
+  }
+
+  String? get videoCallBaseUrl {
+    if (discoveryInformation?.additionalProperties == null) {
+      return null;
+    }
+    final rtcFociJson =
+        discoveryInformation?.additionalProperties[RtcFocus.rtcFociKey];
+    if (rtcFociJson is! List) {
+      return null;
+    }
+    for (final focusJson in rtcFociJson) {
+      if (focusJson is! Map) continue;
+      try {
+        final focus = RtcFocus.fromJson(Map<String, dynamic>.from(focusJson));
+        final baseUrl = focus.liveKitBaseUrl;
+        if (!focus.isLiveKit || baseUrl == null || baseUrl.isEmpty) continue;
+        return baseUrl.endsWith('/')
+            ? baseUrl.substring(0, baseUrl.length - 1)
+            : baseUrl;
+      } catch (e, s) {
+        Logs().wtf(
+          'Failed to parse ${RtcFocus.rtcFociKey} from homeserver summary',
+          e,
+          s,
+        );
+      }
+    }
+    return null;
   }
 }
 

--- a/lib/domain/model/extensions/homeserver_summary_extensions.dart
+++ b/lib/domain/model/extensions/homeserver_summary_extensions.dart
@@ -85,7 +85,7 @@ extension HomeserverSummaryExtensions on HomeserverSummary {
       if (focusJson is! Map) continue;
       try {
         final focus = RtcFocus.fromJson(Map<String, dynamic>.from(focusJson));
-        final baseUrl = focus.liveKitBaseUrl?.toString();
+        final baseUrl = focus.livekitBaseUrl?.toString();
         if (!focus.isLiveKit || baseUrl == null || baseUrl.isEmpty) continue;
         return baseUrl.endsWith('/')
             ? baseUrl.substring(0, baseUrl.length - 1)

--- a/lib/domain/model/extensions/homeserver_summary_extensions.dart
+++ b/lib/domain/model/extensions/homeserver_summary_extensions.dart
@@ -85,7 +85,7 @@ extension HomeserverSummaryExtensions on HomeserverSummary {
       if (focusJson is! Map) continue;
       try {
         final focus = RtcFocus.fromJson(Map<String, dynamic>.from(focusJson));
-        final baseUrl = focus.liveKitBaseUrl;
+        final baseUrl = focus.liveKitBaseUrl?.toString();
         if (!focus.isLiveKit || baseUrl == null || baseUrl.isEmpty) continue;
         return baseUrl.endsWith('/')
             ? baseUrl.substring(0, baseUrl.length - 1)

--- a/lib/domain/model/rtc_focus.dart
+++ b/lib/domain/model/rtc_focus.dart
@@ -1,0 +1,27 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'rtc_focus.g.dart';
+
+@JsonSerializable()
+class RtcFocus with EquatableMixin {
+  static const String rtcFociKey = 'org.matrix.msc4143.rtc_foci';
+  static const String liveKitType = 'livekit';
+
+  final String? type;
+
+  @JsonKey(name: 'livekit_base_url')
+  final String? liveKitBaseUrl;
+
+  RtcFocus({this.type, this.liveKitBaseUrl});
+
+  bool get isLiveKit => type == liveKitType;
+
+  factory RtcFocus.fromJson(Map<String, dynamic> json) =>
+      _$RtcFocusFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RtcFocusToJson(this);
+
+  @override
+  List<Object?> get props => [type, liveKitBaseUrl];
+}

--- a/lib/domain/model/rtc_focus.dart
+++ b/lib/domain/model/rtc_focus.dart
@@ -3,17 +3,16 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'rtc_focus.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(fieldRename: FieldRename.snake)
 class RtcFocus with EquatableMixin {
   static const String rtcFociKey = 'org.matrix.msc4143.rtc_foci';
   static const String liveKitType = 'livekit';
 
   final String? type;
 
-  @JsonKey(name: 'livekit_base_url')
-  final Uri? liveKitBaseUrl;
+  final Uri? livekitBaseUrl;
 
-  RtcFocus({this.type, this.liveKitBaseUrl});
+  RtcFocus({this.type, this.livekitBaseUrl});
 
   bool get isLiveKit => type == liveKitType;
 
@@ -23,5 +22,5 @@ class RtcFocus with EquatableMixin {
   Map<String, dynamic> toJson() => _$RtcFocusToJson(this);
 
   @override
-  List<Object?> get props => [type, liveKitBaseUrl];
+  List<Object?> get props => [type, livekitBaseUrl];
 }

--- a/lib/domain/model/rtc_focus.dart
+++ b/lib/domain/model/rtc_focus.dart
@@ -11,7 +11,7 @@ class RtcFocus with EquatableMixin {
   final String? type;
 
   @JsonKey(name: 'livekit_base_url')
-  final String? liveKitBaseUrl;
+  final Uri? liveKitBaseUrl;
 
   RtcFocus({this.type, this.liveKitBaseUrl});
 

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -17,6 +17,7 @@ import 'package:fluffychat/domain/app_state/room/report_content_state.dart';
 import 'package:fluffychat/domain/model/chat/message_report_reason.dart';
 import 'package:fluffychat/domain/model/contact/contact.dart';
 import 'package:fluffychat/domain/model/extensions/contact/contact_extension.dart';
+import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
 import 'package:fluffychat/domain/model/file_info/file_info.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/domain/usecase/reactions/get_recent_reactions_interactor.dart';
@@ -2334,6 +2335,14 @@ class ChatController extends State<Chat>
 
   bool get isArchived =>
       {Membership.leave, Membership.ban}.contains(room?.membership);
+
+  bool get canSendMessages =>
+      room?.canSendDefaultMessages == true &&
+      room?.membership == Membership.join;
+
+  bool get canStartVideoCall =>
+      canSendMessages &&
+      Matrix.of(context).loginHomeserverSummary?.videoCallBaseUrl != null;
 
   void onPhoneButtonTap() async {
     // VoIP required Android SDK 21

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
 import 'package:fluffychat/pages/chat/chat.dart';
 import 'package:fluffychat/widgets/twake_components/unread_count_badge.dart';
 import 'package:fluffychat/pages/chat/chat_app_bar_title.dart';
@@ -5,6 +6,7 @@ import 'package:fluffychat/pages/chat/chat_invitation_body.dart';
 import 'package:fluffychat/pages/chat/chat_view_body.dart';
 import 'package:fluffychat/pages/chat/chat_view_style.dart';
 import 'package:fluffychat/pages/chat/events/message_content_mixin.dart';
+import 'package:fluffychat/utils/voip/video_call_helper.dart';
 import 'package:fluffychat/presentation/mixins/audio_mixin.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
@@ -160,6 +162,21 @@ class ChatView extends StatelessWidget with MessageContentMixin {
                             onPressed: controller.toggleSearch,
                             icon: const Icon(Icons.search),
                           ),
+                          if (controller.canStartVideoCall)
+                            TwakeIconButton(
+                              icon: Icons.videocam_outlined,
+                              tooltip: L10n.of(context)!.startVideoCall,
+                              onTap: () => VideoCallHelper.start(
+                                room: controller.room,
+                                startedTitle: L10n.of(
+                                  context,
+                                )!.videoCallStartedTitle,
+                                baseUrl: Matrix.of(
+                                  context,
+                                ).loginHomeserverSummary?.videoCallBaseUrl,
+                              ),
+                              preferBelow: false,
+                            ),
                           if (controller.hasActionAppBarMenu)
                             Builder(
                               builder: (context) => TwakeIconButton(

--- a/lib/pages/chat/chat_view_body.dart
+++ b/lib/pages/chat/chat_view_body.dart
@@ -27,7 +27,6 @@ import 'package:flutter_emoji_mart/flutter_emoji_mart.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
-import 'package:matrix/matrix.dart';
 import 'chat_input_row.dart';
 
 class ChatViewBody extends StatelessWidget with MessageContentMixin {
@@ -91,8 +90,7 @@ class ChatViewBody extends StatelessWidget with MessageContentMixin {
                         ),
                       ),
                     ),
-                    if (controller.room!.canSendDefaultMessages &&
-                        controller.room!.membership == Membership.join) ...[
+                    if (controller.canSendMessages) ...[
                       Center(
                         child: Container(
                           alignment: Alignment.center,

--- a/lib/pages/chat/events/message/message_content_builder.dart
+++ b/lib/pages/chat/events/message/message_content_builder.dart
@@ -1,6 +1,9 @@
+import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
 import 'package:fluffychat/pages/chat/events/message/message_content_builder_mixin.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat/events/message_time.dart';
+import 'package:fluffychat/utils/voip/video_call_helper.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/pages/chat/optional_padding.dart';
 import 'package:fluffychat/pages/chat/optional_selection_container_disabled.dart';
 import 'package:fluffychat/pages/chat/optional_stack.dart';
@@ -61,6 +64,9 @@ class MessageContentBuilder extends StatelessWidget
         final isNeedAddNewLine = sizeMessageBubble?.isNeedAddNewLine ?? false;
         final isTextMessageError =
             event.status.isError && event.messageType == MessageTypes.Text;
+        final videoCallBaseUrl = Matrix.of(
+          context,
+        ).loginHomeserverSummary?.videoCallBaseUrl;
 
         return OptionalPadding(
           padding: const EdgeInsets.only(bottom: 8),
@@ -69,7 +75,8 @@ class MessageContentBuilder extends StatelessWidget
             stepWidth:
                 isContainsTagName(event) ||
                     isContainsSpecialHTMLTag(event) ||
-                    event.isCaptionModeOrReply()
+                    event.isCaptionModeOrReply() ||
+                    VideoCallHelper.extractUrl(event, videoCallBaseUrl) != null
                 ? null
                 : stepWidth,
             child: Column(

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -33,6 +33,10 @@ import 'cute_events.dart';
 import 'map_bubble.dart';
 import 'message_download_content.dart';
 import 'sticker.dart';
+import 'video_call_content.dart';
+import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
+import 'package:fluffychat/utils/voip/video_call_helper.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 
 class MessageContent extends StatelessWidget
     with HandleDownloadAndPreviewFileMixin {
@@ -297,6 +301,13 @@ class MessageContent extends StatelessWidget
           case MessageTypes.Text:
           case MessageTypes.Notice:
           case MessageTypes.Emote:
+            final videoCallUrl = VideoCallHelper.extractUrl(
+              event,
+              Matrix.of(context).loginHomeserverSummary?.videoCallBaseUrl,
+            );
+            if (videoCallUrl != null) {
+              return VideoCallContent(callUrl: videoCallUrl);
+            }
             final containedLink = event.text.getFirstValidUrl() ?? '';
             if (AppConfig.renderHtml &&
                 !event.redacted &&

--- a/lib/pages/chat/events/video_call_content.dart
+++ b/lib/pages/chat/events/video_call_content.dart
@@ -1,0 +1,73 @@
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:fluffychat/utils/clipboard.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/utils/twake_snackbar.dart';
+import 'package:fluffychat/utils/url_launcher.dart';
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+class VideoCallContent extends StatelessWidget {
+  final String callUrl;
+
+  const VideoCallContent({super.key, required this.callUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final theme = Theme.of(context);
+    final compact = getIt.get<ResponsiveUtils>().isMobile(context);
+    final buttonSize = compact ? LinagoraButtonSize.xs : LinagoraButtonSize.m;
+
+    return IntrinsicWidth(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: LinagoraSpacing.base),
+            child: Text(
+              l10n.videoCallStartedTitle,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface,
+              ),
+            ),
+          ),
+          const SizedBox(height: LinagoraSpacing.base),
+          Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: LinagoraSpacing.base,
+            ),
+            child: OverflowBar(
+              spacing: LinagoraSpacing.base,
+              overflowSpacing: LinagoraSpacing.base,
+              overflowAlignment: OverflowBarAlignment.start,
+              children: [
+                LinagoraButton(
+                  label: l10n.videoCallCopyLink,
+                  icon: Icons.open_in_new,
+                  size: buttonSize,
+                  variant: LinagoraButtonVariant.outlined,
+                  onPressed: () async {
+                    await TwakeClipboard.instance.copyText(callUrl);
+                    if (context.mounted) {
+                      TwakeSnackBar.show(context, l10n.copiedToClipboard);
+                    }
+                  },
+                ),
+                LinagoraButton(
+                  label: l10n.videoCallJoinCall,
+                  icon: Icons.videocam_outlined,
+                  size: buttonSize,
+                  variant: LinagoraButtonVariant.filled,
+                  onPressed: () =>
+                      UrlLauncher(context, url: callUrl).launchUrl(),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/utils/voip/video_call_helper.dart
+++ b/lib/utils/voip/video_call_helper.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:matrix/matrix.dart';
+
+class VideoCallHelper {
+  const VideoCallHelper._();
+
+  static const _slugAlphabet = 'abcdefghijklmnopqrstuvwxyz';
+  static const callUrlKey = 'call_url';
+
+  static final RegExp _slugRegExp = RegExp(r'^[a-z]{3}-[a-z]{4}-[a-z]{3}$');
+
+  static String? extractUrl(Event event, String? baseUrl) {
+    if (baseUrl == null || baseUrl.isEmpty) return null;
+    if (event.messageType != MessageTypes.Text) return null;
+    final url = event.content.tryGet<String>(callUrlKey);
+    if (url == null || url.isEmpty) return null;
+    final prefix = '$baseUrl/';
+    if (!url.startsWith(prefix)) return null;
+    if (!_slugRegExp.hasMatch(url.substring(prefix.length))) return null;
+    return url;
+  }
+
+  static String generateUrl(String baseUrl) {
+    final random = Random.secure();
+    String letters(int length) => List.generate(
+      length,
+      (_) => _slugAlphabet[random.nextInt(_slugAlphabet.length)],
+    ).join();
+    final slug = '${letters(3)}-${letters(4)}-${letters(3)}';
+    return '$baseUrl/$slug';
+  }
+
+  static void start({
+    required Room? room,
+    required String startedTitle,
+    required String? baseUrl,
+  }) {
+    if (room == null || baseUrl == null) return;
+    final url = generateUrl(baseUrl);
+    unawaited(
+      room.sendEvent({
+        'msgtype': MessageTypes.Text,
+        'body': url,
+        callUrlKey: url,
+      }),
+    );
+  }
+}

--- a/lib/utils/voip/video_call_helper.dart
+++ b/lib/utils/voip/video_call_helper.dart
@@ -42,7 +42,7 @@ class VideoCallHelper {
     unawaited(
       room.sendEvent({
         'msgtype': MessageTypes.Text,
-        'body': url,
+        'body': "$startedTitle $url",
         callUrlKey: url,
       }),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1811,7 +1811,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: c7a4a9f6fe1be9818010122b7761ba43020ed6f2
+      resolved-ref: fac936dfb4721612494a326032e82feeb75f51d2
       url: "https://github.com/linagora/linagora-design-flutter.git"
     source: git
     version: "0.0.1"


### PR DESCRIPTION
## Ticket
Implements #3048 and follow up of #3085
This is the first part of [In-App Call Integration - the MatrixRTC with Livekit](https://github.com/linagora/twake-on-matrix/issues/3100)

## Description
Adds a camera button in the chat app bar.
This button is visible is resolved from `org.matrix.msc4143.rtc_foci` (MSC4143), using the `livekit_base_url` of the environment well-known:

```
"org.matrix.msc4143.rtc_foci": [
  {
    "type": "livekit",
    "livekit_base_url": "https://meet.xxx.xxx"
  }
]
```
This new button generates a meeting link corresponding to livekit_base_url and a random slug (`abc-defg-hij`) and send it to the room. The UI contains "copy link" and "join call" card in the timeline:
<img height="134" alt="image" src="https://github.com/user-attachments/assets/edd42b9d-1913-495d-a168-845f6a53c6d2" />

## Changes

- **Base URL from the homeserver well-known** : resolved from `org.matrix.msc4143.rtc_foci` (MSC4143), using the `livekit_base_url` of the `livekit` focus. New `RtcFocus` model + `HomeserverSummary.videoCallBaseUrl` getter
- **Button gating**: the camera button is shown only when the homeserver advertises a LiveKit transport (`canStartVideoCall`)
- **Link generation / detection** (`VideoCallHelper`): appends a random visio slug (`abc-defg-hij`) to the base URL. Incoming text messages whose `call_url` matches `<baseUrl>/<slug>` are rendered as a join-call card.

## Impact description
- New visio button available in 1:1 and group chats on supported homeservers.
- No env/config flag needed
- No change to existing message rendering for non-call messages.

## Test recommendations
- On a homeserver exposing livekit_base_url entry: the camera button appears where you can send messages. Tapping it send a call link and the timeline shows a join-call card.
- On a homeserver **without** that entry: the button is hidden and no call card is rendered.
- Links pointing to another host or with an invalid slug must **not** render as a call card.

## Complete demo
https://jbournazel-drive.twake.linagora.com/public?sharecode=5XELrPDkf4vG#/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start, copy, and join video calls from chat; messages with call links display a dedicated video-call card with actions and confirmation feedback.
  * Automatic generation and detection of structured call links tied to the homeserver base URL.
  * Localized UI text for video-call interactions.

* **Refactor**
  * Unified chat input and permission checks to control message sending and video-call availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->