### PR TITLE
TW-3078: enhance clipboard paste functionality for iOS to support URLs

### DIFF
--- a/lib/presentation/extensions/text_editting_controller_extension.dart
+++ b/lib/presentation/extensions/text_editting_controller_extension.dart
@@ -10,21 +10,17 @@ extension TextEdittingControllerExtension on TextEditingController {
     final pastedText = await TwakeClipboard.instance.pasteText(
       clipboardReader: clipboardReader,
     );
-    if (pastedText != null) {
-      if (start == -1 || end == -1) {
-        text = pastedText + text;
-        selection = TextSelection.collapsed(offset: text.length);
-        return;
-      }
-      if (start == end) {
-        final startText = text.substring(0, start);
-        final trailingText = text.substring(end, text.length);
-        text = startText + pastedText + trailingText;
-      } else {
-        text = text.replaceRange(start, end, pastedText);
-      }
-      selection = TextSelection.collapsed(offset: end + pastedText.length);
+    if (pastedText == null) return;
+
+    if (start == -1 || end == -1) {
+      text = pastedText + text;
+      selection = TextSelection.collapsed(offset: pastedText.length);
+      return;
     }
+
+    // Replace [start, end) with pastedText, then place cursor after insertion.
+    text = text.replaceRange(start, end, pastedText);
+    selection = TextSelection.collapsed(offset: start + pastedText.length);
   }
 
   Future<void> copyText() async {

--- a/lib/utils/clipboard.dart
+++ b/lib/utils/clipboard.dart
@@ -156,29 +156,52 @@ class TwakeClipboard {
 
   Future<String?> pasteText({ClipboardReader? clipboardReader}) async {
     _reader = clipboardReader ?? await SystemClipboard.instance?.read();
-    String? copied;
 
     final readersFormat = _reader!.getFormats(Formats.standardFormats);
     if (readersFormat.isEmpty) {
-      return copied;
+      return null;
     }
 
-    final c = Completer<String?>();
-    final progress = _reader!.getValue<String>(
+    // Try plain text first.
+    final plainProgress = _reader!.getValue<String>(
       Formats.plainText,
-      (value) {
-        copied = value;
-        c.complete(copied);
-      },
-      onError: (error) {
-        Logs().e('Clipboard::readText(): $error');
-        c.completeError(error);
-      },
+      (_) {},
+      onError: (_) {},
     );
-    if (progress == null) {
-      c.completeError('Clipboard::readText(): error');
+    if (plainProgress != null) {
+      final c = Completer<String?>();
+      _reader!.getValue<String>(
+        Formats.plainText,
+        (value) => c.complete(value),
+        onError: (error) {
+          Logs().e('Clipboard::readText() plain: $error');
+          c.completeError(error);
+        },
+      );
+      return c.future;
     }
-    return c.future;
+
+    // Fallback: clipboard holds a URL (e.g. public.url copied from a browser).
+    // Read it as Formats.uri and convert to its string representation.
+    final uriProgress = _reader!.getValue<NamedUri>(
+      Formats.uri,
+      (_) {},
+      onError: (_) {},
+    );
+    if (uriProgress != null) {
+      final c = Completer<String?>();
+      _reader!.getValue<NamedUri>(
+        Formats.uri,
+        (namedUri) => c.complete(namedUri?.uri.toString()),
+        onError: (error) {
+          Logs().e('Clipboard::readText() uri: $error');
+          c.completeError(error);
+        },
+      );
+      return c.future;
+    }
+
+    return null;
   }
 
   SimpleFileFormat getFormatFrom(String? mimeType) {

--- a/lib/widgets/context_menu_builder_ios_paste_without_permission.dart
+++ b/lib/widgets/context_menu_builder_ios_paste_without_permission.dart
@@ -4,10 +4,65 @@ Widget mobileTwakeContextMenuBuilder(
   BuildContext context,
   EditableTextState editableTextState,
 ) {
+  // On iOS, SystemContextMenu (iOS 16+) avoids the clipboard permission alert
+  // but only shows "Paste" when the clipboard holds plain text. URLs copied
+  // from a browser are stored as public.url — a non-plain-text type — so the
+  // native system menu omits the Paste button entirely.
+  //
+  // AdaptiveTextSelectionToolbar has the same blind spot: it derives button
+  // visibility from ClipboardStatus, which is populated via
+  // Clipboard.getData('text/plain') and therefore also misses public.url.
+  //
+  // Fix: build the button list from editableTextState.contextMenuButtonItems
+  // and, when Paste is absent, add it explicitly. The injected Paste button
+  // calls editableTextState.pasteText() which reads all clipboard types
+  // through the platform channel, including public.url — so it works on all
+  // iOS versions without triggering an extra permission alert on iOS 16+.
+  final buttonItems = _buttonItemsWithPaste(editableTextState);
+
   if (SystemContextMenu.isSupported(context)) {
-    return SystemContextMenu.editableText(editableTextState: editableTextState);
+    // Use the native iOS 16+ menu (no clipboard permission alert).
+    // We can't inject buttons into SystemContextMenu directly, so fall back
+    // to AdaptiveTextSelectionToolbar only when Paste was missing and we had
+    // to add it ourselves.
+    final pasteAlreadyPresent = editableTextState.contextMenuButtonItems.any(
+      (item) => item.type == ContextMenuButtonType.paste,
+    );
+    if (pasteAlreadyPresent) {
+      return SystemContextMenu.editableText(
+        editableTextState: editableTextState,
+      );
+    }
   }
-  return AdaptiveTextSelectionToolbar.editableText(
-    editableTextState: editableTextState,
+
+  // iOS <16, or iOS 16+ where Paste was injected: use Flutter's adaptive
+  // toolbar with the corrected button list.
+  return AdaptiveTextSelectionToolbar.buttonItems(
+    anchors: editableTextState.contextMenuAnchors,
+    buttonItems: buttonItems,
   );
+}
+
+/// Returns [editableTextState.contextMenuButtonItems] with a Paste button
+/// guaranteed to be present when the clipboard is non-empty, regardless of
+/// content type (plain text, URL, image, etc.).
+List<ContextMenuButtonItem> _buttonItemsWithPaste(
+  EditableTextState editableTextState,
+) {
+  final items = editableTextState.contextMenuButtonItems;
+  final hasPaste = items.any(
+    (item) => item.type == ContextMenuButtonType.paste,
+  );
+  if (hasPaste) return items;
+
+  // Insert Paste after Cut (index 1) or at the front when Cut is absent.
+  final pasteItem = ContextMenuButtonItem(
+    type: ContextMenuButtonType.paste,
+    onPressed: () => editableTextState.pasteText(SelectionChangedCause.toolbar),
+  );
+  final cutIndex = items.indexWhere(
+    (item) => item.type == ContextMenuButtonType.cut,
+  );
+  final insertAt = cutIndex == -1 ? 0 : cutIndex + 1;
+  return [...items.sublist(0, insertAt), pasteItem, ...items.sublist(insertAt)];
 }

--- a/lib/widgets/context_menu_builder_ios_paste_without_permission.dart
+++ b/lib/widgets/context_menu_builder_ios_paste_without_permission.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/presentation/extensions/text_editting_controller_extension.dart';
 import 'package:flutter/material.dart';
 
 Widget mobileTwakeContextMenuBuilder(
@@ -15,9 +16,8 @@ Widget mobileTwakeContextMenuBuilder(
   //
   // Fix: build the button list from editableTextState.contextMenuButtonItems
   // and, when Paste is absent, add it explicitly. The injected Paste button
-  // calls editableTextState.pasteText() which reads all clipboard types
-  // through the platform channel, including public.url — so it works on all
-  // iOS versions without triggering an extra permission alert on iOS 16+.
+  // routes through TextEdittingControllerExtension.pasteText() so that the
+  // Formats.uri fallback and correct cursor/undo behaviour are preserved.
   final buttonItems = _buttonItemsWithPaste(editableTextState);
 
   if (SystemContextMenu.isSupported(context)) {
@@ -55,11 +55,19 @@ List<ContextMenuButtonItem> _buttonItemsWithPaste(
   );
   if (hasPaste) return items;
 
-  // Insert Paste after Cut (index 1) or at the front when Cut is absent.
+  // Route through the repo's controller extension so the Formats.uri fallback
+  // and cursor placement in TextEdittingControllerExtension.pasteText() apply,
+  // rather than calling Flutter's internal EditableTextState.pasteText().
+  final controller = editableTextState.widget.controller;
   final pasteItem = ContextMenuButtonItem(
     type: ContextMenuButtonType.paste,
-    onPressed: () => editableTextState.pasteText(SelectionChangedCause.toolbar),
+    onPressed: () {
+      editableTextState.hideToolbar();
+      controller.pasteText();
+    },
   );
+
+  // Insert Paste after Cut or at the front when Cut is absent.
   final cutIndex = items.indexWhere(
     (item) => item.type == ContextMenuButtonType.cut,
   );


### PR DESCRIPTION
## Ticket
**Related issue**

- #3078 

Issue: On iOS, copying a URL from Safari/Chrome and long-tapping the composer showed no "Paste" button. If paste was triggered anyway, the app crashed.                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                
  Why it broke across 3 places:                                                               
                                                                                                                                                                                                                                                                                                                                                                                
  1. context_menu_builder_ios_paste_without_permission.dart — SystemContextMenu (iOS 16+) only shows "Paste" when the clipboard holds public.plain-text. A browser URL is stored as public.url, so the native menu silently omitted the button. AdaptiveTextSelectionToolbar had the same blind spot since it checks clipboard status via Clipboard.getData('text/plain') which 
  also misses public.url. Fixed by probing contextMenuButtonItems — if Paste is absent, inject it manually. On iOS 16+ SystemContextMenu is still used when Paste is already present to preserve the no-permission-alert benefit; only falls back to AdaptiveTextSelectionToolbar when we had to inject Paste ourselves.                                                      
                                                                                                                                                                                                                                                                                                                                                                                
  2. clipboard.dart — TwakeClipboard.pasteText() only tried Formats.plainText. When the clipboard held a URL, getValue returned null and the code threw an error instead of trying the next format. Fixed by falling back to Formats.uri which super_clipboard already supports for public.url on iOS, converting the result to a string. Returns null gracefully if neither    
  format is available.                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                
  3. text_editting_controller_extension.dart — After inserting pasted text, the cursor was set to end + pastedText.length using the old end offset from before the text was modified. For a range selection this could exceed the new text length causing a crash. Fixed by unifying all paste cases into replaceRange(start, end, pastedText) with the cursor always placed at 
  start + pastedText.length, which is always valid.

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/a03a7bc4-f02e-4c8e-920c-afcdc7e62423



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored/injected a visible Paste option in the iOS context menu when missing.
  * Clipboard paste now falls back to URL data when plain text is unavailable.

* **Refactor**
  * Simplified and clarified text-paste insertion flow for more predictable cursor placement and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->