### PR TITLE
fix(chat): prefill caption with composer text when pasting an image

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -77,6 +77,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/network_connection_service.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/utils/room_draft_storage.dart';
 import 'package:fluffychat/utils/room_status_extension.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
@@ -106,7 +107,6 @@ import 'package:linagora_design_flutter/linagora_design_flutter.dart'
 import 'package:linagora_design_flutter/reaction/reaction_picker.dart';
 import 'package:matrix/matrix.dart' hide Contact;
 import 'package:scroll_to_index/scroll_to_index.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:universal_html/html.dart' as html;
 
 import 'events/audio_message/audio_player_widget.dart';
@@ -319,6 +319,8 @@ class ChatController extends State<Chat>
       AutoScrollController();
 
   final TextEditingController _captionsController = TextEditingController();
+
+  final RoomDraftStorage _draftStorage = const RoomDraftStorage();
 
   FocusNode inputFocus = FocusNode();
 
@@ -573,8 +575,7 @@ class ChatController extends State<Chat>
   }
 
   void _loadDraft() async {
-    final prefs = await SharedPreferences.getInstance();
-    final draft = prefs.getString('draft_$roomId');
+    final draft = await _draftStorage.read(roomId!);
     if (draft != null && draft.isNotEmpty) {
       sendController.text = draft;
       inputText.value = draft;
@@ -788,8 +789,7 @@ class ChatController extends State<Chat>
 
     if (sendController.text.trim().isEmpty) return;
     _storeInputTimeoutTimer?.cancel();
-    final prefs = await SharedPreferences.getInstance();
-    prefs.remove('draft_$roomId');
+    await _draftStorage.remove(roomId!);
     var parseCommands = true;
 
     final commandMatch = RegExp(r'^/(\w+)').firstMatch(sendController.text);
@@ -2295,8 +2295,7 @@ class ChatController extends State<Chat>
     }
     _storeInputTimeoutTimer?.cancel();
     _storeInputTimeoutTimer = Timer(_storeInputTimeout, () async {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString('draft_$roomId', text);
+      await _draftStorage.save(roomId!, text);
     });
     if (text.endsWith(' ') && matrix!.hasComplexBundles) {
       final clients = currentRoomBundle;
@@ -2445,8 +2444,7 @@ class ChatController extends State<Chat>
     }
     if (result == SendMediaWithCaptionStatus.done ||
         result == SendMediaWithCaptionStatus.emptyRoom) {
-      final prefs = await SharedPreferences.getInstance();
-      prefs.remove('draft_$roomId');
+      await _draftStorage.remove(roomId!);
       replyEventNotifier.value = null;
     }
 
@@ -2493,9 +2491,7 @@ class ChatController extends State<Chat>
         );
         scrollDown();
 
-        // Also add draft cleanup here
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.remove('draft_$roomId');
+        await _draftStorage.remove(roomId!);
         replyEventNotifier.value = null;
       },
       captionController: _captionsController,

--- a/lib/presentation/mixins/handle_clipboard_action_mixin.dart
+++ b/lib/presentation/mixins/handle_clipboard_action_mixin.dart
@@ -1,9 +1,9 @@
 import 'package:fluffychat/presentation/extensions/text_editting_controller_extension.dart';
 import 'package:fluffychat/presentation/mixins/paste_image_mixin.dart';
 import 'package:fluffychat/utils/clipboard.dart';
+import 'package:fluffychat/utils/room_draft_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 
 mixin HandleClipboardActionMixin on PasteImageMixin {
@@ -14,6 +14,8 @@ mixin HandleClipboardActionMixin on PasteImageMixin {
   Room? get room;
 
   TextEditingController get sendController;
+
+  final RoomDraftStorage _draftStorage = const RoomDraftStorage();
 
   void registerPasteShortcutListeners() {
     ClipboardEvents.instance?.registerPasteEventListener(_onPasteEvent);
@@ -46,8 +48,7 @@ mixin HandleClipboardActionMixin on PasteImageMixin {
       pendingText: pendingText,
       onSendFileCallback: () async {
         sendController.clear();
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.remove('draft_${room!.id}');
+        await _draftStorage.remove(room!.id);
         onSendFileCallback();
       },
     );

--- a/lib/presentation/mixins/handle_clipboard_action_mixin.dart
+++ b/lib/presentation/mixins/handle_clipboard_action_mixin.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/presentation/mixins/paste_image_mixin.dart';
 import 'package:fluffychat/utils/clipboard.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:super_clipboard/super_clipboard.dart';
 
 mixin HandleClipboardActionMixin on PasteImageMixin {
@@ -37,11 +38,18 @@ mixin HandleClipboardActionMixin on PasteImageMixin {
   void onSendFileCallback();
 
   Future<void> pasteClipboardImage(ClipboardReader? clipboardReader) async {
+    final pendingText = sendController.text;
     return pasteImage(
       context,
       room!,
       clipboardReader: clipboardReader,
-      onSendFileCallback: onSendFileCallback,
+      pendingText: pendingText,
+      onSendFileCallback: () async {
+        sendController.clear();
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.remove('draft_${room!.id}');
+        onSendFileCallback();
+      },
     );
   }
 

--- a/lib/presentation/mixins/paste_image_mixin.dart
+++ b/lib/presentation/mixins/paste_image_mixin.dart
@@ -13,6 +13,7 @@ mixin PasteImageMixin {
     BuildContext context,
     Room room, {
     ClipboardReader? clipboardReader,
+    String? pendingText,
     VoidCallback? onSendFileCallback,
     Event? inReplyTo,
   }) async {
@@ -40,6 +41,7 @@ mixin PasteImageMixin {
         return SendFileDialog(
           room: room,
           files: matrixFiles!.nonNulls.toList(),
+          pendingText: pendingText,
           inReplyTo: inReplyTo,
         );
       },

--- a/lib/utils/room_draft_storage.dart
+++ b/lib/utils/room_draft_storage.dart
@@ -1,0 +1,26 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists the unsent message draft of a room across app sessions.
+///
+/// Centralizes the `draft_<roomId>` key so the format lives in a single place
+/// instead of being duplicated at every call site.
+class RoomDraftStorage {
+  const RoomDraftStorage();
+
+  String _keyOf(String roomId) => 'draft_$roomId';
+
+  Future<String?> read(String roomId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_keyOf(roomId));
+  }
+
+  Future<void> save(String roomId, String text) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_keyOf(roomId), text);
+  }
+
+  Future<void> remove(String roomId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_keyOf(roomId));
+  }
+}

--- a/test/utils/room_draft_storage_test.dart
+++ b/test/utils/room_draft_storage_test.dart
@@ -1,0 +1,40 @@
+import 'package:fluffychat/utils/room_draft_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const storage = RoomDraftStorage();
+  const roomId = '!room:example.com';
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('read returns null when no draft is stored', () async {
+    expect(await storage.read(roomId), isNull);
+  });
+
+  test('save then read round-trips the draft', () async {
+    await storage.save(roomId, 'hello world');
+    expect(await storage.read(roomId), 'hello world');
+  });
+
+  test('save persists under the draft_<roomId> key', () async {
+    await storage.save(roomId, 'draft text');
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('draft_$roomId'), 'draft text');
+  });
+
+  test('remove deletes the stored draft', () async {
+    await storage.save(roomId, 'to be removed');
+    await storage.remove(roomId);
+    expect(await storage.read(roomId), isNull);
+  });
+
+  test('drafts are isolated per room', () async {
+    await storage.save(roomId, 'room A draft');
+    await storage.save('!other:example.com', 'room B draft');
+    expect(await storage.read(roomId), 'room A draft');
+    expect(await storage.read('!other:example.com'), 'room B draft');
+  });
+}


### PR DESCRIPTION
## Problem

When you type a message and then **paste an image** (Ctrl+V on web), the caption dialog opens **empty** — the text you were typing is lost from the caption.

TW-2750 (#2751) added "attach media to the text already typed in the composer", but only wired `pendingText` into the **file-picker** and **drag-and-drop** flows. The **paste-image** path (`pasteImage`) was missed.

## Fix

- Thread `pendingText` through `pasteImage` into `SendFileDialog`, matching the other media flows.
- On successful send, clear the composer + remove the saved draft (the typed text now travels as the image caption, so it must not also remain in the composer / be re-sent as a separate message).
- Text is **preserved** if the dialog is cancelled or the paste fails (composer only clears on `done`).

## Scope

Paste-image is web-only (`pasteImagesUsingBytes` is guarded by `PlatformInfos.isWeb`). File-picker and drag-and-drop already worked.

## Test plan

1. Open a chat on web.
2. Type some text in the composer.
3. Paste an image (Ctrl/Cmd+V).
4. ✅ Caption field is pre-filled with the typed text.
5. Send → image sent with caption, composer is empty.
6. Repeat, but **cancel** the dialog → typed text is still in the composer.

<img width="224" height="68" alt="image" src="https://github.com/user-attachments/assets/12e9f397-c5ef-4f90-a983-d921138ee915" />
<img width="375" height="551" alt="image" src="https://github.com/user-attachments/assets/f0577ab9-830e-44c2-8c3c-9941715e82c1" />

<img width="379" height="196" alt="image" src="https://github.com/user-attachments/assets/da08514f-306e-45b0-880a-4fdb3f66f847" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drafts are now persisted per chat so unsent message text is reliably saved and restored.
* **Bug Fixes**
  * Pasting images preserves current message text during the paste/send flow.
  * Drafts are automatically cleared after successful send or media/camera send completion, preventing stale drafts.
* **Tests**
  * Added tests verifying save/read/remove behavior and per-room draft isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->