### PR TITLE
fix(chat): use RoomDraftStorage in _onMediaSent (fix broken main analyze)

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -2457,8 +2457,7 @@ class ChatController extends State<Chat>
   Future<void> _onMediaSent() async {
     scrollDown();
     sendController.clear();
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('draft_$roomId');
+    await _draftStorage.remove(roomId!);
     replyEventNotifier.value = null;
   }
 


### PR DESCRIPTION
## Problem

`flutter analyze` is **red on `main`**:

```
error • Undefined name 'SharedPreferences' • lib/pages/chat/chat.dart:2460:25 • undefined_identifier
```

Every open PR fails the *Analyze code* step (CI analyzes the merge with `main`).

## Cause

A semantic merge conflict between two green PRs merged 47s apart:

- [#3104](https://github.com/linagora/twake-on-matrix/pull/3104) (native photo picker) **added** `_onMediaSent()` using `SharedPreferences.getInstance()` directly — green at the time because the import still existed.
- [#3111](https://github.com/linagora/twake-on-matrix/pull/3111) (prefill caption on paste) **removed** the `shared_preferences` import and extracted the draft logic into `RoomDraftStorage`. Its diff never touched `_onMediaSent` because its base predated #3104.

Git auto-merged both (different lines, no textual conflict), leaving `_onMediaSent` calling `SharedPreferences` with no import → undefined reference on `main`. Neither PR's CI caught it since each was analyzed against its own base, never the combined state.

## Fix

Route `_onMediaSent` through the existing `_draftStorage` helper (`chat.dart:323`), like the other call sites (`792`, `2447`, `2556`).

```diff
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove('draft_$roomId');
+    await _draftStorage.remove(roomId!);
```

`dart analyze lib/pages/chat/chat.dart` → **No issues found!**
