### PR TITLE
refactor(chat): centralize room draft persistence in RoomDraftStorage

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -62,6 +62,7 @@ import 'package:fluffychat/presentation/model/forward/forward_argument.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/account_bundles.dart';
 import 'package:fluffychat/utils/adaptive_bottom_sheet.dart';
+import 'package:fluffychat/utils/room_draft_storage.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/extension/basic_event_extension.dart';
 import 'package:fluffychat/utils/extension/event_status_custom_extension.dart';
@@ -106,7 +107,6 @@ import 'package:linagora_design_flutter/linagora_design_flutter.dart'
 import 'package:linagora_design_flutter/reaction/reaction_picker.dart';
 import 'package:matrix/matrix.dart' hide Contact;
 import 'package:scroll_to_index/scroll_to_index.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:universal_html/html.dart' as html;
 
 import 'events/audio_message/audio_player_widget.dart';
@@ -319,6 +319,8 @@ class ChatController extends State<Chat>
       AutoScrollController();
 
   final TextEditingController _captionsController = TextEditingController();
+
+  final RoomDraftStorage _draftStorage = const RoomDraftStorage();
 
   FocusNode inputFocus = FocusNode();
 
@@ -573,8 +575,7 @@ class ChatController extends State<Chat>
   }
 
   void _loadDraft() async {
-    final prefs = await SharedPreferences.getInstance();
-    final draft = prefs.getString('draft_$roomId');
+    final draft = await _draftStorage.read(roomId!);
     if (draft != null && draft.isNotEmpty) {
       sendController.text = draft;
       inputText.value = draft;
@@ -788,8 +789,7 @@ class ChatController extends State<Chat>
 
     if (sendController.text.trim().isEmpty) return;
     _storeInputTimeoutTimer?.cancel();
-    final prefs = await SharedPreferences.getInstance();
-    prefs.remove('draft_$roomId');
+    await _draftStorage.remove(roomId!);
     var parseCommands = true;
 
     final commandMatch = RegExp(r'^/(\w+)').firstMatch(sendController.text);
@@ -2295,8 +2295,7 @@ class ChatController extends State<Chat>
     }
     _storeInputTimeoutTimer?.cancel();
     _storeInputTimeoutTimer = Timer(_storeInputTimeout, () async {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString('draft_$roomId', text);
+      await _draftStorage.save(roomId!, text);
     });
     if (text.endsWith(' ') && matrix!.hasComplexBundles) {
       final clients = currentRoomBundle;
@@ -2445,8 +2444,7 @@ class ChatController extends State<Chat>
     }
     if (result == SendMediaWithCaptionStatus.done ||
         result == SendMediaWithCaptionStatus.emptyRoom) {
-      final prefs = await SharedPreferences.getInstance();
-      prefs.remove('draft_$roomId');
+      await _draftStorage.remove(roomId!);
       replyEventNotifier.value = null;
     }
 
@@ -2492,10 +2490,7 @@ class ChatController extends State<Chat>
           inReplyTo: replyEventNotifier.value,
         );
         scrollDown();
-
-        // Also add draft cleanup here
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.remove('draft_$roomId');
+        await _draftStorage.remove(roomId!);
         replyEventNotifier.value = null;
       },
       captionController: _captionsController,

--- a/lib/utils/room_draft_storage.dart
+++ b/lib/utils/room_draft_storage.dart
@@ -1,0 +1,26 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists the unsent message draft of a room across app sessions.
+///
+/// Centralizes the `draft_<roomId>` key so the format lives in a single place
+/// instead of being duplicated at every call site.
+class RoomDraftStorage {
+  const RoomDraftStorage();
+
+  String _keyOf(String roomId) => 'draft_$roomId';
+
+  Future<String?> read(String roomId) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_keyOf(roomId));
+  }
+
+  Future<void> save(String roomId, String text) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_keyOf(roomId), text);
+  }
+
+  Future<void> remove(String roomId) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_keyOf(roomId));
+  }
+}

--- a/test/utils/room_draft_storage_test.dart
+++ b/test/utils/room_draft_storage_test.dart
@@ -1,0 +1,40 @@
+import 'package:fluffychat/utils/room_draft_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const storage = RoomDraftStorage();
+  const roomId = '!room:example.com';
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('read returns null when no draft is stored', () async {
+    expect(await storage.read(roomId), isNull);
+  });
+
+  test('save then read round-trips the draft', () async {
+    await storage.save(roomId, 'hello world');
+    expect(await storage.read(roomId), 'hello world');
+  });
+
+  test('save persists under the draft_<roomId> key', () async {
+    await storage.save(roomId, 'draft text');
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('draft_$roomId'), 'draft text');
+  });
+
+  test('remove deletes the stored draft', () async {
+    await storage.save(roomId, 'to be removed');
+    await storage.remove(roomId);
+    expect(await storage.read(roomId), isNull);
+  });
+
+  test('drafts are isolated per room', () async {
+    await storage.save(roomId, 'room A draft');
+    await storage.save('!other:example.com', 'room B draft');
+    expect(await storage.read(roomId), 'room A draft');
+    expect(await storage.read('!other:example.com'), 'room B draft');
+  });
+}


### PR DESCRIPTION
## What

Extracts a small `RoomDraftStorage` helper that owns the `draft_<roomId>` SharedPreferences key and the read/save/remove operations.

## Why

The key `'draft_$roomId'` was hand-built at six call sites in `ChatController` (load draft, send, debounced input-change save, media-send cleanup). Centralizing it removes the duplication and keeps the storage format in one place.

## How

- New `lib/utils/room_draft_storage.dart` — `read` / `save` / `remove` keyed by room id.
- `ChatController` routes every draft access through a `RoomDraftStorage` field; removed the now-unused `shared_preferences` import.
- Added `test/utils/room_draft_storage_test.dart` (round-trip, key format, remove, per-room isolation).

## Notes

- **No behavior change.**
- Split out of #3104 (native photo picker) as an unrelated cleanup.

`flutter analyze` clean, tests green.