### PR TITLE
TW-3052(ui): implements new DS changes

### DIFF
--- a/lib/pages/chat/chat_scroll_view.dart
+++ b/lib/pages/chat/chat_scroll_view.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/presentation/widget_keys/widget_keys.dart';
 import 'package:fluffychat/pages/chat/chat.dart';
 import 'package:fluffychat/pages/chat/chat_event_list_item.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_list_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:inview_notifier_list/inview_notifier_list.dart';
@@ -32,16 +33,15 @@ class _ChatScrollViewState extends State<ChatScrollView> {
   bool _wasRequestingFuture = false;
   List<Event> _currentEvents = [];
   late Map<String, int> _eventIndexMap;
+  List<Event> _visibleEvents = const [];
+  Map<String, int> _visiblePosition = const {};
 
   @override
   void initState() {
     super.initState();
     _currentEvents = List<Event>.from(widget.events)
       ..sort((a, b) => b.originServerTs.compareTo(a.originServerTs));
-    _eventIndexMap = {
-      for (var i = 0; i < _currentEvents.length; i++)
-        _currentEvents[i].eventId: i,
-    };
+    _indexEvents();
     _bottom.addAll(_currentEvents);
   }
 
@@ -71,10 +71,7 @@ class _ChatScrollViewState extends State<ChatScrollView> {
 
     // Update the current events
     _currentEvents = newEvents;
-    _eventIndexMap = {
-      for (var i = 0; i < _currentEvents.length; i++)
-        _currentEvents[i].eventId: i,
-    };
+    _indexEvents();
 
     // Update the lists
     _top
@@ -125,6 +122,21 @@ class _ChatScrollViewState extends State<ChatScrollView> {
     });
   }
 
+  void _indexEvents() {
+    _eventIndexMap = {
+      for (var i = 0; i < _currentEvents.length; i++)
+        _currentEvents[i].eventId: i,
+    };
+    _visibleEvents = [
+      for (final event in _currentEvents)
+        if (event.isVisibleInGui) event,
+    ];
+    _visiblePosition = {
+      for (var i = 0; i < _visibleEvents.length; i++)
+        _visibleEvents[i].eventId: i,
+    };
+  }
+
   @override
   Widget build(BuildContext context) {
     final centerKey = ChatKeys.eventListCenter.valueKey;
@@ -169,11 +181,13 @@ class _ChatScrollViewState extends State<ChatScrollView> {
                 return const SizedBox.shrink();
               }
 
-              final previousEvent = currentEventIndex > 0
-                  ? _currentEvents[currentEventIndex - 1]
+              final visiblePos = _visiblePosition[currentEvent.eventId];
+              final previousEvent = visiblePos != null && visiblePos > 0
+                  ? _visibleEvents[visiblePos - 1]
                   : null;
-              final nextEvent = currentEventIndex < _currentEvents.length - 1
-                  ? _currentEvents[currentEventIndex + 1]
+              final nextEvent =
+                  visiblePos != null && visiblePos < _visibleEvents.length - 1
+                  ? _visibleEvents[visiblePos + 1]
                   : null;
               return ChatEventListItem(
                 event: currentEvent,
@@ -214,11 +228,13 @@ class _ChatScrollViewState extends State<ChatScrollView> {
                 return const SizedBox.shrink();
               }
 
-              final previousEvent = currentEventIndex > 0
-                  ? _currentEvents[currentEventIndex - 1]
+              final visiblePos = _visiblePosition[currentEvent.eventId];
+              final previousEvent = visiblePos != null && visiblePos > 0
+                  ? _visibleEvents[visiblePos - 1]
                   : null;
-              final nextEvent = currentEventIndex < _currentEvents.length - 1
-                  ? _currentEvents[currentEventIndex + 1]
+              final nextEvent =
+                  visiblePos != null && visiblePos < _visibleEvents.length - 1
+                  ? _visibleEvents[visiblePos + 1]
                   : null;
               return ChatEventListItem(
                 event: currentEvent,

--- a/lib/pages/chat/chat_scroll_view.dart
+++ b/lib/pages/chat/chat_scroll_view.dart
@@ -6,6 +6,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_list_extension.dart
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:inview_notifier_list/inview_notifier_list.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
 
 class ChatScrollView extends StatefulWidget {
@@ -127,21 +128,23 @@ class _ChatScrollViewState extends State<ChatScrollView> {
   @override
   Widget build(BuildContext context) {
     final centerKey = ChatKeys.eventListCenter.valueKey;
-    final horizontalPadding = TwakeThemes.isColumnMode(context) ? 16.0 : 0.0;
+    final horizontalPadding = TwakeThemes.isColumnMode(context)
+        ? LinagoraSpacing.base * 2
+        : 0.0;
+    final horizontalPaddingInsets = EdgeInsets.symmetric(
+      horizontal: horizontalPadding,
+    );
 
-    return Padding(
-      padding: EdgeInsets.only(
-        left: horizontalPadding,
-        right: horizontalPadding,
-      ),
-      child: InViewNotifierCustomScrollView(
-        isInViewPortCondition: controller.isInViewPortCondition,
-        center: centerKey,
-        anchor: 1,
-        controller: controller.scrollController,
-        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-        slivers: [
-          SliverList(
+    return InViewNotifierCustomScrollView(
+      isInViewPortCondition: controller.isInViewPortCondition,
+      center: centerKey,
+      anchor: 1,
+      controller: controller.scrollController,
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+      slivers: [
+        SliverPadding(
+          padding: horizontalPaddingInsets,
+          sliver: SliverList(
             delegate: SliverChildBuilderDelegate((context, index) {
               if (index == _bottom.length) {
                 if (controller.timeline!.isRequestingHistory) {
@@ -182,8 +185,11 @@ class _ChatScrollViewState extends State<ChatScrollView> {
               );
             }, childCount: _bottom.length + 1),
           ),
-          SliverList(
-            key: centerKey,
+        ),
+        SliverPadding(
+          key: centerKey,
+          padding: horizontalPaddingInsets,
+          sliver: SliverList(
             delegate: SliverChildBuilderDelegate((context, index) {
               if (index == _top.length) {
                 if (controller.timeline!.isRequestingFuture) {
@@ -224,8 +230,8 @@ class _ChatScrollViewState extends State<ChatScrollView> {
               );
             }, childCount: _top.length + 1),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/chat/chat_view_body.dart
+++ b/lib/pages/chat/chat_view_body.dart
@@ -90,6 +90,9 @@ class ChatViewBody extends StatelessWidget with MessageContentMixin {
                         ),
                       ),
                     ),
+                    const SizedBox(
+                      height: ChatViewBodyStyle.eventListBottomSpacing,
+                    ),
                     if (controller.canSendMessages) ...[
                       Center(
                         child: Container(

--- a/lib/pages/chat/chat_view_body_style.dart
+++ b/lib/pages/chat/chat_view_body_style.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
 
 class ChatViewBodyStyle {
   static ResponsiveUtils responsive = getIt.get<ResponsiveUtils>();
@@ -13,6 +14,9 @@ class ChatViewBodyStyle {
   static double chatScreenMaxWidth = 800.0;
 
   static double dividerSize = 1.0;
+
+  /// Minimum gap between the last message (or its reactions) and the composer bar.
+  static const double eventListBottomSpacing = LinagoraSpacing.base * 0.5;
 
   static double blockedUserBannerHeight = 40.0;
 

--- a/lib/pages/chat/events/formatted_text_widget.dart
+++ b/lib/pages/chat/events/formatted_text_widget.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/pages/chat/events/html_message.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/markdown_fix.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
@@ -27,7 +28,7 @@ class FormattedTextWidget extends StatelessWidget {
 
     return HtmlMessage(
       html: html,
-      defaultTextStyle: Theme.of(context).textTheme.bodyLarge,
+      defaultTextStyle: event.getMessageTextStyle(context),
       linkStyle: linkStyle,
       room: event.room,
       emoteSize: bigEmotes ? fontSize * 3 : fontSize * 1.5,

--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -60,20 +60,29 @@ class HtmlMessage extends StatelessWidget with LinkifyMixin {
     final matrix = Matrix.of(context);
 
     final themeData = Theme.of(context);
-    return Html(
-      data: renderHtml,
-      defaultTextStyle: defaultTextStyle,
-      emoteSize: emoteSize,
-      inlineSpanEnd: bottomWidgetSpan != null
-          ? WidgetSpan(child: bottomWidgetSpan!)
-          : null,
-      linkStyle:
-          linkStyle ??
+
+    // `Html` renders through raw `RichText`, which (unlike `Text`/`Text.rich`)
+    // does not merge the ambient `DefaultTextStyle`. We merge it in here so the
+    // app font family is preserved for styles that don't specify one — the
+    // design-system type-scale tokens intentionally carry no `fontFamily`.
+    final ambientStyle = DefaultTextStyle.of(context).style;
+    final effectiveDefaultTextStyle = ambientStyle.merge(defaultTextStyle);
+    final effectiveLinkStyle = ambientStyle.merge(
+      linkStyle ??
           themeData.textTheme.bodyMedium!.copyWith(
             color: themeData.colorScheme.secondary,
             decoration: TextDecoration.underline,
             decorationColor: themeData.colorScheme.secondary,
           ),
+    );
+    return Html(
+      data: renderHtml,
+      defaultTextStyle: effectiveDefaultTextStyle,
+      emoteSize: emoteSize,
+      inlineSpanEnd: bottomWidgetSpan != null
+          ? WidgetSpan(child: bottomWidgetSpan!)
+          : null,
+      linkStyle: effectiveLinkStyle,
       linkTypes: const [LinkType.url, LinkType.phone],
       shrinkToFit: true,
       maxLines: maxLines,

--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -69,7 +69,7 @@ class HtmlMessage extends StatelessWidget with LinkifyMixin {
     final effectiveDefaultTextStyle = ambientStyle.merge(defaultTextStyle);
     final effectiveLinkStyle = ambientStyle.merge(
       linkStyle ??
-          themeData.textTheme.bodyMedium!.copyWith(
+          themeData.textTheme.bodyMedium?.copyWith(
             color: themeData.colorScheme.secondary,
             decoration: TextDecoration.underline,
             decorationColor: themeData.colorScheme.secondary,

--- a/lib/pages/chat/events/message/display_name_widget.dart
+++ b/lib/pages/chat/events/message/display_name_widget.dart
@@ -25,8 +25,7 @@ class DisplayNameWidget extends StatelessWidget {
             displayName.shortenDisplayName(
               maxCharacters: maxCharactersDisplayNameBubble,
             ),
-            style: Theme.of(context).textTheme.labelMedium?.copyWith(
-              fontFamily: 'Inter',
+            style: LinagoraTextStyle.material().labelMedium.copyWith(
               color: LinagoraSysColors.material().secondary,
             ),
             maxLines: 2,

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -245,17 +245,28 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
         ? MainAxisAlignment.end
         : MainAxisAlignment.start;
 
+    final hasReactionEvent = widget.event.hasReactionEvent(
+      timeline: widget.timeline,
+    );
     final rowChildren = <Widget>[
       if (!widget.event.shouldAlignOwnMessageInDifferentSide)
-        OptionalSelectionContainerDisabled(
-          isEnabled: PlatformInfos.isWeb,
-          child: placeHolderWidget(
-            widget.onAvatarTap,
-            event: widget.event,
-            sameSender: widget.event.isSameSenderWith(widget.previousEvent),
-            ownMessage: widget.event.isOwnMessage,
-            context: context,
-            selectMode: widget.selectMode,
+        Padding(
+          // Reactions hang below the bubble (overflowing by
+          // kMessageReactionsOverlayHeight). Lift the avatar by that amount so
+          // its bottom aligns with the bubble's bottom, not the reactions'.
+          padding: EdgeInsets.only(
+            bottom: hasReactionEvent ? kMessageReactionsOverlayHeight : 0,
+          ),
+          child: OptionalSelectionContainerDisabled(
+            isEnabled: PlatformInfos.isWeb,
+            child: placeHolderWidget(
+              widget.onAvatarTap,
+              event: widget.event,
+              sameSender: widget.event.isSameSenderWith(widget.previousEvent),
+              ownMessage: widget.event.isOwnMessage,
+              context: context,
+              selectMode: widget.selectMode,
+            ),
           ),
         ),
       Expanded(

--- a/lib/pages/chat/events/message/message.dart
+++ b/lib/pages/chat/events/message/message.dart
@@ -263,6 +263,7 @@ class _MessageState extends State<Message> with MessageAvatarMixin {
           event: widget.event,
           matrixState: widget.matrixState,
           nextEvent: widget.nextEvent,
+          previousEvent: widget.previousEvent,
           onSelect: widget.onSelect,
           scrollToEventId: widget.scrollToEventId,
           selected: widget.selected,

--- a/lib/pages/chat/events/message/message_container.dart
+++ b/lib/pages/chat/events/message/message_container.dart
@@ -2,7 +2,6 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 import 'package:fluffychat/pages/chat/chat_view_body_style.dart';
 import 'package:fluffychat/pages/chat/events/message/message.dart';
 import 'package:fluffychat/pages/chat/events/message/message_selected_widget.dart';
-import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat/events/message/multi_platform_message_container.dart';
 import 'package:fluffychat/pages/chat/events/message/swipeable_message.dart';
 import 'package:fluffychat/pages/chat/optional_gesture_detector.dart';
@@ -52,7 +51,6 @@ class MessageContainer extends StatelessWidget {
         constraints: BoxConstraints(
           maxWidth: ChatViewBodyStyle.chatScreenMaxWidth,
         ),
-        padding: MessageStyle.paddingMessage,
         alignment: Alignment.bottomCenter,
         child: SwipeableMessage(
           event: event,
@@ -68,8 +66,6 @@ class MessageContainer extends StatelessWidget {
                         Message.responsiveUtils.isDesktop(context)
                     ? 8.0
                     : 16.0,
-                top: 1.0,
-                bottom: 1.0,
               ),
               isEnabled: !selected,
               child: MessageSelectedWidget(

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -454,8 +454,11 @@ class _MessageContentWithTimestampBuilderState
         widget.previousEvent != null &&
         widget.previousEvent!.senderId == widget.event.senderId;
     final showTail = !isDisplayOnlyEmoji && !hasSameSenderBelow;
+    final alignOwnMessageRight =
+        widget.event.isOwnMessage &&
+        _responsiveUtils.enableRightAndLeftMessageAlignment(context);
     final tailDirection = showTail
-        ? (widget.event.shouldAlignOwnMessageInDifferentSide
+        ? (alignOwnMessageRight
               ? BubbleTailDirection.right
               : BubbleTailDirection.left)
         : BubbleTailDirection.none;

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -449,10 +449,12 @@ class _MessageContentWithTimestampBuilderState
     );
 
     final isDisplayOnlyEmoji = widget.event.isDisplayOnlyEmoji(widget.timeline);
-    // The tail is shown on the last bubble of a same-sender group.
-    final hasSameSenderBelow =
-        widget.previousEvent != null &&
-        widget.previousEvent!.senderId == widget.event.senderId;
+    // The tail is shown on the last bubble of a same-sender group. A group
+    // ends below when the sender changes or a date separator breaks it
+    // (see [Event.isSameSenderWith]).
+    final hasSameSenderBelow = !widget.event.isSameSenderWith(
+      widget.previousEvent,
+    );
     final showTail = !isDisplayOnlyEmoji && !hasSameSenderBelow;
     final alignOwnMessageRight =
         widget.event.isOwnMessage &&

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -38,6 +38,7 @@ class MessageContentWithTimestampBuilder extends StatefulWidget {
   final Event event;
   final MatrixState? matrixState;
   final Event? nextEvent;
+  final Event? previousEvent;
   final void Function(Event)? onSelect;
   final void Function(String)? scrollToEventId;
   final void Function()? onDisplayEmojiReaction;
@@ -78,6 +79,7 @@ class MessageContentWithTimestampBuilder extends StatefulWidget {
     required this.event,
     this.matrixState,
     this.nextEvent,
+    this.previousEvent,
     this.onSelect,
     this.scrollToEventId,
     this.onDisplayEmojiReaction,
@@ -159,9 +161,6 @@ class _MessageContentWithTimestampBuilderState
         !widget.event.originServerTs.sameEnvironment(
           widget.nextEvent!.originServerTs,
         );
-    final noBubble =
-        {MessageTypes.Sticker}.contains(widget.event.messageType) &&
-        !widget.event.redacted;
 
     final timelineText =
         {
@@ -175,7 +174,6 @@ class _MessageContentWithTimestampBuilderState
       child: _messageContentWithTimestampBuilder(
         context: context,
         displayTime: displayTime,
-        noBubble: noBubble,
         timelineText: timelineText,
       ),
     );
@@ -184,7 +182,6 @@ class _MessageContentWithTimestampBuilderState
   Widget _messageContentWithTimestampBuilder({
     required BuildContext context,
     required bool displayTime,
-    required bool noBubble,
     required bool timelineText,
   }) {
     return Row(
@@ -222,8 +219,6 @@ class _MessageContentWithTimestampBuilderState
                       context,
                       event,
                       timelineText: timelineText,
-                      noBubble: noBubble,
-                      displayTime: displayTime,
                     )
                   : !widget.event.status.isError &&
                         !widget.event.status.isSending
@@ -231,15 +226,11 @@ class _MessageContentWithTimestampBuilderState
                       context,
                       event,
                       timelineText: timelineText,
-                      noBubble: noBubble,
-                      displayTime: displayTime,
                     )
                   : null,
               child: _messageBuilder(
                 context: context,
                 timelineText: timelineText,
-                noBubble: noBubble,
-                displayTime: displayTime,
               ),
             ),
           ),
@@ -252,13 +243,35 @@ class _MessageContentWithTimestampBuilderState
     );
   }
 
+  /// Wraps the message preview for a hero dialog with selection/scroll support.
+  Widget _buildHeroPreviewMessage({
+    required BuildContext context,
+    required String keyPrefix,
+    required bool timelineText,
+  }) {
+    return Material(
+      color: Colors.transparent,
+      child: SelectionArea(
+        child: SingleChildScrollView(
+          primary: true,
+          physics: const ClampingScrollPhysics(),
+          child: _messageBuilder(
+            key: ValueKey(
+              '$keyPrefix%${DateTime.now().millisecondsSinceEpoch}',
+            ),
+            context: context,
+            timelineText: timelineText,
+          ),
+        ),
+      ),
+    );
+  }
+
   /// Opens the hero emoji reaction dialog for available messages.
   Future<void> _handleAvailableMessageLongPress(
     BuildContext context,
     Event event, {
     required bool timelineText,
-    required bool noBubble,
-    required bool displayTime,
   }) async {
     // for pin screen
     if (widget.onLongPressMessage != null) {
@@ -277,48 +290,10 @@ class _MessageContentWithTimestampBuilderState
               displayEmojiPicker: _displayEmojiPicker,
               dialogSafeAreaKey:
                   MessageContentWithTimestampBuilder.dialogSafeAreaKey,
-              messageWidget: Material(
-                color: widget.event.isOwnMessage
-                    ? LinagoraRefColors.material().primary[95]
-                    : _responsiveUtils.isMobile(context)
-                    ? LinagoraSysColors.material().onPrimary
-                    : Theme.of(context).colorScheme.surfaceContainerHighest,
-                shape: RoundedRectangleBorder(
-                  borderRadius: MessageStyle.bubbleBorderRadius,
-                ),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    borderRadius: MessageStyle.bubbleBorderRadius,
-                    border:
-                        !widget.event.isOwnMessage &&
-                            _responsiveUtils.isMobile(context)
-                        ? Border.all(
-                            color: MessageStyle.borderColorReceivedBubble,
-                          )
-                        : null,
-                  ),
-                  child: SelectionArea(
-                    child: SingleChildScrollView(
-                      primary: true,
-                      physics: const ClampingScrollPhysics(),
-                      child: _messageBuilder(
-                        key: ValueKey(
-                          'PreviewReactionWidgetKey%${DateTime.now().millisecondsSinceEpoch}',
-                        ),
-                        context: context,
-                        timelineText: timelineText,
-                        noBubble: noBubble,
-                        displayTime: displayTime,
-                        paddingBubble: EdgeInsets.zero,
-                        enableBorder: false,
-                      ),
-                    ),
-                  ),
-                ),
+              messageWidget: _buildHeroPreviewMessage(
+                context: context,
+                keyPrefix: 'PreviewReactionWidgetKey',
+                timelineText: timelineText,
               ),
               emojiPickerBuilder: _emojiPickerBuilder,
               messageContextMenu: _messageContextMenu,
@@ -339,8 +314,6 @@ class _MessageContentWithTimestampBuilderState
     BuildContext context,
     Event event, {
     required bool timelineText,
-    required bool noBubble,
-    required bool displayTime,
   }) async {
     widget.onDisplayEmojiReaction?.call();
     _displayEmojiPicker.value = false;
@@ -354,48 +327,10 @@ class _MessageContentWithTimestampBuilderState
               dialogSafeAreaKey:
                   MessageContentWithTimestampBuilder.dialogSafeAreaKey,
               showReactions: false,
-              messageWidget: Material(
-                color: widget.event.isOwnMessage
-                    ? LinagoraRefColors.material().primary[95]
-                    : _responsiveUtils.isMobile(context)
-                    ? LinagoraSysColors.material().onPrimary
-                    : Theme.of(context).colorScheme.surfaceContainerHighest,
-                shape: RoundedRectangleBorder(
-                  borderRadius: MessageStyle.bubbleBorderRadius,
-                ),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 4,
-                    vertical: 4,
-                  ),
-                  decoration: BoxDecoration(
-                    borderRadius: MessageStyle.bubbleBorderRadius,
-                    border:
-                        !widget.event.isOwnMessage &&
-                            _responsiveUtils.isMobile(context)
-                        ? Border.all(
-                            color: MessageStyle.borderColorReceivedBubble,
-                          )
-                        : null,
-                  ),
-                  child: SelectionArea(
-                    child: SingleChildScrollView(
-                      primary: true,
-                      physics: const ClampingScrollPhysics(),
-                      child: _messageBuilder(
-                        key: ValueKey(
-                          'PreviewErrorWidgetKey%${DateTime.now().millisecondsSinceEpoch}',
-                        ),
-                        context: context,
-                        timelineText: timelineText,
-                        noBubble: noBubble,
-                        displayTime: displayTime,
-                        paddingBubble: EdgeInsets.zero,
-                        enableBorder: false,
-                      ),
-                    ),
-                  ),
-                ),
+              messageWidget: _buildHeroPreviewMessage(
+                context: context,
+                keyPrefix: 'PreviewErrorWidgetKey',
+                timelineText: timelineText,
               ),
               emojiPickerBuilder: _emojiPickerBuilder,
               messageContextMenu: _errorMessageContextMenu,
@@ -508,13 +443,78 @@ class _MessageContentWithTimestampBuilderState
     Key? key,
     required BuildContext context,
     required bool timelineText,
-    required bool noBubble,
-    required bool displayTime,
-    EdgeInsets? paddingBubble,
-    bool enableBorder = true,
   }) {
     final hasReactionEvent = widget.event.hasReactionEvent(
       timeline: widget.timeline,
+    );
+
+    final isDisplayOnlyEmoji = widget.event.isDisplayOnlyEmoji(widget.timeline);
+    // The tail is shown on the last bubble of a same-sender group.
+    final hasSameSenderBelow =
+        widget.previousEvent != null &&
+        widget.previousEvent!.senderId == widget.event.senderId;
+    final showTail = !isDisplayOnlyEmoji && !hasSameSenderBelow;
+    final tailDirection = showTail
+        ? (widget.event.isOwnMessage
+              ? BubbleTailDirection.right
+              : BubbleTailDirection.left)
+        : BubbleTailDirection.none;
+    // Media without caption/reply uses the tighter media padding.
+    final isMediaOnly = widget.event.isVideoOrImage && !timelineText;
+    final bubbleContentType = isMediaOnly
+        ? BubbleContentType.mediaOnly
+        : BubbleContentType.other;
+    final bubbleConstraints = BoxConstraints(
+      maxWidth: MessageStyle.messageBubbleWidth(
+        context,
+        event: widget.event,
+        maxWidthScreen: widget.maxWidth,
+      ),
+    );
+    final bubbleContent = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (!_hideDisplayName(context))
+          OptionalSelectionContainerDisabled(
+            isEnabled: PlatformInfos.isWeb,
+            child: DisplayNameWidget(event: widget.event),
+          ),
+        OptionalStack(
+          isEnabled: timelineText,
+          alignment: AlignmentDirectional.bottomEnd,
+          children: [
+            MessageContentBuilder(
+              event: widget.event,
+              timeline: widget.timeline,
+              onSelect: widget.onSelect,
+              nextEvent: widget.nextEvent,
+              scrollToEventId: widget.scrollToEventId,
+              selectMode: widget.selectMode,
+              onRetryTextMessage: widget.onRetryTextMessage,
+            ),
+            if (!widget.event.isReplyEventWithAudio())
+              OptionalSelectionContainerDisabled(
+                isEnabled: PlatformInfos.isWeb,
+                child: Padding(
+                  padding: MessageStyle.paddingMessageTime,
+                  child: Text.rich(
+                    WidgetSpan(
+                      child: MessageTime(
+                        timelineOverlayMessage:
+                            widget.event.timelineOverlayMessage,
+                        room: widget.event.room,
+                        event: widget.event,
+                        showSeenIcon: widget.event.isOwnMessage,
+                        timeline: widget.timeline,
+                        onRetryTextMessage: widget.onRetryTextMessage,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ],
     );
 
     return OptionalStack(
@@ -524,84 +524,17 @@ class _MessageContentWithTimestampBuilderState
           : AlignmentDirectional.bottomEnd,
       isEnabled: hasReactionEvent,
       children: [
-        Container(
-          decoration: widget.event.isDisplayOnlyEmoji(widget.timeline)
-              ? null
-              : BoxDecoration(
-                  borderRadius: MessageStyle.bubbleBorderRadius,
-                  color: widget.event.isOwnMessage
-                      ? LinagoraRefColors.material().primary[95]
-                      : _responsiveUtils.isMobile(context)
-                      ? LinagoraSysColors.material().onPrimary
-                      : Theme.of(context).colorScheme.surfaceContainerHighest,
-                  border: enableBorder
-                      ? (!widget.event.isOwnMessage &&
-                                _responsiveUtils.isMobile(context)
-                            ? Border.all(
-                                color: MessageStyle.borderColorReceivedBubble,
-                              )
-                            : null)
-                      : null,
-                ),
-          padding:
-              paddingBubble ??
-              (noBubble
-                  ? const .symmetric(horizontal: 16.0)
-                  : MessageStyle.paddingMessageContentBuilder(widget.event)),
-          constraints: BoxConstraints(
-            maxWidth: MessageStyle.messageBubbleWidth(
-              context,
-              event: widget.event,
-              maxWidthScreen: widget.maxWidth,
-            ),
+        if (isDisplayOnlyEmoji)
+          Container(constraints: bubbleConstraints, child: bubbleContent)
+        else
+          MessageBubble(
+            isOwnMessage: widget.event.isOwnMessage,
+            tailDirection: tailDirection,
+            hasReactions: hasReactionEvent,
+            contentType: bubbleContentType,
+            constraints: bubbleConstraints,
+            child: bubbleContent,
           ),
-          margin: hasReactionEvent ? const .only(bottom: 24) : null,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              if (!_hideDisplayName(context))
-                OptionalSelectionContainerDisabled(
-                  isEnabled: PlatformInfos.isWeb,
-                  child: DisplayNameWidget(event: widget.event),
-                ),
-              OptionalStack(
-                isEnabled: timelineText,
-                alignment: AlignmentDirectional.bottomEnd,
-                children: [
-                  MessageContentBuilder(
-                    event: widget.event,
-                    timeline: widget.timeline,
-                    onSelect: widget.onSelect,
-                    nextEvent: widget.nextEvent,
-                    scrollToEventId: widget.scrollToEventId,
-                    selectMode: widget.selectMode,
-                    onRetryTextMessage: widget.onRetryTextMessage,
-                  ),
-                  if (!widget.event.isReplyEventWithAudio())
-                    OptionalSelectionContainerDisabled(
-                      isEnabled: PlatformInfos.isWeb,
-                      child: Padding(
-                        padding: MessageStyle.paddingMessageTime,
-                        child: Text.rich(
-                          WidgetSpan(
-                            child: MessageTime(
-                              timelineOverlayMessage:
-                                  widget.event.timelineOverlayMessage,
-                              room: widget.event.room,
-                              event: widget.event,
-                              showSeenIcon: widget.event.isOwnMessage,
-                              timeline: widget.timeline,
-                              onRetryTextMessage: widget.onRetryTextMessage,
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
-                ],
-              ),
-            ],
-          ),
-        ),
         PositionedDirectional(
           start: 8,
           end: 0,

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -455,7 +455,7 @@ class _MessageContentWithTimestampBuilderState
         widget.previousEvent!.senderId == widget.event.senderId;
     final showTail = !isDisplayOnlyEmoji && !hasSameSenderBelow;
     final tailDirection = showTail
-        ? (widget.event.isOwnMessage
+        ? (widget.event.shouldAlignOwnMessageInDifferentSide
               ? BubbleTailDirection.right
               : BubbleTailDirection.left)
         : BubbleTailDirection.none;

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -462,8 +462,10 @@ class _MessageContentWithTimestampBuilderState
               ? BubbleTailDirection.right
               : BubbleTailDirection.left)
         : BubbleTailDirection.none;
-    // Media without caption/reply uses the tighter media padding.
-    final isMediaOnly = widget.event.isVideoOrImage && !timelineText;
+    final showDisplayName = !_hideDisplayName(context);
+    // Media without caption/reply uses the tighter media padding
+    final isMediaOnly =
+        widget.event.isVideoOrImage && !timelineText && !showDisplayName;
     final bubbleContentType = isMediaOnly
         ? BubbleContentType.mediaOnly
         : BubbleContentType.other;
@@ -477,7 +479,7 @@ class _MessageContentWithTimestampBuilderState
     final bubbleContent = Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (!_hideDisplayName(context))
+        if (showDisplayName)
           OptionalSelectionContainerDisabled(
             isEnabled: PlatformInfos.isWeb,
             child: DisplayNameWidget(event: widget.event),

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -14,7 +14,6 @@ class MessageStyle {
   static ResponsiveUtils responsiveUtils = getIt.get<ResponsiveUtils>();
 
   static const double heightDivider = 1.0;
-  static final bubbleBorderRadius = BorderRadius.circular(16);
   static final errorStatusPlaceHolderWidth = 16 * AppConfig.bubbleSizeFactor;
   static final errorStatusPlaceHolderHeight = 16 * AppConfig.bubbleSizeFactor;
   static const double avatarSize = 40;
@@ -254,7 +253,6 @@ class MessageStyle {
   static const double pushpinIconSize = 14.0;
 
   static const double paddingAllPushpin = 0;
-  static const Color borderColorReceivedBubble = Color(0xFFEBEDF0);
 
   static MainAxisAlignment messageAlignment(
     Event event,

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/domain/matrix_events/event_type_rules.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
 import 'package:fluffychat/presentation/model/file/display_image_info.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
@@ -205,21 +206,19 @@ class MessageStyle {
     Event? nextEvent,
     Event currentEvent,
   ) {
-    // add spaces to messages only
     if (nextEvent == null ||
         displayTime ||
-        nextEvent.type != EventTypes.Message) {
+        !EventTypeRules.messageContentTypes.contains(nextEvent.type)) {
       return 0;
     }
 
-    return currentEvent.senderId != nextEvent.senderId ? 8 : 4;
+    return currentEvent.senderId != nextEvent.senderId
+        ? LinagoraSpacing.base
+        : LinagoraSpacing.base / 4;
   }
 
   static EdgeInsets paddingDisplayName(Event event) =>
       const EdgeInsets.only(bottom: LinagoraSpacing.base / 2);
-
-  static EdgeInsets get paddingMessage =>
-      const EdgeInsets.symmetric(vertical: 2.0);
 
   static EdgeInsets get paddingTimestamp =>
       const EdgeInsets.only(left: 8.0, right: 4.0);

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -216,10 +216,8 @@ class MessageStyle {
     return currentEvent.senderId != nextEvent.senderId ? 8 : 4;
   }
 
-  static EdgeInsets paddingDisplayName(Event event) => EdgeInsets.only(
-    left: event.messageType == MessageTypes.Image ? 0 : 8.0,
-    bottom: 4.0,
-  );
+  static EdgeInsets paddingDisplayName(Event event) =>
+      const EdgeInsets.only(bottom: 4.0);
 
   static EdgeInsets get paddingMessage =>
       const EdgeInsets.symmetric(vertical: 2.0);
@@ -244,16 +242,6 @@ class MessageStyle {
       end: selected || responsiveUtils.isDesktop(context) ? 8 : 0,
     );
   }
-
-  static EdgeInsets paddingMessageContentBuilder(Event event) =>
-      EdgeInsets.only(
-        left: 8 * AppConfig.bubbleSizeFactor,
-        right: 8 * AppConfig.bubbleSizeFactor,
-        top: 8 * AppConfig.bubbleSizeFactor,
-        bottom: event.timelineOverlayMessage
-            ? 8 * AppConfig.bubbleSizeFactor
-            : 0 * AppConfig.bubbleSizeFactor,
-      );
 
   static EdgeInsets get paddingMessageTime =>
       const EdgeInsets.only(left: 6, right: 8.0, bottom: 4.0);

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -63,7 +63,7 @@ class MessageStyle {
       Theme.of(context).colorScheme.surfaceTint.withOpacity(0.08);
 
   static const double messageBubbleDesktopMaxWidth = 520.0;
-  static const double messageBubbleMobileRatioMaxWidth = 0.80;
+  static const double messageBubbleMobileRatioMaxWidth = 0.88;
   static const double messageBubbleTabletRatioMaxWidth = 0.30;
   static const double iconContextMenuSize = 40;
 

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -8,6 +8,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
 import 'package:matrix/matrix.dart';
 
 class MessageStyle {
@@ -216,7 +217,7 @@ class MessageStyle {
   }
 
   static EdgeInsets paddingDisplayName(Event event) =>
-      const EdgeInsets.only(bottom: 4.0);
+      const EdgeInsets.only(bottom: LinagoraSpacing.base / 2);
 
   static EdgeInsets get paddingMessage =>
       const EdgeInsets.symmetric(vertical: 2.0);

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -19,7 +19,6 @@ class MessageStyle {
   static final errorStatusPlaceHolderHeight = 16 * AppConfig.bubbleSizeFactor;
   static const double avatarSize = 40;
   static const double fontSize = 15;
-  static const notSameSenderPadding = EdgeInsets.only(left: 8.0, bottom: 4);
 
   static const double buttonHeight = 66;
 

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -107,7 +107,6 @@ class MessageContent extends StatelessWidget
                           context,
                         ),
                         richTextStyle: event.getMessageTextStyle(context),
-                        isCaption: event.isCaptionModeOrReply(),
                       ),
                     ),
                 ],
@@ -217,7 +216,6 @@ class MessageContent extends StatelessWidget
                           context,
                         ),
                         richTextStyle: event.getMessageTextStyle(context),
-                        isCaption: event.isCaptionModeOrReply(),
                       ),
                     ),
                 ],
@@ -313,15 +311,10 @@ class MessageContent extends StatelessWidget
                 !event.redacted &&
                 event.isRichMessage &&
                 containedLink.isEmpty) {
-              return Padding(
-                padding: MessageContentStyle.emojiPadding,
-                child: FormattedTextWidget(
-                  event: event,
-                  linkStyle: MessageContentStyle.linkStyleMessageContent(
-                    context,
-                  ),
-                  fontSize: fontSize,
-                ),
+              return FormattedTextWidget(
+                event: event,
+                linkStyle: MessageContentStyle.linkStyleMessageContent(context),
+                fontSize: fontSize,
               );
             }
             // else we fall through to the normal message rendering

--- a/lib/pages/chat/events/message_content_style.dart
+++ b/lib/pages/chat/events/message_content_style.dart
@@ -4,6 +4,7 @@ import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/style/linagora_text_style.dart';
 
 class MessageContentStyle {
   static ResponsiveUtils responsiveUtils = getIt.get<ResponsiveUtils>();
@@ -82,7 +83,7 @@ class MessageContentStyle {
   );
 
   static TextStyle? linkStyleMessageContent(BuildContext context) =>
-      Theme.of(context).textTheme.bodyLarge?.copyWith(
+      LinagoraTextStyle.material().bodyMedium3.copyWith(
         color: Theme.of(context).colorScheme.secondary,
       );
 

--- a/lib/pages/chat/events/message_content_style.dart
+++ b/lib/pages/chat/events/message_content_style.dart
@@ -81,8 +81,6 @@ class MessageContentStyle {
     vertical: 4,
   );
 
-  static const EdgeInsets emojiPadding = EdgeInsets.symmetric(horizontal: 8.0);
-
   static TextStyle? linkStyleMessageContent(BuildContext context) =>
       Theme.of(context).textTheme.bodyLarge?.copyWith(
         color: Theme.of(context).colorScheme.secondary,

--- a/lib/pages/chat/events/message_reactions.dart
+++ b/lib/pages/chat/events/message_reactions.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
+import 'package:linagora_design_flutter/style/linagora_text_style.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
@@ -151,7 +152,7 @@ class ReactionsList extends StatelessWidget {
             child: Center(
               child: Text(
                 '+${reactionList.length - 3}',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                style: LinagoraTextStyle.material().bodyMedium.copyWith(
                   color: LinagoraRefColors.material().neutral[50],
                 ),
               ),
@@ -431,7 +432,7 @@ class Reaction extends StatelessWidget {
                 '$count',
                 style:
                     countStyle ??
-                    Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    LinagoraTextStyle.material().bodyMedium.copyWith(
                       color: LinagoraRefColors.material().neutral[50],
                     ),
                 textAlign: TextAlign.center,

--- a/lib/pages/chat/events/message_time.dart
+++ b/lib/pages/chat/events/message_time.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 import 'package:linagora_design_flutter/colors/linagora_state_layer.dart';
+import 'package:linagora_design_flutter/style/linagora_text_style.dart';
 import 'package:matrix/matrix.dart';
 
 class MessageTime extends StatelessWidget {
@@ -64,25 +65,19 @@ class MessageTime extends StatelessWidget {
             Text(
               '${L10n.of(context)!.edited} ',
               textScaler: const TextScaler.linear(1.0),
-              style: Theme.of(context).textTheme.bodySmall?.merge(
-                TextStyle(
-                  color: timelineOverlayMessage
-                      ? Colors.white
-                      : LinagoraRefColors.material().tertiary[30],
-                  letterSpacing: 0.4,
-                ),
+              style: LinagoraTextStyle.material().bodySmall.copyWith(
+                color: timelineOverlayMessage
+                    ? Colors.white
+                    : LinagoraRefColors.material().tertiary[30],
               ),
             ),
           Text(
             DateFormat("HH:mm").format(event.originServerTs),
             textScaler: const TextScaler.linear(1.0),
-            style: Theme.of(context).textTheme.bodySmall?.merge(
-              TextStyle(
-                color: timelineOverlayMessage
-                    ? Colors.white
-                    : LinagoraRefColors.material().tertiary[30],
-                letterSpacing: 0.4,
-              ),
+            style: LinagoraTextStyle.material().bodySmall.copyWith(
+              color: timelineOverlayMessage
+                  ? Colors.white
+                  : LinagoraRefColors.material().tertiary[30],
             ),
           ),
           TextMessageRetryButton(event: event, onRetry: onRetryTextMessage),

--- a/lib/pages/chat/events/message_upload_content.dart
+++ b/lib/pages/chat/events/message_upload_content.dart
@@ -230,7 +230,6 @@ class _MessageUploadingContentState extends State<MessageUploadingContent>
               fontSize: AppConfig.messageFontSize * AppConfig.fontSizeFactor,
               linkStyle: MessageContentStyle.linkStyleMessageContent(context),
               richTextStyle: event.getMessageTextStyle(context),
-              isCaption: event.isCaptionModeOrReply(),
             ),
           ),
         ],

--- a/lib/pages/chat/events/reply_content_style.dart
+++ b/lib/pages/chat/events/reply_content_style.dart
@@ -6,7 +6,6 @@ import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 
 class ReplyContentStyle {
   static ResponsiveUtils responsive = getIt.get<ResponsiveUtils>();
-  static const double fontSizeDisplayName = AppConfig.messageFontSize * 0.76;
   static const double fontSizeDisplayContent = AppConfig.messageFontSize * 0.88;
   static const double replyContentSize = fontSizeDisplayContent * 2;
 
@@ -45,19 +44,15 @@ class ReplyContentStyle {
   static const double previewedImagePlaceholderPadding = 4.0;
 
   static TextStyle? displayNameTextStyle(BuildContext context) {
-    return Theme.of(context).textTheme.titleSmall?.copyWith(
+    return LinagoraTextStyle.material().titleSmall.copyWith(
       color: Theme.of(context).colorScheme.onSurfaceVariant,
-      fontWeight: FontWeight.bold,
-      fontSize: fontSizeDisplayName,
     );
   }
 
   static TextStyle? replyBodyTextStyle(BuildContext context) {
-    return Theme.of(context).textTheme.bodySmall?.copyWith(
+    return LinagoraTextStyle.material().bodyMedium.copyWith(
       color: LinagoraRefColors.material().neutral[50],
-      fontWeight: FontWeight.w500,
       overflow: TextOverflow.ellipsis,
-      fontSize: fontSizeDisplayContent,
     );
   }
 

--- a/lib/presentation/mixins/message_avatar_mixin.dart
+++ b/lib/presentation/mixins/message_avatar_mixin.dart
@@ -24,8 +24,7 @@ mixin MessageAvatarMixin {
     required BuildContext context,
     required bool selectMode,
   }) {
-    if (selectMode ||
-        (event.room.isDirectChat && responsive.isMobile(context))) {
+    if (selectMode || event.room.isDirectChat) {
       return const SizedBox.shrink();
     }
 

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -22,6 +22,7 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:future_loading_dialog/future_loading_dialog.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
+import 'package:linagora_design_flutter/style/linagora_text_style.dart';
 import 'package:matrix/matrix.dart';
 import 'package:universal_html/html.dart' as html;
 
@@ -331,7 +332,7 @@ extension LocalizedBody on Event {
       return textStyleForOnlyEmoji(context);
     }
 
-    return Theme.of(context).textTheme.bodyLarge?.copyWith(
+    return LinagoraTextStyle.material().bodyMedium3.copyWith(
       color: Theme.of(context).colorScheme.onSurface,
     );
   }

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -6,6 +6,7 @@ import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/pages/chat/events/message_reactions.dart';
 import 'package:fluffychat/presentation/extensions/media_thumbnail_extension.dart';
 import 'package:fluffychat/utils/clipboard.dart';
+import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/extension/event_info_extension.dart';
 import 'package:fluffychat/utils/extension/mime_type_extension.dart';
@@ -152,7 +153,10 @@ extension LocalizedBody on Event {
     );
   }
 
-  // Check if the sender of the current event is the same as the compared event.
+  // Returns true when this event and the compared event do NOT belong to the
+  // same visual sender group: different sender, non-message event in between,
+  // or a date separator between them (different environment). Avatar, bubble
+  // tail and display name all rely on this boundary.
   bool isSameSenderWith(Event? comparedEvent) {
     // If the compared event is null, it is assumed that the message is the newest.
     if (comparedEvent == null) {
@@ -175,7 +179,8 @@ extension LocalizedBody on Event {
       return true;
     }
 
-    return senderId != comparedEvent.senderId;
+    return senderId != comparedEvent.senderId ||
+        !originServerTs.sameEnvironment(comparedEvent.originServerTs);
   }
 
   bool get isOwnMessage => senderId == room.client.userID;

--- a/lib/widgets/file_widget/base_file_tile_widget.dart
+++ b/lib/widgets/file_widget/base_file_tile_widget.dart
@@ -132,7 +132,6 @@ class BaseFileTileWidget extends StatelessWidget {
             fontSize: AppConfig.messageFontSize * AppConfig.fontSizeFactor,
             linkStyle: MessageContentStyle.linkStyleMessageContent(context),
             richTextStyle: event!.getMessageTextStyle(context),
-            isCaption: event!.isCaptionModeOrReply(),
           ),
         ),
       ];

--- a/lib/widgets/file_widget/download_file_tile_widget.dart
+++ b/lib/widgets/file_widget/download_file_tile_widget.dart
@@ -183,7 +183,6 @@ class DownloadFileTileWidget extends StatelessWidget {
               fontSize: AppConfig.messageFontSize * AppConfig.fontSizeFactor,
               linkStyle: MessageContentStyle.linkStyleMessageContent(context),
               richTextStyle: event!.getMessageTextStyle(context),
-              isCaption: event!.isCaptionModeOrReply(),
             ),
           ),
         ],

--- a/lib/widgets/file_widget/downloading_file_tile_widget.dart
+++ b/lib/widgets/file_widget/downloading_file_tile_widget.dart
@@ -168,7 +168,6 @@ class DownloadingFileTileWidget extends StatelessWidget {
               fontSize: AppConfig.messageFontSize * AppConfig.fontSizeFactor,
               linkStyle: MessageContentStyle.linkStyleMessageContent(context),
               richTextStyle: event!.getMessageTextStyle(context),
-              isCaption: event!.isCaptionModeOrReply(),
             ),
           ),
         ],

--- a/lib/widgets/file_widget/file_tile_widget_style.dart
+++ b/lib/widgets/file_widget/file_tile_widget_style.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_matrix_html/color_extension.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
+import 'package:linagora_design_flutter/style/linagora_text_style.dart';
 
 class FileTileWidgetStyle {
   const FileTileWidgetStyle();
@@ -37,15 +38,15 @@ class FileTileWidgetStyle {
   }
 
   TextStyle? textStyle(BuildContext context) {
-    return Theme.of(context).textTheme.bodyLarge?.copyWith(
+    return LinagoraTextStyle.material().bodyMedium2.copyWith(
       color: Theme.of(context).colorScheme.onSurface,
     );
   }
 
   TextStyle textInformationStyle(BuildContext context) {
-    return Theme.of(
-      context,
-    ).textTheme.bodySmall!.copyWith(color: fileInfoColor);
+    return LinagoraTextStyle.material().bodySmall.copyWith(
+      color: fileInfoColor,
+    );
   }
 
   EdgeInsets get imagePadding => const EdgeInsets.all(4.0);

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
@@ -17,7 +17,6 @@ class TwakeLinkPreview extends StatelessWidget with LinkifyMixin {
   final double fontSize;
   final TextStyle? linkStyle;
   final TextStyle? richTextStyle;
-  final bool isCaption;
 
   const TwakeLinkPreview({
     super.key,
@@ -27,7 +26,6 @@ class TwakeLinkPreview extends StatelessWidget with LinkifyMixin {
     required this.fontSize,
     this.linkStyle,
     this.richTextStyle,
-    this.isCaption = false,
   });
 
   static ValueKey<String> get twakeLinkViewKey =>
@@ -42,7 +40,6 @@ class TwakeLinkPreview extends StatelessWidget with LinkifyMixin {
     return TwakeLinkView(
       key: twakeLinkViewKey,
       firstValidUrl: firstValidUrl,
-      isCaption: isCaption,
       body: event.formattedText.isNotEmpty
           ? FormattedTextWidget(
               event: event,

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
@@ -268,7 +268,7 @@ class LinkPreviewBuilder extends StatelessWidget {
                   child: Text(
                     key: LinkPreviewBuilder.titleKey,
                     urlPreviewPresentation.title ?? '',
-                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    style: LinagoraTextStyle.material().bodyMedium2.copyWith(
                       color: Theme.of(context).colorScheme.onSurfaceVariant,
                     ),
                     maxLines: 2,
@@ -281,8 +281,8 @@ class LinkPreviewBuilder extends StatelessWidget {
                   child: Text(
                     key: LinkPreviewBuilder.subtitleKey,
                     urlPreviewPresentation.description ?? '',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: LinagoraRefColors.material().neutral[50],
+                    style: LinagoraTextStyle.material().titleSmall.copyWith(
+                      color: LinagoraRefColors.material().tertiary[20],
                     ),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_view.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_view.dart
@@ -5,20 +5,18 @@ class TwakeLinkView extends StatelessWidget {
   final Widget body;
   final Widget previewItemWidget;
   final String? firstValidUrl;
-  final bool isCaption;
 
   const TwakeLinkView({
     super.key,
     required this.body,
     required this.previewItemWidget,
     this.firstValidUrl,
-    this.isCaption = false,
   });
 
   @override
   Widget build(BuildContext context) {
     if (firstValidUrl == null) {
-      return _buildMessageBody(context);
+      return body;
     }
 
     return _buildMessageWithPreview(context);
@@ -29,24 +27,10 @@ class TwakeLinkView extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Padding(
-          padding: isCaption
-              ? EdgeInsets.zero
-              : TwakeLinkViewStyle.previewItemPadding,
-          child: previewItemWidget,
-        ),
+        previewItemWidget,
         const SizedBox(height: TwakeLinkViewStyle.previewToBodySpacing),
-        _buildMessageBody(context),
+        body,
       ],
-    );
-  }
-
-  Widget _buildMessageBody(BuildContext context) {
-    return Padding(
-      padding: isCaption
-          ? EdgeInsets.zero
-          : TwakeLinkViewStyle.paddingMessageBody,
-      child: body,
     );
   }
 }

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_view_style.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_view_style.dart
@@ -5,14 +5,8 @@ import 'package:flutter/material.dart';
 class TwakeLinkViewStyle {
   static ResponsiveUtils responsiveUtils = getIt.get<ResponsiveUtils>();
 
-  static const EdgeInsetsDirectional paddingMessageBody =
-      EdgeInsetsDirectional.symmetric(horizontal: 8.0);
-
   static const EdgeInsetsDirectional paddingCleanRichText =
       EdgeInsetsDirectional.only(start: 8.0, end: 8.0, top: 8.0);
 
   static const double previewToBodySpacing = 2.0;
-  static const previewItemPadding = EdgeInsetsDirectional.symmetric(
-    horizontal: 8.0,
-  );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -930,7 +930,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: "66b2f48eef7c42f3a6a4dfcf0c50e38302ca3750"
+      resolved-ref: "70b7135b98abf41607ad7c04d0c44ab4529b3786"
       url: "https://github.com/linagora/emoji_mart.git"
     source: git
     version: "1.0.2"
@@ -1810,11 +1810,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: master
-      resolved-ref: fac936dfb4721612494a326032e82feeb75f51d2
+      ref: "v0.1.0"
+      resolved-ref: f2a08a92a4a37424956a7a945cd1e0d23dbff060
       url: "https://github.com/linagora/linagora-design-flutter.git"
     source: git
-    version: "0.0.1"
+    version: "0.1.0"
   linkfy_text:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   linagora_design_flutter:
     git:
       url: https://github.com/linagora/linagora-design-flutter.git
-      ref: master
+      ref: v0.1.0
   flutter_matrix_html:
     git:
       url: https://github.com/linagora/flutter_matrix_html.git

--- a/test/mixin/message_avatar_mixin_test.dart
+++ b/test/mixin/message_avatar_mixin_test.dart
@@ -126,7 +126,7 @@ Future<void> main() async {
         expect(find.byType(Avatar), findsOneWidget);
       });
 
-      testWidgets('Should display Avatar when Own message in direct chat', (
+      testWidgets('Should return SizedBox when Own message in direct chat', (
         WidgetTester tester,
       ) async {
         await runTest(
@@ -138,11 +138,11 @@ Future<void> main() async {
           screenSize: webSize,
           isDirectChat: true,
         );
-        verify(room.requestUser(event.senderId, ignoreErrors: true)).called(1);
-        expect(find.byType(Avatar), findsOneWidget);
+        verifyNever(room.requestUser(event.senderId, ignoreErrors: true));
+        expect(find.byType(SizedBox), findsOneWidget);
       });
 
-      testWidgets('Should return Avatar when Not my message in direct chat', (
+      testWidgets('Should return SizedBox when Not my message in direct chat', (
         WidgetTester tester,
       ) async {
         await runTest(
@@ -154,8 +154,8 @@ Future<void> main() async {
           screenSize: webSize,
           isDirectChat: true,
         );
-        verify(room.requestUser(event.senderId, ignoreErrors: true)).called(1);
-        expect(find.byType(Avatar), findsOneWidget);
+        verifyNever(room.requestUser(event.senderId, ignoreErrors: true));
+        expect(find.byType(SizedBox), findsOneWidget);
       });
 
       testWidgets('Should return Avatar when not my message in group chat', (

--- a/test/pages/chat/events/message/message_content_builder_mixin_test.dart
+++ b/test/pages/chat/events/message/message_content_builder_mixin_test.dart
@@ -256,7 +256,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "prefix line one\nprefix line two\nsioaldhgowehg wegh welg abcdefghij klmn",
+                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with filename -> Done",
+              "format": "org.matrix.custom.html",
+              "formatted_body":
+                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with filename -&gt; Done</p>",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -358,7 +361,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "prefix line one\nprefix line two\nsioaldhgowehg wegh welg abcdefghij klmn",
+                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with filename -> Done",
+              "format": "org.matrix.custom.html",
+              "formatted_body":
+                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with filename -&gt; Done</p>",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -466,7 +472,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "prefix line one\nprefix line two\nsioaldhgowehg wegh welg abcdefghij",
+                  "- Copy/Drop text from LibreOffice files to composer\n- Download PDF file from Chrome viewer\n- Download attachment for mobile\n- Small improvements for Printing emails",
+              "format": "org.matrix.custom.html",
+              "formatted_body":
+                  "- Copy/Drop text from LibreOffice files to composer<br/>- Download PDF file from Chrome viewer<br/>- Download attachment for mobile<br/>- Small improvements for Printing emails",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -566,7 +575,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "prefix line one\nprefix line two\nsioaldhgowehg wegh welg abcdefghij",
+                  "- Copy/Drop text from LibreOffice files to composer\n- Download PDF file from Chrome viewer\n- Download attachment for mobile\n- Small improvements for Printing emails",
+              "format": "org.matrix.custom.html",
+              "formatted_body":
+                  "- Copy/Drop text from LibreOffice files to composer<br/>- Download PDF file from Chrome viewer<br/>- Download attachment for mobile<br/>- Small improvements for Printing emails",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',

--- a/test/pages/chat/events/message/message_content_builder_mixin_test.dart
+++ b/test/pages/chat/events/message/message_content_builder_mixin_test.dart
@@ -236,7 +236,7 @@ Future<void> main() async {
           );
 
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 421.97491455078125,
+            totalMessageWidth: 388.375,
             isNeedAddNewLine: false,
           );
 
@@ -256,10 +256,7 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with name -> Done",
-              "format": "org.matrix.custom.html",
-              "formatted_body":
-                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with name -&gt; Done</p>",
+                  "prefix line one\nprefix line two\nsioaldhgowehg wegh welg abcdefghij klmn",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -339,7 +336,7 @@ Future<void> main() async {
             room: room,
           );
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 421.97491455078125,
+            totalMessageWidth: 388.375,
             isNeedAddNewLine: false,
           );
           await runTest(
@@ -361,10 +358,7 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with name -> Done",
-              "format": "org.matrix.custom.html",
-              "formatted_body":
-                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with name -&gt; Done</p>",
+                  "prefix line one\nprefix line two\nsioaldhgowehg wegh welg abcdefghij klmn",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -452,7 +446,7 @@ Future<void> main() async {
           );
 
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 398.12469482421875,
+            totalMessageWidth: 260.875,
             isNeedAddNewLine: false,
           );
 
@@ -472,10 +466,7 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "- Copy/Drop text from LibreOffice files to composer\n- Download PDF file from Chrome viewer\n- Download attachment for mobile\n- Small improvement for Printing email",
-              "format": "org.matrix.custom.html",
-              "formatted_body":
-                  "- Copy/Drop text from LibreOffice files to composer<br/>- Download PDF file from Chrome viewer<br/>- Download attachment for mobile<br/>- Small improvement for Printing email",
+                  "prefix line one\nprefix line two\nsioaldhgowehg wegh welg abcdefghij",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -553,7 +544,7 @@ Future<void> main() async {
           );
 
           const expectedMetrics = MessageMetrics(
-            totalMessageWidth: 398.12469482421875,
+            totalMessageWidth: 260.875,
             isNeedAddNewLine: false,
           );
 
@@ -575,10 +566,7 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "- Copy/Drop text from LibreOffice files to composer\n- Download PDF file from Chrome viewer\n- Download attachment for mobile\n- Small improvement for Printing email",
-              "format": "org.matrix.custom.html",
-              "formatted_body":
-                  "- Copy/Drop text from LibreOffice files to composer<br/>- Download PDF file from Chrome viewer<br/>- Download attachment for mobile<br/>- Small improvement for Printing email",
+                  "prefix line one\nprefix line two\nsioaldhgowehg wegh welg abcdefghij",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',


### PR DESCRIPTION
## Ticket
Implements #3052 

## Changes
**Uses a first version of the design-system `MessageBubble` that was introduced by https://github.com/linagora/linagora-design-flutter/pull/72**
- Replace the custom bubble `Container` (color, border, radius, padding, margin) with `MessageBubble` from the DS
- Remove dead style constants from `MessageStyle` (`bubbleBorderRadius`, `notSameSenderPadding`, `borderColorReceivedBubble`, `paddingMessageContentBuilder`, `paddingMessage`)

**Bubble tail**
- Show the tail only on the last bubble of a same-sender group and never on emoji-only messages
- Compute `tailDirection` from `isOwnMessage` and `user alterned messages preferences`, so the tail points to the correct side

**Spacing & typography**
- Use `LinagoraSpacing` tokens for paddings or other spacings
- More use of `LinagoraTextStyle`

**Reactions overlay alignment**
- Reactions hang below the bubble, so the sender avatar is lifted by `kMessageReactionsOverlayHeight` to keep its bottom aligned with the bubble's bottom

**DM avatars & max width**
- Remove avatars in direct messages
- Increase the mobile bubble max-width ratio to 88%

**Previous-event threading / visible events**
- In `chat_scroll_view.dart`, build a separate index over *visible* events so `previousEvent`/`nextEvent` (used for grouping and tail logic) ignore non-visible timeline entries

**Refactor**
- Extract the hero long-press preview into `_buildHeroPreviewMessage` to avoid duplicateed code

### How can you test ?
(Compare what you see with https://www.figma.com/design/Cu4NB44bcURKEy40DEfwWi/Design-system-1.0?node-id=54909-28771&m=dev
- Sent / received text bubbles render with correct color, border and tail.
- Same-sender grouping shows a single tail on the last bubble.
- Media-only messages use the tighter media padding.
- Reactions stay correctly aligned with the avatar.
- DM conversations no longer show avatars.
- Emoji-only messages render without a bubble/tail.

## Demo
### Mobile

<img height="500" alt="Simulator Screenshot - iPhone 17 - 2026-06-09 at 13 07 00" src="https://github.com/user-attachments/assets/4bcba845-8ebe-4ca1-835a-c4ae9ecd361c" />

### Web

<img width="1728" height="996" alt="Capture d’écran 2026-06-09 à 13 09 22" src="https://github.com/user-attachments/assets/f940c33d-7e27-40ec-a3e5-81afd6a33ed0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined message spacing, bubble sizing, and layout for improved readability and mobile fit
  * Unified text styling across message bodies, timestamps, reactions, and link previews

* **Bug Fixes**
  * Fixed avatar/placeholder alignment when reactions are present
  * Improved message neighbor/delivery rendering to ignore non-visible events

* **Chores**
  * Updated design system library to v0.1.0

* **Tests**
  * Adjusted unit tests to reflect updated avatar and bubble sizing behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->