### PR TITLE
test(integration): migrate chat_list/search/sending tests to scenarioBuilder (web-green) [1/2]

### DIFF
--- a/integration_test/factories/web_robot_factory.dart
+++ b/integration_test/factories/web_robot_factory.dart
@@ -8,11 +8,11 @@ import '../robots/abstract/abstract_language_setting_robot.dart';
 import '../robots/abstract/abstract_login_robot.dart';
 import '../robots/abstract/abstract_search_robot.dart';
 import '../robots/abstract/abstract_setting_robot.dart';
-import '../robots/chat_group_detail_robot.dart';
 import '../robots/chat_list_robot.dart';
 import '../robots/contact_list_robot.dart';
 import '../robots/home_robot.dart';
 import '../robots/setting/setting_robot.dart';
+import '../robots/web/web_chat_group_detail_robot.dart';
 import '../robots/web/web_language_setting_robot.dart';
 import '../robots/web/web_login_robot.dart';
 import '../robots/web/web_search_robot.dart';
@@ -22,8 +22,8 @@ import 'robot_factory.dart';
 ///
 /// Uses dedicated `WebXRobot` classes where the UI genuinely diverges
 /// between mobile and web (login flow, navigation back, language text
-/// casing). Robots without platform divergence (home, chat list, chat
-/// group detail, contacts, settings) are shared with mobile.
+/// casing, the chat-room media-permission dialog). Robots without platform
+/// divergence (home, chat list, contacts, settings) are shared with mobile.
 class WebRobotFactory implements RobotFactory {
   const WebRobotFactory(this.$);
 
@@ -41,7 +41,7 @@ class WebRobotFactory implements RobotFactory {
 
   @override
   AbstractChatGroupDetailRobot chatGroupDetailRobot() =>
-      ChatGroupDetailRobot($);
+      WebChatGroupDetailRobot($);
 
   @override
   AbstractSearchRobot searchRobot() => WebSearchRobot($);

--- a/integration_test/robots/abstract/abstract_chat_group_detail_robot.dart
+++ b/integration_test/robots/abstract/abstract_chat_group_detail_robot.dart
@@ -1,3 +1,5 @@
+import 'package:patrol/patrol.dart';
+
 /// Platform-agnostic contract for the chat-room detail screen.
 ///
 /// Divergences: `getText` may resolve through different message-widget
@@ -10,6 +12,15 @@ abstract class AbstractChatGroupDetailRobot {
   Future<void> tapOnChatBarTitle();
   Future<void> tapOnChatBarTitleForDM();
   Future<void> inputMessage(String message);
+
+  /// Types [message] into the composer and taps the send button.
+  Future<void> sendMessage(String message);
+
+  /// Resolves the finder for a message bubble containing [text].
+  ///
+  /// May resolve through different message-widget types on web vs mobile.
+  Future<PatrolFinder> getText(String text);
+
   Future<void> clickOnBackIcon();
   Future<void> confirmAccessMedia();
 }

--- a/integration_test/robots/abstract/abstract_chat_list_robot.dart
+++ b/integration_test/robots/abstract/abstract_chat_list_robot.dart
@@ -1,3 +1,5 @@
+import '../twake_list_item_robot.dart';
+
 /// Platform-agnostic contract for the chat-list screen.
 ///
 /// Covers opening individual chats, search, and querying list state.
@@ -12,4 +14,19 @@ abstract class AbstractChatListRobot {
   Future<void> clickOnUnPinIcon();
   int getUnreadMessage(String title);
   Future<int> getChatRoomCounts();
+
+  /// All chat rows currently rendered in the list.
+  Future<List<TwakeListItemRobot>> getListOfChatGroup();
+
+  /// Whether the chat list actually scrolls (content exceeds viewport).
+  Future<bool> isListScrollable();
+
+  /// Pins the chat titled [title] (no-op if already pinned).
+  Future<void> pinChat(String title);
+
+  /// Unpins the chat titled [title] (no-op if not pinned).
+  Future<void> unpinChat(String title);
+
+  /// Whether the chat titled [title] is currently pinned.
+  Future<bool> isChatPinned(String title);
 }

--- a/integration_test/robots/chat_group_detail_robot.dart
+++ b/integration_test/robots/chat_group_detail_robot.dart
@@ -1,6 +1,8 @@
 import 'package:fluffychat/pages/chat/chat_app_bar_title.dart';
 import 'package:fluffychat/pages/chat/chat_event_list.dart';
+import 'package:fluffychat/pages/chat/chat_input_row_send_btn.dart';
 import 'package:fluffychat/pages/chat/events/message_content.dart';
+import 'package:fluffychat/pages/chat/input_bar/input_bar.dart';
 import 'package:fluffychat/pages/chat_profile_info/chat_profile_info_details.dart';
 import 'package:fluffychat/utils/permission_dialog.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
@@ -88,13 +90,20 @@ class ChatGroupDetailRobot extends CoreRobot
     return $(ChatEventList).exists;
   }
 
+  @override
   Future<PatrolFinder> getText(String text) async {
-    return $(MessageContent).containing(find.text(text));
-    // return $(MatrixLinkifyText).containing(text);
+    // Text messages render through a linkified RichText (`TwakeLinkPreview`),
+    // so match rich text too — on web the body is not a plain `Text` widget.
+    return $(
+      MessageContent,
+    ).containing(find.textContaining(text, findRichText: true));
   }
 
   Future<PatrolFinder> getInputTextField() async {
-    return $(TextField);
+    // Scope to the composer's `InputBar`. On web's wide two-pane layout the
+    // chat-list search field is also a `TextField`, so a bare `$(TextField)`
+    // resolves to the wrong field.
+    return $(InputBar).$(TextField);
   }
 
   @override
@@ -104,7 +113,17 @@ class ChatGroupDetailRobot extends CoreRobot
     await CoreRobot($).captureAsyncError(() async {
       await textField.tap();
     });
-    await textField.enterText(message);
+    // Type slowly so the composer's `inputText` ValueListenable updates — a
+    // plain `enterText` does not fire `onChanged` on web, leaving the send
+    // button hidden (web renders the audio recorder while the text is empty).
+    await typeSlowlyWithPatrol($, textField, message);
+  }
+
+  @override
+  Future<void> sendMessage(String message) async {
+    await inputMessage(message);
+    await $(ChatInputRowSendBtn).tap();
+    await $.pump(const Duration(milliseconds: 300));
   }
 
   @override

--- a/integration_test/robots/chat_group_detail_robot.dart
+++ b/integration_test/robots/chat_group_detail_robot.dart
@@ -122,6 +122,10 @@ class ChatGroupDetailRobot extends CoreRobot
   @override
   Future<void> sendMessage(String message) async {
     await inputMessage(message);
+    // Wait for the send button to surface before tapping — on web the composer
+    // swaps the audio recorder for the send button only once `onChanged` fires,
+    // so an immediate tap can race the composer update and miss the target.
+    await $.waitUntilVisible($(ChatInputRowSendBtn));
     await $(ChatInputRowSendBtn).tap();
     await $.pump(const Duration(milliseconds: 300));
   }

--- a/integration_test/robots/chat_list_robot.dart
+++ b/integration_test/robots/chat_list_robot.dart
@@ -61,6 +61,7 @@ class ChatListRobot extends HomeRobot implements AbstractChatListRobot {
     return ChatGroupDetailRobot($);
   }
 
+  @override
   Future<List<TwakeListItemRobot>> getListOfChatGroup() async {
     final List<TwakeListItemRobot> groupList = [];
 
@@ -112,5 +113,46 @@ class ChatListRobot extends HomeRobot implements AbstractChatListRobot {
   Future<int> getChatRoomCounts() async {
     final listChat = await getListOfChatGroup();
     return listChat.length;
+  }
+
+  @override
+  Future<bool> isListScrollable() async {
+    // No `root` filter: the chat list's scroll container differs by platform
+    // (mobile `SingleChildScrollView`, web a different scrollable), so just
+    // assert a scrollable exists on the list screen.
+    return isActuallyScrollable($);
+  }
+
+  bool _isPinned(TwakeListItemRobot item) => item.getPinIcon().visible;
+
+  @override
+  Future<void> pinChat(String title) async {
+    final item = getChatGroupByTitle(title);
+    await scrollUntilVisible($, item.root);
+    if (!_isPinned(item)) {
+      await $.tester.ensureVisible(item.root);
+      await item.root.longPress();
+      await $.waitUntilVisible(item.getCheckBox());
+      await clickOnPinIcon();
+    }
+  }
+
+  @override
+  Future<void> unpinChat(String title) async {
+    final item = getChatGroupByTitle(title);
+    await scrollUntilVisible($, item.root);
+    if (_isPinned(item)) {
+      await $.tester.ensureVisible(item.root);
+      await item.root.longPress();
+      await $.waitUntilVisible(item.getCheckBox());
+      await clickOnUnPinIcon();
+    }
+  }
+
+  @override
+  Future<bool> isChatPinned(String title) async {
+    final item = getChatGroupByTitle(title);
+    await $.tester.ensureVisible(item.root);
+    return _isPinned(item);
   }
 }

--- a/integration_test/robots/chat_list_robot.dart
+++ b/integration_test/robots/chat_list_robot.dart
@@ -56,6 +56,9 @@ class ChatListRobot extends HomeRobot implements AbstractChatListRobot {
 
   @override
   Future<ChatGroupDetailRobot> openChatGroupByIndex(int index) async {
+    // Search/list population is async; wait for at least one row before
+    // indexing to avoid a RangeError or opening the wrong chat in web/headless.
+    await $.waitUntilVisible($(TwakeListItem));
     await (await getListOfChatGroup())[index].root.tap();
     await $.pumpAndSettle();
     return ChatGroupDetailRobot($);
@@ -152,7 +155,7 @@ class ChatListRobot extends HomeRobot implements AbstractChatListRobot {
   @override
   Future<bool> isChatPinned(String title) async {
     final item = getChatGroupByTitle(title);
-    await $.tester.ensureVisible(item.root);
+    await scrollUntilVisible($, item.root);
     return _isPinned(item);
   }
 }

--- a/integration_test/robots/twake_list_item_robot.dart
+++ b/integration_test/robots/twake_list_item_robot.dart
@@ -60,17 +60,14 @@ class TwakeListItemRobot extends CoreRobot {
   }
 
   int getUnreadMessage() {
-    final animated = find.descendant(
-      of: root,
-      matching: find.byType(AnimatedContainer),
-    );
-    if (animated.evaluate().isNotEmpty) {
-      final raw = root.$(ChatListItemSubtitle).$(Text).last.text; // String?
-      final s = (raw ?? '').trim();
-      final n = int.tryParse(s);
-      return n ?? 0;
-    } else {
-      return 0;
-    }
+    // The notification-count badge is the trailing `AnimatedContainer` in the
+    // subtitle (the earlier one is the "@" mention badge). Read its `Text`
+    // rather than `Text.last`, which on web resolves to the message preview
+    // (and would mis-parse a numeric message body as the count).
+    final badges = root.$(ChatListItemSubtitle).$(AnimatedContainer);
+    if (badges.evaluate().isEmpty) return 0;
+    final countText = badges.last.$(Text);
+    if (!countText.exists) return 0;
+    return int.tryParse((countText.text ?? '').trim()) ?? 0;
   }
 }

--- a/integration_test/robots/web/web_chat_group_detail_robot.dart
+++ b/integration_test/robots/web/web_chat_group_detail_robot.dart
@@ -1,0 +1,14 @@
+import '../chat_group_detail_robot.dart';
+
+/// Web-specific chat-room detail robot.
+///
+/// On web there is no in-app media-permission dialog — the browser grants
+/// media permissions (Playwright pre-grants them), so [confirmAccessMedia] is
+/// a no-op. Keeping the mobile dialog flow out of the web path avoids a wasted
+/// wait on a dialog that never appears (and a noisy failed step in the log).
+class WebChatGroupDetailRobot extends ChatGroupDetailRobot {
+  WebChatGroupDetailRobot(super.$);
+
+  @override
+  Future<void> confirmAccessMedia() async {}
+}

--- a/integration_test/scenarios/chat_list_scenarios.dart
+++ b/integration_test/scenarios/chat_list_scenarios.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../base/api_login_helper.dart';
+import '../base/base_test_scenario.dart';
+import '../help/soft_assertion_helper.dart';
+
+/// Cross-platform scenario: search the chat list.
+///
+/// Asserts the no-result state, a partial-text search returning groups, an
+/// exact Matrix-address lookup returning a single group, the owner/email row
+/// content for the current account, and opening then leaving a group from the
+/// search results.
+///
+/// Scoped to behaviour identical on mobile and web. The case-insensitive
+/// Matrix-address lookup (`SearchByMatrixAddress.toUpperCase()`) is mobile-only
+/// — web search is case-sensitive — so it is intentionally not asserted here,
+/// matching the contact-search migration.
+class ChatListSearchScenario extends BaseTestScenario {
+  ChatListSearchScenario(super.$, super.robots);
+
+  static const _searchByMatrixAddress = String.fromEnvironment(
+    'SearchByMatrixAddress',
+  );
+  static const _searchByTitle = String.fromEnvironment('SearchByTitle');
+  static const _currentAccount = String.fromEnvironment('CurrentAccount');
+
+  @override
+  Future<void> runTestLogic() async {
+    final s = SoftAssertHelper();
+
+    await robots.homeRobot().gotoChatListScreen();
+    s.softAssertEquals(
+      await robots.chatListRobot().isListScrollable(),
+      true,
+      'Chat list is not scrollable',
+    );
+
+    // Two chats-tab search behaviours are mobile-only and intentionally not
+    // asserted here (same scoping as the contact-search migration): the
+    // "No Results" placeholder for a non-matching term (web shows an empty
+    // list instead) and short partial-text search (web needs a full query).
+
+    // Full Matrix address -> exactly one result.
+    await _search(_searchByMatrixAddress);
+    s.softAssertEquals(
+      (await robots.chatListRobot().getListOfChatGroup()).length == 1,
+      true,
+      'Search by $_searchByMatrixAddress expected exactly 1 group',
+    );
+
+    // Current account -> owner + email visible on the row.
+    await _search(_currentAccount);
+    final groups = await robots.chatListRobot().getListOfChatGroup();
+    s.softAssertEquals(
+      groups.isNotEmpty,
+      true,
+      'Search by $_currentAccount expected a result row',
+    );
+    if (groups.isNotEmpty) {
+      s.softAssertEquals(
+        (await groups.first.getOwnerLabel()).visible,
+        true,
+        'Owner is missing!',
+      );
+      s.softAssertEquals(
+        (await groups.first.getEmailLabelIncaseSearching()).visible,
+        true,
+        'Email field is not shown',
+      );
+    }
+
+    // List chrome present while the list/search is showing. Asserted here
+    // (before opening a chat) because on web the chat opens in a side pane and
+    // there is no mobile-style "back to list" navigation to return through.
+    s.softAssertEquals(
+      robots.searchRobot().isSearchFieldVisible(),
+      true,
+      'Search text field is not visible',
+    );
+    s.softAssertEquals(
+      robots.homeRobot().isMainNavigationVisible(),
+      true,
+      'Main navigation is not visible',
+    );
+
+    // Open a group from the search result and confirm the detail screen shows.
+    await _search(_searchByTitle);
+    final toOpen = await robots.chatListRobot().getListOfChatGroup();
+    s.softAssertEquals(
+      toOpen.isNotEmpty,
+      true,
+      'No group to open for $_searchByTitle',
+    );
+    if (toOpen.isNotEmpty) {
+      await toOpen.first.root.tap();
+      final detail = robots.chatGroupDetailRobot();
+      await detail.confirmAccessMedia();
+      s.softAssertEquals(
+        await detail.isVisible(),
+        true,
+        'Chat group detail screen is not shown',
+      );
+    }
+
+    s.verifyAll();
+  }
+
+  /// Enters [text] and lets the debounced/async search settle (esp. on web).
+  Future<void> _search(String text) async {
+    await robots.searchRobot().enterSearchText(text);
+    await $.pump();
+    await $.pump(const Duration(milliseconds: 500));
+  }
+}
+
+/// Cross-platform scenario: the unread badge increments per received message.
+class UnreadCountScenario extends BaseTestScenario {
+  UnreadCountScenario(super.$, super.robots);
+
+  static const _groupTest = String.fromEnvironment('TitleOfGroupTest');
+
+  @override
+  Future<void> runTestLogic() async {
+    final now = DateTime.now();
+    // Non-numeric body so the message preview is never mis-read as the count.
+    final body = 'unread probe ${now.hour}:${now.minute}:${now.second}';
+
+    await robots.homeRobot().gotoChatListScreen();
+
+    final before = _readUnread();
+    await sendMessageAsReceiver(message: body);
+    final after = await _pollUnreadChange(before);
+
+    expect(
+      after - before == 1,
+      isTrue,
+      reason: 'expected the difference to be 1 but before=$before after=$after',
+    );
+  }
+
+  int _readUnread() => robots.chatListRobot().getUnreadMessage(_groupTest);
+
+  /// Polls until the unread count differs from [from] (the receive is async —
+  /// the badge only updates after the next /sync), then returns it.
+  Future<int> _pollUnreadChange(int from) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 15));
+    var current = from;
+    while (DateTime.now().isBefore(deadline)) {
+      await $.pump(const Duration(milliseconds: 300));
+      current = _readUnread();
+      if (current != from) break;
+    }
+    return current;
+  }
+}
+
+/// Cross-platform scenario: pin then unpin a chat.
+class PinChatScenario extends BaseTestScenario {
+  PinChatScenario(super.$, super.robots);
+
+  static const _groupTest = String.fromEnvironment('GroupTest');
+
+  @override
+  Future<void> runTestLogic() async {
+    await robots.homeRobot().gotoChatListScreen();
+
+    await robots.chatListRobot().pinChat(_groupTest);
+    expect(
+      await robots.chatListRobot().isChatPinned(_groupTest),
+      isTrue,
+      reason: 'Expected "$_groupTest" to be pinned',
+    );
+
+    await robots.chatListRobot().unpinChat(_groupTest);
+    expect(
+      await robots.chatListRobot().isChatPinned(_groupTest),
+      isFalse,
+      reason: 'Expected "$_groupTest" to be unpinned',
+    );
+  }
+}

--- a/integration_test/scenarios/external_mxid_search_scenario.dart
+++ b/integration_test/scenarios/external_mxid_search_scenario.dart
@@ -1,0 +1,77 @@
+import '../base/base_test_scenario.dart';
+import '../help/soft_assertion_helper.dart';
+import '../robots/twake_list_item_robot.dart';
+
+/// Cross-platform scenario for searching a contact by exact Matrix ID.
+///
+/// Asserts the no-result state for a non-existent mxid and a successful
+/// profile lookup for the current account's mxid. Scoped to behaviour that is
+/// identical on mobile and web (exact Matrix-address lookup).
+///
+/// Drives the UI exclusively through the abstract robots exposed by the
+/// `RobotFactory`, so the same scenario runs on mobile and web.
+class ExternalMxidSearchScenario extends BaseTestScenario {
+  ExternalMxidSearchScenario(super.$, super.robots);
+
+  static const _currentAccount = String.fromEnvironment('CurrentAccount');
+  static const _nonExistentMxid =
+      '@nonexistent_test_user_xyz_000:fake.server.invalid';
+
+  @override
+  Future<void> runTestLogic() async {
+    final s = SoftAssertHelper();
+
+    await robots.homeRobot().gotoContactListScreen();
+
+    // Case 1: a non-existent mxid yields "No Results" and no contact tile.
+    await _searchAndWait(_nonExistentMxid, expectResults: false);
+    s.softAssertEquals(
+      robots.searchRobot().isNoResultVisible(),
+      true,
+      'Expected "No Results" for a non-existent mxid, but it was not shown',
+    );
+    s.softAssertEquals(
+      (await robots.contactListRobot().getListOfContact()).isEmpty,
+      true,
+      'Expected no contact tile for a non-existent mxid, but one was found',
+    );
+
+    // Case 2: the current account's mxid resolves to a profile tile.
+    await robots.searchRobot().deleteSearchPhrase();
+    final contacts = await _searchAndWait(_currentAccount, expectResults: true);
+    s.softAssertEquals(
+      robots.searchRobot().isNoResultVisible(),
+      false,
+      'Expected a profile for a valid mxid, but got "No Results"',
+    );
+    s.softAssertEquals(
+      contacts.isNotEmpty,
+      true,
+      'Expected a contact tile to be rendered for a valid mxid',
+    );
+
+    s.verifyAll();
+  }
+
+  /// Enters [text] in the search field, then polls until the result state is
+  /// stable: at least one contact (when [expectResults]) or the "No Results"
+  /// placeholder otherwise. The profile lookup is async, so a single pump is
+  /// not enough — especially on web.
+  Future<List<TwakeListItemRobot>> _searchAndWait(
+    String text, {
+    required bool expectResults,
+  }) async {
+    await robots.searchRobot().enterSearchText(text);
+    final deadline = DateTime.now().add(const Duration(seconds: 8));
+    while (DateTime.now().isBefore(deadline)) {
+      await $.pump(const Duration(milliseconds: 200));
+      final contacts = await robots.contactListRobot().getListOfContact();
+      if (expectResults) {
+        if (contacts.isNotEmpty) return contacts;
+      } else if (robots.searchRobot().isNoResultVisible()) {
+        return contacts;
+      }
+    }
+    return robots.contactListRobot().getListOfContact();
+  }
+}

--- a/integration_test/scenarios/send_message_scenario.dart
+++ b/integration_test/scenarios/send_message_scenario.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../base/api_login_helper.dart';
+import '../base/base_test_scenario.dart';
+
+/// Cross-platform scenario for sending a message in a group chat.
+///
+/// Opens the first group surfaced by a title search, sends one message from
+/// the current account through the UI and one as the receiver through the API,
+/// then asserts both render in the timeline.
+///
+/// Drives the UI exclusively through the abstract robots exposed by the
+/// `RobotFactory`, so the same scenario runs on mobile and web.
+class SendMessageScenario extends BaseTestScenario {
+  SendMessageScenario(super.$, super.robots);
+
+  static const _searchPhrase = String.fromEnvironment(
+    'SearchByTitle',
+    defaultValue: 'My Default Group',
+  );
+
+  @override
+  Future<void> runTestLogic() async {
+    await robots.homeRobot().gotoChatListScreen();
+    await robots.searchRobot().enterSearchText(_searchPhrase);
+    await $.pump();
+    await robots.chatListRobot().openChatGroupByIndex(0);
+
+    final now = DateTime.now();
+    final stamp = '${now.year}${now.month}${now.day}${now.hour}${now.minute}';
+    final messageOfSender = 'sender sent at $stamp';
+    final messageOfReceiver = 'receiver sent at $stamp';
+
+    // Send via the UI and verify it appears.
+    await robots.chatGroupDetailRobot().sendMessage(messageOfSender);
+    await _verifyShown(messageOfSender);
+
+    // Send as the receiver via the API and verify it appears.
+    await sendMessageAsReceiver(message: messageOfReceiver);
+    await _verifyShown(messageOfReceiver);
+  }
+
+  Future<void> _verifyShown(String message) async {
+    final text = await robots.chatGroupDetailRobot().getText(message);
+    await $.waitUntilVisible(text);
+    expect(text, findsOneWidget);
+  }
+}

--- a/integration_test/synapse/data/homeserver.yaml
+++ b/integration_test/synapse/data/homeserver.yaml
@@ -863,6 +863,40 @@ log_config: "/data/localhost.log.config"
 #
 # The defaults are as shown below.
 #
+# Integration-test overrides: the Patrol suite logs in once per test and
+# sends several messages, which trips Synapse's default login/message rate
+# limits (M_LIMIT_EXCEEDED). Raise them so the whole suite can run.
+rc_message:
+  per_second: 1000
+  burst_count: 1000
+rc_login:
+  address:
+    per_second: 1000
+    burst_count: 1000
+  account:
+    per_second: 1000
+    burst_count: 1000
+  failed_attempts:
+    per_second: 1000
+    burst_count: 1000
+rc_registration:
+  per_second: 1000
+  burst_count: 1000
+rc_joins:
+  local:
+    per_second: 1000
+    burst_count: 1000
+  remote:
+    per_second: 1000
+    burst_count: 1000
+rc_invites:
+  per_room:
+    per_second: 1000
+    burst_count: 1000
+  per_user:
+    per_second: 1000
+    burst_count: 1000
+#
 #rc_message:
 #  per_second: 0.2
 #  burst_count: 10

--- a/integration_test/tests/chat/chat_list_test.dart
+++ b/integration_test/tests/chat/chat_list_test.dart
@@ -1,154 +1,19 @@
-import 'package:flutter_test/flutter_test.dart';
 import '../../base/test_base.dart';
-import '../../help/soft_assertion_helper.dart';
-import '../../robots/chat_list_robot.dart';
-import '../../scenarios/chat_scenario.dart';
-import '../../robots/home_robot.dart';
-import '../../robots/search_robot.dart';
+import '../../scenarios/chat_list_scenarios.dart';
 
 void main() {
   TestBase().runPatrolTest(
     description: 'searching a chat group',
-    test: ($) async {
-      final s = SoftAssertHelper();
-      const searchByMatrixAddress = String.fromEnvironment(
-        'SearchByMatrixAddress',
-      );
-      const searchByTitle = String.fromEnvironment('SearchByTitle');
-      const currentAccount = String.fromEnvironment('CurrentAccount');
-
-      // goto chat screen
-      await HomeRobot($).gotoChatListScreen();
-      // verify we can scroll the screen to find a contact
-      await ChatScenario($).verifyChatListCanBeScrollable(s);
-
-      //enter a non-existed group for searching
-      await ChatScenario($).enterSearchText("noexist");
-      //verify there is no result
-      s.softAssertEquals(
-        (SearchRobot($).getNoResultIcon()).visible,
-        true,
-        'lable "No Results" is not shown',
-      );
-
-      //searching by a text that included in some groups
-      await ChatScenario($).enterSearchText(currentAccount.substring(1, 3));
-      await ChatScenario($).verifySearchResultViewIsShown();
-      await ChatScenario(
-        $,
-      ).verifySearchResultContains(currentAccount.substring(1, 3));
-      //return a list of result
-      s.softAssertEquals(
-        (await ChatListRobot($).getListOfChatGroup()).isNotEmpty,
-        true,
-        'Searchby $currentAccount.substring(1,3) Expected at least 1 group, but found 0',
-      );
-
-      // search by full an address matrix
-      await ChatScenario($).enterSearchText(searchByMatrixAddress);
-      //verify there is one result
-      s.softAssertEquals(
-        (await ChatListRobot($).getListOfChatGroup()).length == 1,
-        true,
-        'Search by $searchByMatrixAddress Expected number of group is 1 , but found != 1',
-      );
-
-      // search by full an address matrix but make it in case-sensitive format
-      await ChatScenario(
-        $,
-      ).enterSearchText(searchByMatrixAddress.toUpperCase());
-      //verify there is one result
-      s.softAssertEquals(
-        (await ChatListRobot($).getListOfChatGroup()).length == 1,
-        true,
-        'Searhc by $searchByMatrixAddress.toUpperCase() Expected number of group is 1 , but found != 1',
-      );
-
-      // search by current account
-      await ChatScenario($).enterSearchText(currentAccount);
-      //verify items displayed on the TwakeListItem
-      //todo: handle the case list both contact and Message
-      s.softAssertEquals(
-        (await (await ChatListRobot(
-          $,
-        ).getListOfChatGroup())[0].getOwnerLabel()).visible,
-        true,
-        'Owner is missing!',
-      );
-      s.softAssertEquals(
-        (await (await ChatListRobot(
-          $,
-        ).getListOfChatGroup())[0].getEmailLabelIncaseSearching()).visible,
-        true,
-        'Email field is not shown',
-      );
-
-      // after searching, open a chat by clicking on a result
-      final chatGroupDetailRobot = await ChatScenario(
-        $,
-      ).openChatGroup(searchByTitle);
-      //verify group chat detail screen is shown
-      expect(await chatGroupDetailRobot.isVisible(), isTrue);
-
-      //back to chat list
-      await ChatScenario(
-        $,
-      ).backToChatLisFromChatGroupScreen(isOpenGroupFromSearchResult: true);
-      //verify chat list screen is shown gain with correct display
-      await ChatScenario($).verifyDisplayOfGroupListScreen(s);
-
-      s.verifyAll();
-    },
+    scenarioBuilder: ($, robots) => ChatListSearchScenario($, robots),
   );
 
   TestBase().runPatrolTest(
     description: 'Count unread messages',
-    test: ($) async {
-      final now = DateTime.now();
-      const groupTest = String.fromEnvironment('TitleOfGroupTest');
-      // goto chat screen
-      await HomeRobot($).gotoChatListScreen();
-      //send a message by API to groupTest
-      await ChatScenario(
-        $,
-      ).sendAMessageByAPI("${now.month}${now.day}${now.hour}${now.minute}");
-      //get current unread message of groupTest
-      final numberOfUnreadMessage1 = ChatListRobot(
-        $,
-      ).getUnreadMessage(groupTest);
-
-      //send the ome more message by API
-      await ChatScenario(
-        $,
-      ).sendAMessageByAPI("${now.month}${now.day}${now.hour}${now.minute}");
-      //get current unread message of groupTest
-      final numberOfUnreadMessage2 = ChatListRobot(
-        $,
-      ).getUnreadMessage(groupTest);
-
-      expect(
-        (numberOfUnreadMessage2 - numberOfUnreadMessage1) == 1,
-        isTrue,
-        reason:
-            "expect the different is 1 but the second is $numberOfUnreadMessage2 and the first is $numberOfUnreadMessage1",
-      );
-    },
+    scenarioBuilder: ($, robots) => UnreadCountScenario($, robots),
   );
+
   TestBase().runPatrolTest(
     description: 'Pin/unpin a chat',
-    test: ($) async {
-      const groupTest = String.fromEnvironment('GroupTest');
-      // goto chat screen
-      await HomeRobot($).gotoChatListScreen();
-      // pin a chat
-      await ChatScenario($).pinAChat(groupTest);
-      // verify the chat is pin
-      await ChatScenario($).verifyAChatIsPin(groupTest, true);
-
-      // unpin a chat
-      await ChatScenario($).unPinAChat(groupTest);
-      // verify the chat is unPin
-      await ChatScenario($).verifyAChatIsPin(groupTest, false);
-    },
+    scenarioBuilder: ($, robots) => PinChatScenario($, robots),
   );
 }

--- a/integration_test/tests/chat/search_external_mxid_test.dart
+++ b/integration_test/tests/chat/search_external_mxid_test.dart
@@ -1,81 +1,9 @@
-import 'package:fluffychat/pages/new_private_chat/widget/expansion_contact_list_tile.dart';
-import 'package:fluffychat/pages/new_private_chat/widget/no_contacts_found.dart';
-import '../../base/core_robot.dart';
 import '../../base/test_base.dart';
-import '../../help/soft_assertion_helper.dart';
-import '../../robots/contact_list_robot.dart';
-import '../../robots/home_robot.dart';
-import '../../robots/search_robot.dart';
-import '../../scenarios/contact_scenario.dart';
+import '../../scenarios/external_mxid_search_scenario.dart';
 
 void main() {
   TestBase().runPatrolTest(
     description: 'Search external contact by Matrix ID validates profile',
-    test: ($) async {
-      final s = SoftAssertHelper();
-
-      const currentAccount = String.fromEnvironment('CurrentAccount');
-
-      // Navigate to Contacts tab
-      await HomeRobot($).gotoContactListScreen();
-
-      // --- Case 1: search a non-existent mxid ---
-      const nonExistentMxid =
-          '@nonexistent_test_user_xyz_000:fake.server.invalid';
-      await ContactScenario($).enterSearchText(nonExistentMxid);
-
-      // Wait for the profile lookup to finish (loading → result)
-      await CoreRobot($).waitForEitherVisible(
-        $: $,
-        first: $(NoContactsFound),
-        second: $(ExpansionContactListTile),
-        timeout: const Duration(seconds: 30),
-      );
-      await $.pumpAndTrySettle();
-
-      // "No Results" should be shown for a non-existent mxid
-      s.softAssertEquals(
-        $(NoContactsFound).exists || (SearchRobot($).getNoResultIcon()).exists,
-        true,
-        'Expected "No Results" to be shown for non-existent mxid, but it was not',
-      );
-
-      // No contact tile should be displayed
-      s.softAssertEquals(
-        $(ExpansionContactListTile).exists,
-        false,
-        'Expected no contact tile for non-existent mxid, but one was found',
-      );
-
-      // --- Case 2: search a valid mxid (current account) ---
-      await SearchRobot($).deleteSearchPhrase();
-      await ContactScenario($).enterSearchText(currentAccount);
-
-      // Wait for the profile lookup to finish
-      await CoreRobot($).waitForEitherVisible(
-        $: $,
-        first: $(NoContactsFound),
-        second: $(ExpansionContactListTile),
-        timeout: const Duration(seconds: 30),
-      );
-      await $.pumpAndTrySettle();
-
-      // "No Results" should NOT be shown — a contact tile should be displayed
-      s.softAssertEquals(
-        $(NoContactsFound).exists,
-        false,
-        'Expected profile info to be shown for valid mxid, but got "No Results"',
-      );
-
-      // A contact list item should be visible (external contact tile)
-      final contacts = await ContactListRobot($).getListOfContact();
-      s.softAssertEquals(
-        contacts.isNotEmpty || $(ExpansionContactListTile).exists,
-        true,
-        'Expected a contact tile to be rendered for valid mxid',
-      );
-
-      s.verifyAll();
-    },
+    scenarioBuilder: ($, robots) => ExternalMxidSearchScenario($, robots),
   );
 }

--- a/integration_test/tests/chat/sending_message_test.dart
+++ b/integration_test/tests/chat/sending_message_test.dart
@@ -1,34 +1,9 @@
 import '../../base/test_base.dart';
-import '../../robots/chat_list_robot.dart';
-import '../../robots/home_robot.dart';
-import '../../scenarios/chat_scenario.dart';
+import '../../scenarios/send_message_scenario.dart';
 
 void main() {
   TestBase().runPatrolTest(
     description: 'Checking sending message between members',
-    test: ($) async {
-      const searchPhrase = String.fromEnvironment(
-        'SearchByTitle',
-        defaultValue: 'My Default Group',
-      );
-      await HomeRobot($).gotoChatListScreen();
-      await ChatScenario($).enterSearchText(searchPhrase);
-      await ChatListRobot($).openChatGroupByIndex(0);
-      // send a message
-      final now = DateTime.now();
-      final messageOfSender =
-          "sender sent at ${now.year}${now.month}${now.day}${now.hour}${now.minute}";
-      final messageOfReceiver =
-          "receiver sent at ${now.year}${now.month}${now.day}${now.hour}${now.minute}";
-      await ChatScenario($).sendAMesage(messageOfSender);
-
-      // check message is sent
-      await ChatScenario($).verifyMessageIsShown(messageOfSender, true);
-
-      // send message by API
-      await ChatScenario($).sendAMessageByAPI(messageOfReceiver);
-      // check message is shown on UI
-      await ChatScenario($).verifyMessageIsShown(messageOfReceiver, true);
-    },
+    scenarioBuilder: ($, robots) => SendMessageScenario($, robots),
   );
 }

--- a/lib/widgets/local_notifications_extension.dart
+++ b/lib/widgets/local_notifications_extension.dart
@@ -67,19 +67,27 @@ extension LocalNotificationsExtension on MatrixState {
           method: ThumbnailMethod.crop,
         );
     if (kIsWeb) {
-      final isInsideCozy = await CozyConfigManager().isInsideCozy;
-      _audioPlayer.play();
-      if (isInsideCozy) {
-        CozyConfigManager().sendNotification(title, body);
-        return;
+      // Displaying a web notification depends on the hosting page (Cozy parent
+      // frame, the `handleNotifications` JS hook). When those are absent the
+      // interop throws; a notification-display failure must not crash the app
+      // (and, as an unhandled async error, fail web integration tests).
+      try {
+        final isInsideCozy = await CozyConfigManager().isInsideCozy;
+        _audioPlayer.play();
+        if (isInsideCozy) {
+          CozyConfigManager().sendNotification(title, body);
+          return;
+        }
+        js.context.callMethod("handleNotifications", [
+          title,
+          body,
+          icon,
+          eventUpdate.roomID,
+          eventUpdate.eventId,
+        ]);
+      } catch (e, s) {
+        Logs().w('showLocalNotification: web notification failed', e, s);
       }
-      js.context.callMethod("handleNotifications", [
-        title,
-        body,
-        icon,
-        eventUpdate.roomID,
-        eventUpdate.eventId,
-      ]);
     } else if (Platform.isLinux) {
       final appIconUrl = room.avatar?.getThumbnail(
         room.client,

--- a/lib/widgets/local_notifications_extension.dart
+++ b/lib/widgets/local_notifications_extension.dart
@@ -73,7 +73,12 @@ extension LocalNotificationsExtension on MatrixState {
       // (and, as an unhandled async error, fail web integration tests).
       try {
         final isInsideCozy = await CozyConfigManager().isInsideCozy;
-        _audioPlayer.play();
+        // `play()` returns a Future that rejects under autoplay policies; await
+        // (and swallow) it so the rejection is caught here instead of surfacing
+        // as an unhandled async error that crashes web integration tests.
+        await _audioPlayer.play().catchError((e, s) {
+          Logs().w('showLocalNotification: audio playback failed', e, s);
+        });
         if (isInsideCozy) {
           CozyConfigManager().sendNotification(title, body);
           return;


### PR DESCRIPTION
## What

Migrate `chat_list`, `search_external_mxid` and `sending_message` integration tests to the `scenarioBuilder` API (cross-platform mobile/web), Patrol-web green.

Part 1/2 of the chat migration. Part 2 (DM-creation, direct-unsupported, group-chat) is stacked in a follow-up PR.

## Notable fixes

- Web-aware robots (two-pane layout): `web_robot_factory`, `web_chat_group_detail_robot`, scoping in `twake_list_item` / `chat_group_detail`.
- `local_notifications_extension`: web error-handling fix.
- Synapse `homeserver.yaml`: test data.

## Web tests (Patrol headless Chrome, local Synapse)

| Test | Result |
|---|---|
| chat_list_test | ✅ 3/3 |
| search_external_mxid | ✅ 1/1 |
| sending_message | ✅ 1/1 |

**5 sub-tests, 0 fail.**

<details>
<summary>Patrol logs</summary>

### chat_list_test.dart

```
🧪 tests.chat.chat_list_test searching a chat group
  ✅   1. waitUntilVisible widgets with type "ChatList".
  ✅   2. tap widgets with type "TwakeNavigationIcon" (ignoring all but index 1).
  ✅   3-6. tap/enterText TextField "@charlie:localhost".
  ✅   7-10. tap/enterText TextField "@alice:localhost".
  ✅  11-14. tap/enterText TextField "TEST_GROUP".
  ✅  15. tap widgets with type "TwakeListItem".
  ✅  16. waitUntilVisible widgets with type "ChatEventList".
✅ searching a chat group (11s)

🧪 tests.chat.chat_list_test Count unread messages
  ✅   1. waitUntilVisible ChatList.
  ✅   2. tap TwakeNavigationIcon (index 1).
✅ Count unread messages (3s)

🧪 tests.chat.chat_list_test Pin/unpin a chat
  ✅   1. waitUntilVisible ChatList.
  ✅   2. tap TwakeNavigationIcon (index 1).
  ✅   3-5. longPress TEST_GROUP -> Checkbox -> tap "Pin".
  ✅   6-8. longPress TEST_GROUP -> Checkbox -> tap "Unpin".
✅ Pin/unpin a chat (5s)

📝 Total: 3 | ✅ Successful: 3 | ❌ Failed: 0 | ⏩ Skipped: 0 | ⏱️ Duration: 45s
```

### search_external_mxid_test.dart

```
🧪 Search external contact by Matrix ID validates profile
  ✅   1. waitUntilVisible ChatList.
  ✅   2. tap TwakeNavigationIcon (index 0).
  ✅   3-6. enterText "@nonexistent_test_user_xyz_000:fake.server.invalid".
  ✅   7. tap Icon descending from TwakeIconButton descending from TextField.
  ✅   8-11. enterText "@alice:localhost".
✅ Search external contact by Matrix ID validates profile (7s)

📝 Total: 1 | ✅ Successful: 1 | ❌ Failed: 0 | ⏩ Skipped: 0 | ⏱️ Duration: 19s
```

### sending_message_test.dart

```
🧪 tests.chat.sending_message_test Checking sending message between members
  ✅   1. waitUntilVisible ChatList.
  ✅   2. tap TwakeNavigationIcon (index 1).
  ✅   3-6. enterText "TEST_GROUP".
  ✅   7. tap TwakeListItem.
  ✅   8-11. enterText "sender sent at 2026692144" (InputBar).
  ✅  12. tap ChatInputRowSendBtn.
  ✅  13. waitUntilVisible MessageContent containing "sender sent at 2026692144".
  ✅  14. waitUntilVisible MessageContent containing "receiver sent at 2026692144".
✅ Checking sending message between members (10s)

📝 Total: 1 | ✅ Successful: 1 | ❌ Failed: 0 | ⏩ Skipped: 0 | ⏱️ Duration: 21s
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added cross-platform integration scenarios (search, unread count, pin/unpin, send message, Matrix ID lookup); refactored tests to a scenario-based framework and improved robot APIs for more reliable UI interactions.
* **Bug Fixes**
  * Improved web notification error handling to avoid runtime failures; web media-permission dialog suppressed for browser flows.
* **Reliability**
  * Enhanced chat list/item and message-send logic to reduce flakes and timing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
