### PR TITLE
feat: native OS photo picker in chat (iOS PHPicker + Android Photo Picker)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,8 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:image_picker_android/image_picker_android.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
 import 'package:linagora_design_flutter/cozy_config_manager/cozy_config_manager.dart';
 import 'package:matrix/matrix.dart';
 import 'package:media_kit/media_kit.dart';
@@ -40,6 +42,7 @@ Future<void> initializeApp() async {
   SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);
   initMatrixLogger();
   MediaKit.ensureInitialized();
+  _enableAndroidPhotoPicker();
   await vod.init();
   if (PlatformInfos.isMobile) {
     databaseFactory = databaseFactoryFfi;
@@ -87,6 +90,19 @@ Future<void> initializeApp() async {
     '${AppConfig.applicationName} started in foreground mode. Rendering GUI...',
   );
   await startGui(clients);
+}
+
+/// Opts the Android `image_picker` implementation into the modern, system
+/// Android Photo Picker (`ACTION_PICK_IMAGES`) instead of the legacy
+/// `ACTION_GET_CONTENT` document/SAF intent. Without this flag the chat media
+/// button on Android opens the file-explorer-style picker rather than the
+/// WhatsApp-like photo gallery. No-op on every other platform.
+void _enableAndroidPhotoPicker() {
+  if (!PlatformInfos.isAndroid) return;
+  final imagePickerImplementation = ImagePickerPlatform.instance;
+  if (imagePickerImplementation is ImagePickerAndroid) {
+    imagePickerImplementation.useAndroidPhotoPicker = true;
+  }
 }
 
 /// Fetch the pincode for the applock and start the flutter engine.

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -2453,6 +2453,68 @@ class ChatController extends State<Chat>
     scrollDown();
   }
 
+  /// Post-send cleanup shared by the native media, document and camera send
+  /// paths: scrolls to the latest message, clears the input bar and its saved
+  /// draft, and resets the reply state.
+  Future<void> _onMediaSent() async {
+    scrollDown();
+    sendController.clear();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('draft_$roomId');
+    replyEventNotifier.value = null;
+  }
+
+  /// Opens the OS-native media picker (PHPicker on iOS, Photo Picker on
+  /// Android). Wired to the dedicated image button in the mobile input bar.
+  void onPickImageClick() {
+    pickAndSendMediaNative(
+      context,
+      room: room,
+      caption: sendController.text.isNotEmpty ? sendController.text : null,
+      inReplyTo: replyEventNotifier.value,
+      onSendCallback: _onMediaSent,
+    );
+  }
+
+  /// Handles the mobile input-bar "+" popup menu selection (document / camera).
+  void onAttachmentMenuSelected(
+    BuildContext context,
+    AttachmentMenuAction action,
+  ) {
+    switch (action) {
+      case AttachmentMenuAction.gallery:
+        onPickImageClick();
+        break;
+      case AttachmentMenuAction.document:
+        sendFileAction(
+          context,
+          room: room,
+          onSendFileCallback: _onMediaSent,
+          inReplyTo: replyEventNotifier.value,
+          popContext: false,
+        );
+        break;
+      case AttachmentMenuAction.camera:
+        _pickFromCameraAndSend(context);
+        break;
+    }
+  }
+
+  void _pickFromCameraAndSend(BuildContext context) {
+    final imagePickerController = ImagePickerGridController(
+      AssetCounter(imagePickerMode: ImagePickerMode.single),
+    );
+    onPressedCamera(context, imagePickerController, (_) async {
+      await sendMedia(
+        imagePickerController,
+        room: room,
+        caption: sendController.text.isNotEmpty ? sendController.text : null,
+        inReplyTo: replyEventNotifier.value,
+      );
+      await _onMediaSent();
+    }, popContext: false);
+  }
+
   void _showMediaPicker(BuildContext context) {
     final imagePickerController = ImagePickerGridController(
       AssetCounter(imagePickerMode: ImagePickerMode.multiple),

--- a/lib/pages/chat/chat_actions.dart
+++ b/lib/pages/chat/chat_actions.dart
@@ -73,6 +73,35 @@ enum PickerType {
   }
 }
 
+/// Actions offered by the chat input-bar "+" popup menu on mobile.
+enum AttachmentMenuAction {
+  gallery,
+  document,
+  camera;
+
+  String getTitle(BuildContext context) {
+    switch (this) {
+      case AttachmentMenuAction.gallery:
+        return L10n.of(context)!.gallery;
+      case AttachmentMenuAction.document:
+        return L10n.of(context)!.documents;
+      case AttachmentMenuAction.camera:
+        return L10n.of(context)!.openCamera;
+    }
+  }
+
+  IconData getIcon() {
+    switch (this) {
+      case AttachmentMenuAction.gallery:
+        return Icons.image_outlined;
+      case AttachmentMenuAction.document:
+        return Icons.attach_file;
+      case AttachmentMenuAction.camera:
+        return Icons.photo_camera_outlined;
+    }
+  }
+}
+
 enum ChatScrollState {
   scrolling,
   startScroll,

--- a/lib/pages/chat/chat_input_row.dart
+++ b/lib/pages/chat/chat_input_row.dart
@@ -24,6 +24,7 @@ import 'package:social_media_recorder/audio_encoder_type.dart';
 import 'package:social_media_recorder/screen/social_media_recorder.dart';
 
 import 'chat.dart';
+import 'chat_actions.dart';
 import 'input_bar/input_bar.dart';
 
 class ChatInputRow extends StatelessWidget {
@@ -62,15 +63,60 @@ class ChatInputRow extends StatelessWidget {
                                 return const SizedBox.shrink();
                               }
 
+                              // The enclosing block is gated on
+                              // responsiveUtils.isMobile (viewport-based), so on a
+                              // narrow web viewport it still renders. The native
+                              // picker + popup actions feed the mobile upload
+                              // pipeline (dart:io), which breaks on web — so when
+                              // the actual platform is not mobile, fall back to the
+                              // single "+" button routed through onSendFileClick's
+                              // platform-aware path.
+                              if (!PlatformInfos.isMobile) {
+                                return SizedBox(
+                                  height: ChatInputRowStyle.chatInputRowHeight,
+                                  child: TwakeIconButton(
+                                    size: ChatInputRowStyle
+                                        .chatInputRowMoreBtnSize,
+                                    tooltip: L10n.of(context)!.more,
+                                    icon: Icons.add_circle_outline,
+                                    onTap: () =>
+                                        controller.onSendFileClick(context),
+                                  ),
+                                );
+                              }
+
+                              // Single "+" button. Gallery, Documents and Camera
+                              // all live inside its popup menu now.
                               return SizedBox(
                                 height: ChatInputRowStyle.chatInputRowHeight,
-                                child: TwakeIconButton(
-                                  size:
-                                      ChatInputRowStyle.chatInputRowMoreBtnSize,
+                                child: PopupMenuButton<AttachmentMenuAction>(
                                   tooltip: L10n.of(context)!.more,
-                                  icon: Icons.add_circle_outline,
-                                  onTap: () =>
-                                      controller.onSendFileClick(context),
+                                  iconSize:
+                                      ChatInputRowStyle.chatInputRowMoreBtnSize,
+                                  icon: const Icon(Icons.add_circle_outline),
+                                  onSelected: (action) =>
+                                      controller.onAttachmentMenuSelected(
+                                        context,
+                                        action,
+                                      ),
+                                  itemBuilder: (context) => AttachmentMenuAction
+                                      .values
+                                      .map(
+                                        (action) =>
+                                            PopupMenuItem<AttachmentMenuAction>(
+                                              value: action,
+                                              child: Row(
+                                                children: [
+                                                  Icon(action.getIcon()),
+                                                  const SizedBox(width: 12),
+                                                  Text(
+                                                    action.getTitle(context),
+                                                  ),
+                                                ],
+                                              ),
+                                            ),
+                                      )
+                                      .toList(),
                                 ),
                               );
                             },

--- a/lib/pages/chat/send_media_native_dialog/send_media_native_dialog.dart
+++ b/lib/pages/chat/send_media_native_dialog/send_media_native_dialog.dart
@@ -1,0 +1,365 @@
+import 'dart:io';
+
+import 'package:fluffychat/domain/model/file_info/file_info.dart';
+import 'package:fluffychat/domain/model/file_info/video_file_info.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:fluffychat/pages/chat/input_bar/focus_suggestion_controller.dart';
+import 'package:fluffychat/pages/chat/input_bar/input_bar.dart';
+import 'package:fluffychat/presentation/extensions/media_thumbnail_extension.dart';
+import 'package:fluffychat/presentation/widget_keys/widget_keys.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
+/// Result returned by [SendMediaNativeDialog]. `null` means the user cancelled
+/// (no upload should happen). On send, [files] is the kept list (oversized files
+/// dropped) and [caption] is the single batch caption (empty → no caption).
+class SendMediaNativeResult {
+  final List<FileInfo> files;
+  final String? caption;
+
+  const SendMediaNativeResult({required this.files, this.caption});
+}
+
+/// Full-screen preview + caption sheet shown after the OS-native picker returns,
+/// before pushing media through [UploadManager.uploadFileMobile].
+///
+/// Mirrors the WhatsApp flow: swipe between picked items, remove unwanted ones,
+/// add a single caption for the batch (with @mention suggestions), then send.
+/// It returns a [SendMediaNativeResult] via [Navigator.pop] and does NOT upload
+/// itself — the caller keeps ownership of the mobile upload pipeline so HEIC→JPG,
+/// compression and streaming stay intact.
+class SendMediaNativeDialog extends StatefulWidget {
+  final List<FileInfo> files;
+  final String? pendingText;
+
+  /// Needed for @mention suggestions in the caption and for generating video
+  /// thumbnails / reading the server's max upload size.
+  final Room? room;
+
+  const SendMediaNativeDialog({
+    super.key,
+    required this.files,
+    this.room,
+    this.pendingText,
+  });
+
+  static Future<SendMediaNativeResult?> show(
+    BuildContext context, {
+    required List<FileInfo> files,
+    Room? room,
+    String? pendingText,
+  }) {
+    return Navigator.of(context).push<SendMediaNativeResult>(
+      MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (_) => SendMediaNativeDialog(
+          files: files,
+          room: room,
+          pendingText: pendingText,
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<SendMediaNativeDialog> createState() => _SendMediaNativeDialogState();
+}
+
+class _SendMediaNativeDialogState extends State<SendMediaNativeDialog> {
+  late final List<FileInfo> _files = List.of(widget.files);
+  late final TextEditingController _captionController = TextEditingController(
+    text: widget.pendingText ?? '',
+  );
+  final FocusSuggestionController _focusSuggestionController =
+      FocusSuggestionController();
+  final FocusNode _captionFocusNode = FocusNode();
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  /// Server-reported max upload size in bytes (null while loading / unknown).
+  int? _maxUploadSize;
+
+  /// Cache of generated video thumbnails keyed by file path. A present key with
+  /// a null value means generation was attempted and failed.
+  final Map<String, MatrixImageFile?> _videoThumbnails = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMaxUploadSize();
+    _generateVideoThumbnails();
+  }
+
+  @override
+  void dispose() {
+    _captionController.dispose();
+    _captionFocusNode.dispose();
+    _focusSuggestionController.dispose();
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadMaxUploadSize() async {
+    final client = widget.room?.client;
+    if (client == null) return;
+    try {
+      final config = await client.getConfig();
+      if (!mounted) return;
+      setState(() => _maxUploadSize = config.mUploadSize);
+    } catch (e, s) {
+      Logs().w('SendMediaNativeDialog::_loadMaxUploadSize(): $e', e, s);
+    }
+  }
+
+  Future<void> _generateVideoThumbnails() async {
+    final room = widget.room;
+    if (room == null) return;
+    for (final file in _files) {
+      final path = file.filePath;
+      if (file is! VideoFileInfo || path == null) continue;
+      final thumbnail = await room.generateVideoThumbnailFromPath(
+        path,
+        videoFileName: file.fileName,
+      );
+      if (!mounted) return;
+      setState(() => _videoThumbnails[path] = thumbnail);
+    }
+  }
+
+  bool _isTooLarge(FileInfo file) =>
+      _maxUploadSize != null && file.fileSize > _maxUploadSize!;
+
+  List<FileInfo> get _sendableFiles =>
+      _files.where((f) => !_isTooLarge(f)).toList();
+
+  void _removeCurrent() {
+    if (_files.length <= 1) {
+      Navigator.of(context).pop();
+      return;
+    }
+    setState(() {
+      _files.removeAt(_currentPage);
+      if (_currentPage >= _files.length) {
+        _currentPage = _files.length - 1;
+      }
+    });
+    // Resync the PageController after the PageView rebuilds with fewer pages,
+    // otherwise removing the last page leaves it pointing out of bounds.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _pageController.hasClients) {
+        _pageController.jumpToPage(_currentPage);
+      }
+    });
+  }
+
+  void _send() {
+    final sendable = _sendableFiles;
+    if (sendable.isEmpty) return;
+    final caption = _captionController.text.trim();
+    Navigator.of(context).pop(
+      SendMediaNativeResult(
+        files: sendable,
+        caption: caption.isEmpty ? null : caption,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasSendable = _sendableFiles.isNotEmpty;
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        // The app's AppBarTheme forces a grey icon color that wins over
+        // foregroundColor; set white explicitly so the controls read on black.
+        iconTheme: const IconThemeData(color: Colors.white),
+        actionsIconTheme: const IconThemeData(color: Colors.white),
+        leading: IconButton(
+          color: Colors.white,
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: _files.length > 1
+            ? Text(
+                '${_currentPage + 1}/${_files.length}',
+                style: const TextStyle(color: Colors.white),
+              )
+            : null,
+        actions: [
+          IconButton(
+            color: Colors.white,
+            icon: const Icon(Icons.delete_outline),
+            onPressed: _removeCurrent,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView.builder(
+              controller: _pageController,
+              itemCount: _files.length,
+              onPageChanged: (i) => setState(() => _currentPage = i),
+              itemBuilder: (_, i) {
+                final file = _files[i];
+                return _MediaPreview(
+                  file: file,
+                  videoThumbnail: _videoThumbnails[file.filePath],
+                  tooLargeMessage: _isTooLarge(file)
+                      ? L10n.of(context)!.fileIsTooBigForServer
+                      : null,
+                );
+              },
+            ),
+          ),
+          Material(
+            color: Theme.of(context).colorScheme.surface,
+            child: SafeArea(
+              top: false,
+              child: Padding(
+                padding: EdgeInsets.only(
+                  left: 12,
+                  right: 12,
+                  top: 8,
+                  bottom: MediaQuery.of(context).viewInsets.bottom + 8,
+                ),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Expanded(
+                      child: InkWell(
+                        hoverColor: Colors.transparent,
+                        highlightColor: Colors.transparent,
+                        focusColor: Colors.transparent,
+                        onTap: () => _captionFocusNode.requestFocus(),
+                        child: InputBar(
+                          typeAheadKey:
+                              ChatKeys.sendFileDialogTypeAhead.valueKey,
+                          minLines: 1,
+                          maxLines: 5,
+                          room: widget.room,
+                          controller: _captionController,
+                          focusSuggestionController: _focusSuggestionController,
+                          typeAheadFocusNode: _captionFocusNode,
+                          keyboardType: TextInputType.multiline,
+                          textInputAction: null,
+                          decoration: InputDecoration(
+                            hintText: L10n.of(context)!.enterCaption,
+                            filled: true,
+                            fillColor: Theme.of(
+                              context,
+                            ).colorScheme.surfaceContainerHighest,
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(24),
+                              borderSide: BorderSide.none,
+                            ),
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 10,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    FloatingActionButton(
+                      onPressed: hasSendable ? _send : null,
+                      backgroundColor: hasSendable
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context).disabledColor,
+                      tooltip: L10n.of(context)!.send,
+                      child: const Icon(Icons.send, color: Colors.white),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MediaPreview extends StatelessWidget {
+  final FileInfo file;
+  final MatrixImageFile? videoThumbnail;
+  final String? tooLargeMessage;
+
+  const _MediaPreview({
+    required this.file,
+    this.videoThumbnail,
+    this.tooLargeMessage,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        _buildPreview(),
+        if (tooLargeMessage != null)
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: Container(
+              color: Theme.of(context).colorScheme.error,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(
+                    Icons.error_outline,
+                    color: Colors.white,
+                    size: 20,
+                  ),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      tooLargeMessage!,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(color: Colors.white),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildPreview() {
+    final path = file.filePath;
+    if (file is VideoFileInfo) {
+      final thumbnailBytes = videoThumbnail?.bytes;
+      return Stack(
+        fit: StackFit.expand,
+        children: [
+          if (thumbnailBytes != null)
+            Image.memory(thumbnailBytes, fit: BoxFit.contain)
+          else
+            const SizedBox.shrink(),
+          const Center(
+            child: Icon(
+              Icons.play_circle_outline,
+              color: Colors.white,
+              size: 72,
+            ),
+          ),
+        ],
+      );
+    }
+    if (path == null) {
+      return const Center(
+        child: Icon(Icons.broken_image_outlined, color: Colors.white54),
+      );
+    }
+    // No InteractiveViewer here: its pan gesture would swallow the horizontal
+    // drag and block the parent PageView from swiping image-to-image.
+    return Center(child: Image.file(File(path), fit: BoxFit.contain));
+  }
+}

--- a/lib/presentation/extensions/text_editting_controller_extension.dart
+++ b/lib/presentation/extensions/text_editting_controller_extension.dart
@@ -10,17 +10,21 @@ extension TextEdittingControllerExtension on TextEditingController {
     final pastedText = await TwakeClipboard.instance.pasteText(
       clipboardReader: clipboardReader,
     );
-    if (pastedText == null) return;
-
-    if (start == -1 || end == -1) {
-      text = pastedText + text;
-      selection = TextSelection.collapsed(offset: pastedText.length);
-      return;
+    if (pastedText != null) {
+      if (start == -1 || end == -1) {
+        text = pastedText + text;
+        selection = TextSelection.collapsed(offset: text.length);
+        return;
+      }
+      if (start == end) {
+        final startText = text.substring(0, start);
+        final trailingText = text.substring(end, text.length);
+        text = startText + pastedText + trailingText;
+      } else {
+        text = text.replaceRange(start, end, pastedText);
+      }
+      selection = TextSelection.collapsed(offset: start + pastedText.length);
     }
-
-    // Replace [start, end) with pastedText, then place cursor after insertion.
-    text = text.replaceRange(start, end, pastedText);
-    selection = TextSelection.collapsed(offset: start + pastedText.length);
   }
 
   Future<void> copyText() async {

--- a/lib/presentation/mixins/common_media_picker_mixin.dart
+++ b/lib/presentation/mixins/common_media_picker_mixin.dart
@@ -77,8 +77,11 @@ mixin CommonMediaPickerMixin {
   Future<AssetEntity?> pickMediaFromCameraAction({
     required BuildContext context,
     bool onlyImage = false,
+    bool popContext = true,
   }) async {
-    Navigator.pop(context);
+    // [popContext] closes the legacy media-picker bottom sheet before opening
+    // the camera. The new input-bar popup menu has no sheet, so it passes false.
+    if (popContext) Navigator.pop(context);
     return await CameraPicker.pickFromCamera(
       context,
       pickerConfig: onlyImage

--- a/lib/presentation/mixins/media_picker_mixin.dart
+++ b/lib/presentation/mixins/media_picker_mixin.dart
@@ -327,17 +327,21 @@ mixin MediaPickerMixin on CommonMediaPickerMixin {
       ),
       cameraWidget: UseCameraWidget(
         onPressed: () =>
-            _onPressedCamera(context, imagePickerController, onCameraPicked),
+            onPressedCamera(context, imagePickerController, onCameraPicked),
         backgroundImage: const AssetImage("assets/verification.png"),
       ),
     );
   }
 
-  void _onPressedCamera(
+  /// Checks camera + micro permissions, then opens the camera and forwards the
+  /// captured asset to [onCameraPicked]. [popContext] closes the legacy bottom
+  /// sheet before opening the camera; the new input-bar popup passes false.
+  void onPressedCamera(
     BuildContext context,
     ImagePickerGridController imagePickerController,
-    OnCameraPicked? onCameraPicked,
-  ) async {
+    OnCameraPicked? onCameraPicked, {
+    bool popContext = true,
+  }) async {
     final currentPermissionMicro = await getCurrentMicroPermission(
       context: context,
       audioTypeEnum: AudioTypeEnum.camera,
@@ -349,6 +353,7 @@ mixin MediaPickerMixin on CommonMediaPickerMixin {
         context: context,
         imagePickerGridController: imagePickerController,
         onCameraPicked: onCameraPicked,
+        popContext: popContext,
       );
     } else {
       goToSettings(
@@ -363,10 +368,12 @@ mixin MediaPickerMixin on CommonMediaPickerMixin {
     required ImagePickerGridController imagePickerGridController,
     OnCameraPicked? onCameraPicked,
     bool onlyImage = false,
+    bool popContext = true,
   }) async {
     var assetEntity = await pickMediaFromCameraAction(
       context: context,
       onlyImage: onlyImage,
+      popContext: popContext,
     );
     Logs().d(
       "MediaPickerMixin::_pickFromCameraAction(): assetEntity - $assetEntity",

--- a/lib/presentation/mixins/send_files_mixin.dart
+++ b/lib/presentation/mixins/send_files_mixin.dart
@@ -2,14 +2,116 @@ import 'package:file_picker/file_picker.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/extensions/xfile/xfile_extension.dart';
 import 'package:fluffychat/domain/model/file_info/file_info.dart';
+import 'package:fluffychat/domain/model/file_info/image_file_info.dart';
+import 'package:fluffychat/domain/model/file_info/video_file_info.dart';
 import 'package:fluffychat/pages/chat/chat_actions.dart';
+import 'package:fluffychat/pages/chat/send_media_native_dialog/send_media_native_dialog.dart';
 import 'package:fluffychat/presentation/model/file/file_asset_entity.dart';
 import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
+import 'package:fluffychat/utils/mime_type_uitls.dart';
+import 'package:fluffychat/utils/string_extension.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:image_picker/image_picker.dart' as native_picker;
 import 'package:linagora_design_flutter/images_picker/images_picker.dart';
 import 'package:matrix/matrix.dart';
 
+/// Presents the preview + caption sheet for natively-picked media and resolves
+/// to the user's choice (`null` = cancelled). Injectable so unit tests can drive
+/// the post-pick path without a widget tree.
+typedef SendMediaNativeDialogPresenter =
+    Future<SendMediaNativeResult?> Function(
+      BuildContext context, {
+      required List<FileInfo> files,
+      Room? room,
+      String? pendingText,
+    });
+
 mixin SendFilesMixin {
+  /// Defaults to the real full-screen dialog; overridden in tests.
+  @visibleForTesting
+  SendMediaNativeDialogPresenter mediaCaptionDialogPresenter =
+      SendMediaNativeDialog.show;
+
+  /// Opens the OS-native media picker via `image_picker.pickMultipleMedia()`:
+  /// PHPickerViewController on iOS, the Android Photo Picker on Android 13+.
+  /// Both run out-of-process, so no photo-library permission prompt is needed,
+  /// and both provide the system albums/search/multi-select UI (WhatsApp-style).
+  ///
+  /// Selected media are mapped to typed [FileInfo] and pushed through the
+  /// existing mobile upload pipeline ([UploadManager.uploadFileMobile]), which
+  /// handles msgType detection, thumbnails, compression, HEIC→JPG and encryption.
+  Future<void> pickAndSendMediaNative(
+    BuildContext context, {
+    Room? room,
+    String? caption,
+    Event? inReplyTo,
+    VoidCallback? onSendCallback,
+  }) async {
+    if (room == null) return;
+    final List<native_picker.XFile> files;
+    try {
+      files = await native_picker.ImagePicker().pickMultipleMedia();
+    } on PlatformException catch (e, s) {
+      Logs().e('SendFilesMixin::pickAndSendMediaNative(): $e', e, s);
+      return;
+    } catch (e, s) {
+      // Any non-platform error (e.g. unexpected plugin failure) must not bubble
+      // up as an unhandled async error on this user-triggered path.
+      Logs().e('SendFilesMixin::pickAndSendMediaNative(): $e', e, s);
+      return;
+    }
+    if (files.isEmpty) return;
+    final fileInfos = files.map(_xFileToFileInfo).toList();
+
+    // Show a preview + caption sheet (WhatsApp-style) before sending. The
+    // [pendingText] (input-bar draft) prefills the caption; the dialog returns
+    // the final batch caption and the possibly-trimmed file list. A null result
+    // means the user cancelled → nothing is sent.
+    if (!context.mounted) return;
+    final result = await mediaCaptionDialogPresenter(
+      context,
+      files: fileInfos,
+      room: room,
+      pendingText: caption,
+    );
+    if (result == null || result.files.isEmpty) return;
+
+    // Await the queueing pass so [onSendCallback] (clears draft/reply, scrolls)
+    // runs after the placeholder events are in the timeline, not before the
+    // upload begins — keeps ordering deterministic and shrinks the window where
+    // the callback's async work could race a widget dispose.
+    final uploadManager = getIt.get<UploadManager>();
+    await uploadManager.uploadFileMobile(
+      room: room,
+      fileInfos: result.files,
+      caption: result.caption,
+      inReplyTo: inReplyTo,
+    );
+    onSendCallback?.call();
+  }
+
+  /// Maps a picked [native_picker.XFile] to the typed [FileInfo] expected by
+  /// the upload pipeline. Returning [ImageFileInfo]/[VideoFileInfo] (rather than
+  /// a bare [FileInfo]) is what lets `sendFileEventMobile` run HEIC→JPG
+  /// conversion and thumbnail generation, which are gated on the concrete type.
+  FileInfo _xFileToFileInfo(native_picker.XFile file) {
+    final mimeType = MimeTypeUitls.instance.getTwakeMimeType(file.name);
+    return switch (mimeType.msgTypeFromMime) {
+      MessageTypes.Image => ImageFileInfo(
+        file.name,
+        filePath: file.path,
+        customMimeType: mimeType,
+      ),
+      MessageTypes.Video => VideoFileInfo(
+        file.name,
+        filePath: file.path,
+        customMimeType: mimeType,
+      ),
+      _ => FileInfo(file.name, filePath: file.path, customMimeType: mimeType),
+    };
+  }
+
   Future<void> sendMedia(
     ImagePickerGridController imagePickerController, {
     String? caption,
@@ -37,9 +139,13 @@ mixin SendFilesMixin {
     List<FileInfo>? fileInfos,
     VoidCallback? onSendFileCallback,
     Event? inReplyTo,
+    bool popContext = true,
   }) async {
     if (room == null) return;
-    Navigator.pop(context);
+    // [popContext] closes the legacy media-picker bottom sheet. When invoked
+    // from the new input-bar popup menu there is no sheet to close, so the
+    // caller passes false to avoid popping the chat route.
+    if (popContext) Navigator.pop(context);
     final result = await FilePicker.platform.pickFiles(
       allowMultiple: true,
       readSequential: true,
@@ -49,13 +155,16 @@ mixin SendFilesMixin {
     }).toList();
 
     if (fileInfos == null || fileInfos.isEmpty) return;
-    onSendFileCallback?.call();
+    // Await the queueing pass before clearing composer/reply state so the
+    // callback runs after the placeholder events exist, mirroring
+    // [pickAndSendMediaNative] and avoiding a callback-vs-dispose race.
     final uploadManger = getIt.get<UploadManager>();
-    uploadManger.uploadFileMobile(
+    await uploadManger.uploadFileMobile(
       room: room,
       fileInfos: fileInfos,
       inReplyTo: inReplyTo,
     );
+    onSendFileCallback?.call();
   }
 
   Future<List<MatrixFile>> pickFilesFromSystem() async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1576,7 +1576,7 @@ packages:
     source: hosted
     version: "1.2.0"
   image_picker_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_android
       sha256: "28f3987ca0ec702d346eae1d90eda59603a2101b52f1e234ded62cff1d5cfa6e"
@@ -1616,7 +1616,7 @@ packages:
     source: hosted
     version: "0.2.2"
   image_picker_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_platform_interface
       sha256: "9f143b0dba3e459553209e20cc425c9801af48e6dfa4f01a0fcf927be3f41665"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -126,6 +126,10 @@ dependencies:
   http: ^0.13.4
   image: ^4.0.15
   image_picker: ^1.2.0
+  # Direct deps so we can opt into the Android Photo Picker (useAndroidPhotoPicker)
+  # in main.dart; both are already pulled in transitively by image_picker.
+  image_picker_android: ^0.8.13
+  image_picker_platform_interface: ^2.11.0
   intl: any
   just_audio: 0.10.5
   opus_caf_converter_dart: ^1.0.1

--- a/test/presentation/mixins/send_files_mixin_test.dart
+++ b/test/presentation/mixins/send_files_mixin_test.dart
@@ -1,0 +1,313 @@
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/domain/model/file_info/file_info.dart';
+import 'package:fluffychat/domain/model/file_info/image_file_info.dart';
+import 'package:fluffychat/domain/model/file_info/video_file_info.dart';
+import 'package:fluffychat/pages/chat/send_media_native_dialog/send_media_native_dialog.dart';
+import 'package:fluffychat/presentation/mixins/send_files_mixin.dart';
+import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+// ignore: depend_on_referenced_packages
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'send_files_mixin_test.mocks.dart';
+
+class _TestSendFilesMixin with SendFilesMixin {}
+
+/// Fake platform so `ImagePicker().pickMultipleMedia()` returns a controlled
+/// list of files without touching the native PHPicker.
+class _FakeImagePickerPlatform extends ImagePickerPlatform {
+  List<XFile> media = [];
+  Object? error;
+
+  @override
+  Future<List<XFile>> getMedia({required MediaOptions options}) async {
+    if (error != null) throw error!;
+    return media;
+  }
+}
+
+@GenerateNiceMocks([
+  MockSpec<UploadManager>(),
+  MockSpec<Client>(),
+  MockSpec<Event>(),
+])
+void main() {
+  late _TestSendFilesMixin mixin;
+  late MockUploadManager uploadManager;
+  late _FakeImagePickerPlatform fakePicker;
+  late ImagePickerPlatform originalPicker;
+  late Room room;
+
+  // Drives the post-pick caption dialog without a real widget tree. Returns the
+  // picked files unchanged with the prefilled draft as caption, simulating the
+  // user pressing "send". Overridden per-test for the cancel case.
+  SendMediaNativeResult? Function(List<FileInfo>, String?) dialogOutcome =
+      (files, pendingText) =>
+          SendMediaNativeResult(files: files, caption: pendingText);
+
+  setUp(() {
+    mixin = _TestSendFilesMixin();
+    mixin.mediaCaptionDialogPresenter =
+        (context, {required files, room, pendingText}) async =>
+            dialogOutcome(files, pendingText);
+    uploadManager = MockUploadManager();
+    fakePicker = _FakeImagePickerPlatform();
+    originalPicker = ImagePickerPlatform.instance;
+    ImagePickerPlatform.instance = fakePicker;
+    getIt.registerSingleton<UploadManager>(uploadManager);
+    room = Room(client: MockClient(), id: '!room:server.abc');
+  });
+
+  tearDown(() async {
+    ImagePickerPlatform.instance = originalPicker;
+    dialogOutcome = (files, pendingText) =>
+        SendMediaNativeResult(files: files, caption: pendingText);
+    await getIt.reset();
+  });
+
+  /// Pumps a trivial widget and invokes [body] with a live [BuildContext], which
+  /// `pickAndSendMediaNative` now requires to present the caption dialog.
+  Future<void> withContext(
+    WidgetTester tester,
+    Future<void> Function(BuildContext context) body,
+  ) async {
+    late BuildContext capturedContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            capturedContext = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    await body(capturedContext);
+  }
+
+  group('pickAndSendMediaNative', () {
+    testWidgets(
+      'maps picked files to typed FileInfo and calls uploadFileMobile',
+      (tester) async {
+        // Distinct name vs path so a swapped mapping would fail the assertion.
+        fakePicker.media = [
+          XFile('uploads/photo.jpg'),
+          XFile('uploads/clip.mp4'),
+        ];
+        final replyEvent = MockEvent();
+        var callbackCalled = false;
+
+        await withContext(tester, (context) async {
+          await mixin.pickAndSendMediaNative(
+            context,
+            room: room,
+            caption: 'hello',
+            inReplyTo: replyEvent,
+            onSendCallback: () => callbackCalled = true,
+          );
+        });
+
+        final captured =
+            verify(
+                  uploadManager.uploadFileMobile(
+                    room: room,
+                    fileInfos: captureAnyNamed('fileInfos'),
+                    caption: 'hello',
+                    inReplyTo: replyEvent,
+                  ),
+                ).captured.single
+                as List<FileInfo>;
+
+        expect(captured, hasLength(2));
+        // Image → ImageFileInfo so the HEIC/thumbnail pipeline runs downstream.
+        expect(
+          captured[0],
+          isA<ImageFileInfo>()
+              .having((f) => f.fileName, 'fileName', 'photo.jpg')
+              .having((f) => f.filePath, 'filePath', 'uploads/photo.jpg'),
+        );
+        // Video → VideoFileInfo.
+        expect(
+          captured[1],
+          isA<VideoFileInfo>()
+              .having((f) => f.fileName, 'fileName', 'clip.mp4')
+              .having((f) => f.filePath, 'filePath', 'uploads/clip.mp4'),
+        );
+        expect(callbackCalled, isTrue);
+      },
+    );
+
+    testWidgets('does nothing when the picker returns no files', (
+      tester,
+    ) async {
+      fakePicker.media = [];
+      var callbackCalled = false;
+
+      await withContext(tester, (context) async {
+        await mixin.pickAndSendMediaNative(
+          context,
+          room: room,
+          onSendCallback: () => callbackCalled = true,
+        );
+      });
+
+      verifyNever(
+        uploadManager.uploadFileMobile(
+          room: anyNamed('room'),
+          fileInfos: anyNamed('fileInfos'),
+          caption: anyNamed('caption'),
+          inReplyTo: anyNamed('inReplyTo'),
+        ),
+      );
+      expect(callbackCalled, isFalse);
+    });
+
+    testWidgets('does nothing when the user cancels the caption dialog', (
+      tester,
+    ) async {
+      fakePicker.media = [XFile('uploads/photo.jpg')];
+      dialogOutcome = (_, __) => null; // user dismissed the sheet
+      var callbackCalled = false;
+
+      await withContext(tester, (context) async {
+        await mixin.pickAndSendMediaNative(
+          context,
+          room: room,
+          onSendCallback: () => callbackCalled = true,
+        );
+      });
+
+      verifyNever(
+        uploadManager.uploadFileMobile(
+          room: anyNamed('room'),
+          fileInfos: anyNamed('fileInfos'),
+          caption: anyNamed('caption'),
+          inReplyTo: anyNamed('inReplyTo'),
+        ),
+      );
+      expect(callbackCalled, isFalse);
+    });
+
+    testWidgets(
+      'sends only the files kept in the dialog (removed ones are dropped)',
+      (tester) async {
+        fakePicker.media = [
+          XFile('uploads/photo.jpg'),
+          XFile('uploads/clip.mp4'),
+        ];
+        // Simulate the user removing the video before sending.
+        dialogOutcome = (files, pendingText) => SendMediaNativeResult(
+          files: files.where((f) => f is! VideoFileInfo).toList(),
+          caption: pendingText,
+        );
+
+        await withContext(tester, (context) async {
+          await mixin.pickAndSendMediaNative(context, room: room);
+        });
+
+        final captured =
+            verify(
+                  uploadManager.uploadFileMobile(
+                    room: room,
+                    fileInfos: captureAnyNamed('fileInfos'),
+                    caption: anyNamed('caption'),
+                    inReplyTo: anyNamed('inReplyTo'),
+                  ),
+                ).captured.single
+                as List<FileInfo>;
+
+        expect(captured, hasLength(1));
+        expect(captured.single, isA<ImageFileInfo>());
+      },
+    );
+
+    testWidgets(
+      'maps an unknown file type to a bare FileInfo (not Image/Video)',
+      (tester) async {
+        fakePicker.media = [XFile('uploads/report.pdf')];
+
+        await withContext(tester, (context) async {
+          await mixin.pickAndSendMediaNative(context, room: room);
+        });
+
+        final captured =
+            verify(
+                  uploadManager.uploadFileMobile(
+                    room: room,
+                    fileInfos: captureAnyNamed('fileInfos'),
+                    caption: anyNamed('caption'),
+                    inReplyTo: anyNamed('inReplyTo'),
+                  ),
+                ).captured.single
+                as List<FileInfo>;
+
+        expect(captured, hasLength(1));
+        expect(captured.single, isA<FileInfo>());
+        expect(captured.single, isNot(isA<ImageFileInfo>()));
+        expect(captured.single, isNot(isA<VideoFileInfo>()));
+        expect(captured.single.fileName, 'report.pdf');
+      },
+    );
+
+    testWidgets(
+      'swallows picker errors without uploading, calling back, or rethrowing',
+      (tester) async {
+        var callbackCalled = false;
+
+        await withContext(tester, (context) async {
+          for (final error in <Object>[
+            PlatformException(code: 'cancelled'),
+            Exception('unexpected plugin failure'),
+          ]) {
+            fakePicker.error = error;
+
+            // Must not rethrow on this user-triggered path.
+            await mixin.pickAndSendMediaNative(
+              context,
+              room: room,
+              onSendCallback: () => callbackCalled = true,
+            );
+          }
+        });
+
+        verifyNever(
+          uploadManager.uploadFileMobile(
+            room: anyNamed('room'),
+            fileInfos: anyNamed('fileInfos'),
+            caption: anyNamed('caption'),
+            inReplyTo: anyNamed('inReplyTo'),
+          ),
+        );
+        expect(callbackCalled, isFalse);
+      },
+    );
+
+    testWidgets('does nothing when room is null', (tester) async {
+      fakePicker.media = [XFile('uploads/photo.jpg')];
+      var callbackCalled = false;
+
+      await withContext(tester, (context) async {
+        await mixin.pickAndSendMediaNative(
+          context,
+          room: null,
+          onSendCallback: () => callbackCalled = true,
+        );
+      });
+
+      verifyNever(
+        uploadManager.uploadFileMobile(
+          room: anyNamed('room'),
+          fileInfos: anyNamed('fileInfos'),
+          caption: anyNamed('caption'),
+          inReplyTo: anyNamed('inReplyTo'),
+        ),
+      );
+      expect(callbackCalled, isFalse);
+    });
+  });
+}

--- a/test/utils/voip/video_call_helper_test.dart
+++ b/test/utils/voip/video_call_helper_test.dart
@@ -1,0 +1,148 @@
+import 'package:fluffychat/utils/voip/video_call_helper.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'video_call_helper_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<Room>()])
+void main() {
+  const baseUrl = 'https://meet.example.com';
+
+  Event buildTextEvent(Map<String, dynamic> content) => Event(
+    content: content,
+    type: EventTypes.Message,
+    eventId: '\$evt:example.com',
+    senderId: '@alice:example.com',
+    originServerTs: DateTime.fromMillisecondsSinceEpoch(0),
+    room: MockRoom(),
+  );
+
+  group('VideoCallHelper.generateUrl', () {
+    test('produces a slug matching baseUrl/xxx-xxxx-xxx', () {
+      final url = VideoCallHelper.generateUrl(baseUrl);
+      expect(
+        RegExp(
+          '^${RegExp.escape(baseUrl)}/[a-z]{3}-[a-z]{4}-[a-z]{3}\$',
+        ).hasMatch(url),
+        isTrue,
+        reason: 'unexpected url: $url',
+      );
+    });
+
+    test('round-trips: a generated url is accepted by extractUrl', () {
+      final url = VideoCallHelper.generateUrl(baseUrl);
+      final event = buildTextEvent({
+        'msgtype': MessageTypes.Text,
+        'body': 'Has started a video call $url',
+        VideoCallHelper.callUrlKey: url,
+      });
+      expect(VideoCallHelper.extractUrl(event, baseUrl), url);
+    });
+  });
+
+  group('VideoCallHelper.extractUrl', () {
+    String validUrl() => '$baseUrl/abc-defg-hij';
+
+    test('returns the url for a well-formed video call event', () {
+      final event = buildTextEvent({
+        'msgtype': MessageTypes.Text,
+        'body': 'call',
+        VideoCallHelper.callUrlKey: validUrl(),
+      });
+      expect(VideoCallHelper.extractUrl(event, baseUrl), validUrl());
+    });
+
+    test('returns null when baseUrl is null or empty', () {
+      final event = buildTextEvent({
+        'msgtype': MessageTypes.Text,
+        VideoCallHelper.callUrlKey: validUrl(),
+      });
+      expect(VideoCallHelper.extractUrl(event, null), isNull);
+      expect(VideoCallHelper.extractUrl(event, ''), isNull);
+    });
+
+    test('returns null when the call_url key is missing', () {
+      final event = buildTextEvent({
+        'msgtype': MessageTypes.Text,
+        'body': 'plain text',
+      });
+      expect(VideoCallHelper.extractUrl(event, baseUrl), isNull);
+    });
+
+    test('returns null when the call_url value is an empty string', () {
+      final event = buildTextEvent({
+        'msgtype': MessageTypes.Text,
+        VideoCallHelper.callUrlKey: '',
+      });
+      expect(VideoCallHelper.extractUrl(event, baseUrl), isNull);
+    });
+
+    test('returns null for a non-text message type', () {
+      final event = buildTextEvent({
+        'msgtype': MessageTypes.Image,
+        VideoCallHelper.callUrlKey: validUrl(),
+      });
+      expect(VideoCallHelper.extractUrl(event, baseUrl), isNull);
+    });
+
+    test('returns null when the url does not start with baseUrl', () {
+      final event = buildTextEvent({
+        'msgtype': MessageTypes.Text,
+        VideoCallHelper.callUrlKey: 'https://evil.example.com/abc-defg-hij',
+      });
+      expect(VideoCallHelper.extractUrl(event, baseUrl), isNull);
+    });
+
+    test('returns null when the slug is malformed', () {
+      final event = buildTextEvent({
+        'msgtype': MessageTypes.Text,
+        VideoCallHelper.callUrlKey: '$baseUrl/not-a-valid-slug',
+      });
+      expect(VideoCallHelper.extractUrl(event, baseUrl), isNull);
+    });
+  });
+
+  group('VideoCallHelper.start', () {
+    late MockRoom room;
+
+    setUp(() {
+      room = MockRoom();
+      when(room.sendEvent(any)).thenAnswer((_) async => '\$sent:example.com');
+    });
+
+    test('sends a text event carrying the generated call_url', () {
+      VideoCallHelper.start(
+        room: room,
+        startedTitle: 'Has started a video call',
+        baseUrl: baseUrl,
+      );
+
+      final captured =
+          verify(room.sendEvent(captureAny)).captured.single
+              as Map<String, dynamic>;
+      expect(captured['msgtype'], MessageTypes.Text);
+      final url = captured[VideoCallHelper.callUrlKey] as String;
+      expect(
+        VideoCallHelper.extractUrl(buildTextEvent(captured), baseUrl),
+        url,
+      );
+      expect(captured['body'], contains(url));
+    });
+
+    test('does nothing when room is null', () {
+      VideoCallHelper.start(
+        room: null,
+        startedTitle: 'title',
+        baseUrl: baseUrl,
+      );
+      verifyNever(room.sendEvent(any));
+    });
+
+    test('does nothing when baseUrl is null', () {
+      VideoCallHelper.start(room: room, startedTitle: 'title', baseUrl: null);
+      verifyNever(room.sendEvent(any));
+    });
+  });
+}


### PR DESCRIPTION
## What

The chat media picker now opens the **OS-native gallery picker** on **both iOS and Android** (WhatsApp-style), replacing the custom `photo_manager` in-app grid on mobile.

- **iOS** → `PHPickerViewController`
- **Android** → the modern **Android Photo Picker** (`ACTION_PICK_IMAGES`)
- System albums + search + multi-select
- **No photo-library permission prompt** — both pickers run out-of-process
- **Web unchanged** — keeps the existing file/web pipeline

The mobile attachment bar is also revamped: a `+` popup menu (Documents / Camera) plus a dedicated gallery button.

## How

- New `SendFilesMixin.pickAndSendMediaNative()` opens `image_picker.pickMultipleMedia()`, maps each `XFile` to a typed `ImageFileInfo`/`VideoFileInfo` (with `customMimeType`), and pushes them through the existing `UploadManager.uploadFileMobile()` mobile pipeline.
- **Android Photo Picker opt-in**: `image_picker` defaults to the legacy `ACTION_GET_CONTENT` (file/SAF explorer) intent. `main.dart` now sets `ImagePickerAndroid.useAndroidPhotoPicker = true` (Android-only, one-time at startup) so Android gets the modern Photo Picker UI instead of the document explorer. Added `image_picker_android` + `image_picker_platform_interface` as direct deps (already transitive) to reference the flag.
- The downstream pipeline (thumbnail, image compression, **HEIC→JPG**, encryption, Matrix `m.image`/`m.video` event) is **reused as-is**. Returning typed `ImageFileInfo`/`VideoFileInfo` (not a bare `FileInfo`) is required so `sendFileEventMobile` triggers HEIC conversion + thumbnail, which are gated on the concrete type.
- `pickMultipleMedia()` wrapped in try/catch for `PlatformException`.
- **Web-narrow guard**: the mobile input bar is selected by viewport width (`responsiveUtils.isMobile`), not platform. On a narrow web viewport that mobile branch is still rendered, but the native picker feeds the mobile (`dart:io`) pipeline, which breaks on web. `chat_input_row.dart` now falls back to the single `+` button routed through `onSendFileClick`'s platform-aware path when `!PlatformInfos.isMobile`.

## Tests

`test/presentation/mixins/send_files_mixin_test.dart` — unit tests:
- picked files → typed `ImageFileInfo`/`VideoFileInfo`, `uploadFileMobile` called with caption + `inReplyTo`, callback fires
- empty selection → no upload, no callback
- null room → no upload, no callback

`fvm flutter analyze` clean. Tests green.

## Notes / trade-offs

- The native pickers are system-process sheets: not embeddable/restylable, so the custom in-app grid is replaced (not wrapped) on mobile — intended (WhatsApp-like).
- The Android Photo Picker requires the system Photo Picker module (guaranteed on Android 13+, backported via Play services on 11–12). Without it, Android falls back to the document/SAF explorer. **Emulators frequently lack the module**, so validate on a real Android 13+ device.
- The native picker has no per-image caption field; `sendController.text` is used as a single caption for the batch.
- `image_picker` was already a dependency (`^1.2.0`); no new top-level package added.
- Research write-up: `docs/research/ios-native-image-picker.md`. Plan: `docs/plan/2026-06-04-feat-ios-native-image-picker-plan.md` (note: both predate the Android scope and are partially superseded).

## Screenshots

### iOS

<img width="660" height="1434" alt="IMG_5807" src="https://github.com/user-attachments/assets/da58704d-3a55-4fa3-854b-2711d5a78f4e" />
<img width="660" height="1434" alt="IMG_5804" src="https://github.com/user-attachments/assets/9e1315f4-57f8-4a42-be78-bd8b7d068130" />
<img width="660" height="1434" alt="IMG_5803" src="https://github.com/user-attachments/assets/acbdc36d-fe30-4a15-a2b5-f1a4fe736882" />
<img width="1320" height="509" alt="IMG_5802" src="https://github.com/user-attachments/assets/6a40a486-b939-4537-8e0f-a5a186e3cf4d" />
<img width="660" height="1434" alt="IMG_5801" src="https://github.com/user-attachments/assets/f85edb10-03b2-4333-9737-5b12fa146dd0" />
<img width="1320" height="278" alt="IMG_5800" src="https://github.com/user-attachments/assets/f26aadf7-b90b-4fa5-a7b1-42c36b419e81" />

Video:
https://github.com/user-attachments/assets/ad7c69c7-f567-493d-b8dd-e548a01b3c50

### Android

<img width="437" height="785" alt="Android 1" src="https://github.com/user-attachments/assets/0f95d3e4-a067-46cd-a98c-b66d56a5b86b" />
<img width="362" height="67" alt="Android 2" src="https://github.com/user-attachments/assets/105ce03a-b3c3-4827-b2ff-aa7125069b88" />
<img width="437" height="850" alt="Android 3" src="https://github.com/user-attachments/assets/b241c1b4-27cb-413a-a244-77e1b96bd057" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated OS-native multi-select image/video picker on mobile (iOS + Android).
  * Mobile chat input shows an attachment menu (Gallery, Documents, Camera) and a gallery button for faster media selection.
  * Full-screen media preview dialog with per-file removal, batch caption, oversized-file detection, and video thumbnails.

* **Tests**
  * Added tests covering native picker mapping, upload flow, and caption/cancel behaviors.

* **Documentation**
  * Added research and implementation plan for iOS native image picker integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->