### PR TITLE
test(integration): migrate chat_group_open_profile + transfer_ownership to scenarioBuilder (web-green) [PR 9a]

### DIFF
--- a/integration_test/factories/mobile_robot_factory.dart
+++ b/integration_test/factories/mobile_robot_factory.dart
@@ -2,17 +2,23 @@ import 'package:patrol/patrol.dart';
 
 import '../robots/abstract/abstract_chat_group_detail_robot.dart';
 import '../robots/abstract/abstract_chat_list_robot.dart';
+import '../robots/abstract/abstract_chat_profile_info_robot.dart';
 import '../robots/abstract/abstract_contact_list_robot.dart';
+import '../robots/abstract/abstract_group_information_robot.dart';
 import '../robots/abstract/abstract_home_robot.dart';
 import '../robots/abstract/abstract_language_setting_robot.dart';
 import '../robots/abstract/abstract_login_robot.dart';
 import '../robots/abstract/abstract_search_robot.dart';
+import '../robots/abstract/abstract_search_view_robot.dart';
 import '../robots/abstract/abstract_setting_robot.dart';
+import '../robots/chat/chat_profile_info_robot.dart';
 import '../robots/chat_group_detail_robot.dart';
 import '../robots/chat_list_robot.dart';
 import '../robots/contact_list_robot.dart';
+import '../robots/group_information_robot.dart';
 import '../robots/home_robot.dart';
 import '../robots/login_robot.dart';
+import '../robots/search/search_view_robot.dart';
 import '../robots/search_robot.dart';
 import '../robots/setting/app_language_setting_robot.dart';
 import '../robots/setting/setting_robot.dart';
@@ -43,6 +49,17 @@ class MobileRobotFactory implements RobotFactory {
 
   @override
   AbstractSearchRobot searchRobot() => SearchRobot($);
+
+  @override
+  AbstractSearchViewRobot searchViewRobot() => SearchViewRobot($);
+
+  @override
+  AbstractGroupInformationRobot groupInformationRobot() =>
+      GroupInformationRobot($);
+
+  @override
+  AbstractChatProfileInfoRobot chatProfileInfoRobot() =>
+      ChatProfileInfoRobot($);
 
   @override
   AbstractContactListRobot contactListRobot() => ContactListRobot($);

--- a/integration_test/factories/robot_factory.dart
+++ b/integration_test/factories/robot_factory.dart
@@ -2,11 +2,14 @@ import 'package:patrol/patrol.dart';
 
 import '../robots/abstract/abstract_chat_group_detail_robot.dart';
 import '../robots/abstract/abstract_chat_list_robot.dart';
+import '../robots/abstract/abstract_chat_profile_info_robot.dart';
 import '../robots/abstract/abstract_contact_list_robot.dart';
+import '../robots/abstract/abstract_group_information_robot.dart';
 import '../robots/abstract/abstract_home_robot.dart';
 import '../robots/abstract/abstract_language_setting_robot.dart';
 import '../robots/abstract/abstract_login_robot.dart';
 import '../robots/abstract/abstract_search_robot.dart';
+import '../robots/abstract/abstract_search_view_robot.dart';
 import '../robots/abstract/abstract_setting_robot.dart';
 
 /// Contract for producing platform-appropriate robot implementations.
@@ -26,6 +29,9 @@ abstract class RobotFactory {
   AbstractChatListRobot chatListRobot();
   AbstractChatGroupDetailRobot chatGroupDetailRobot();
   AbstractSearchRobot searchRobot();
+  AbstractSearchViewRobot searchViewRobot();
+  AbstractGroupInformationRobot groupInformationRobot();
+  AbstractChatProfileInfoRobot chatProfileInfoRobot();
   AbstractContactListRobot contactListRobot();
   AbstractSettingRobot settingRobot();
   AbstractLanguageSettingRobot languageSettingRobot();

--- a/integration_test/factories/web_robot_factory.dart
+++ b/integration_test/factories/web_robot_factory.dart
@@ -2,17 +2,23 @@ import 'package:patrol/patrol.dart';
 
 import '../robots/abstract/abstract_chat_group_detail_robot.dart';
 import '../robots/abstract/abstract_chat_list_robot.dart';
+import '../robots/abstract/abstract_chat_profile_info_robot.dart';
 import '../robots/abstract/abstract_contact_list_robot.dart';
+import '../robots/abstract/abstract_group_information_robot.dart';
 import '../robots/abstract/abstract_home_robot.dart';
 import '../robots/abstract/abstract_language_setting_robot.dart';
 import '../robots/abstract/abstract_login_robot.dart';
 import '../robots/abstract/abstract_search_robot.dart';
+import '../robots/abstract/abstract_search_view_robot.dart';
 import '../robots/abstract/abstract_setting_robot.dart';
 import '../robots/chat_list_robot.dart';
 import '../robots/contact_list_robot.dart';
 import '../robots/home_robot.dart';
+import '../robots/search/search_view_robot.dart';
 import '../robots/setting/setting_robot.dart';
 import '../robots/web/web_chat_group_detail_robot.dart';
+import '../robots/web/web_chat_profile_info_robot.dart';
+import '../robots/web/web_group_information_robot.dart';
 import '../robots/web/web_language_setting_robot.dart';
 import '../robots/web/web_login_robot.dart';
 import '../robots/web/web_search_robot.dart';
@@ -45,6 +51,17 @@ class WebRobotFactory implements RobotFactory {
 
   @override
   AbstractSearchRobot searchRobot() => WebSearchRobot($);
+
+  @override
+  AbstractSearchViewRobot searchViewRobot() => SearchViewRobot($);
+
+  @override
+  AbstractGroupInformationRobot groupInformationRobot() =>
+      WebGroupInformationRobot($);
+
+  @override
+  AbstractChatProfileInfoRobot chatProfileInfoRobot() =>
+      WebChatProfileInfoRobot($);
 
   @override
   AbstractContactListRobot contactListRobot() => ContactListRobot($);

--- a/integration_test/robots/abstract/abstract_chat_profile_info_robot.dart
+++ b/integration_test/robots/abstract/abstract_chat_profile_info_robot.dart
@@ -1,0 +1,20 @@
+import 'package:fluffychat/presentation/enum/profile_info/profile_info_body_enum.dart';
+
+/// Platform-agnostic contract for the member profile-info screen.
+abstract class AbstractChatProfileInfoRobot {
+  Future<String> getDisplayName();
+  Future<String> getEmail();
+  Future<String> getPhoneNumber();
+
+  Future<void> verifyDisplayName({required String displayName});
+  Future<void> verifyDisplayMatrixId({required String matrixId});
+  Future<void> verifyEmail({required String email});
+  Future<void> verifyPhoneNumber({required String phoneNumber});
+
+  Future<void> verifyProfileActionButtonVisible(
+    ProfileInfoActions action, {
+    bool expected = true,
+  });
+  Future<void> tapProfileActionButton(ProfileInfoActions action);
+  Future<void> confirmTransferOwnership();
+}

--- a/integration_test/robots/abstract/abstract_group_information_robot.dart
+++ b/integration_test/robots/abstract/abstract_group_information_robot.dart
@@ -1,0 +1,6 @@
+/// Platform-agnostic contract for the group-information screen.
+abstract class AbstractGroupInformationRobot {
+  /// Scrolls the member list until the participant identified by
+  /// [matrixID] is visible, taps it and waits for the profile view.
+  Future<void> openMemberDetail({required String matrixID});
+}

--- a/integration_test/robots/abstract/abstract_search_view_robot.dart
+++ b/integration_test/robots/abstract/abstract_search_view_robot.dart
@@ -1,0 +1,12 @@
+/// Platform-agnostic contract for the room-search view.
+///
+/// Implemented by `SearchViewRobot` (shared mobile/web for now); the
+/// factory returns the platform-appropriate instance so scenarios never
+/// reference a concrete class.
+abstract class AbstractSearchViewRobot {
+  /// Searches for [roomName] and opens the first matching room.
+  ///
+  /// Returns `false` when no room matches, so the scenario can decide
+  /// whether that is a failure or an expected platform divergence.
+  Future<bool> searchAndOpenRoom(String roomName);
+}

--- a/integration_test/robots/chat/chat_profile_info_robot.dart
+++ b/integration_test/robots/chat/chat_profile_info_robot.dart
@@ -10,37 +10,46 @@ import 'package:patrol/patrol.dart';
 import 'package:fluffychat/presentation/enum/profile_info/profile_info_body_enum.dart';
 
 import '../../base/core_robot.dart';
+import '../abstract/abstract_chat_profile_info_robot.dart';
 
-class ChatProfileInfoRobot extends CoreRobot {
+class ChatProfileInfoRobot extends CoreRobot
+    implements AbstractChatProfileInfoRobot {
   ChatProfileInfoRobot(super.$);
 
+  @override
   Future<void> verifyDisplayName({required String displayName}) async {
     final displayNameFinder = find.text(displayName);
     expect(displayNameFinder, findsOneWidget);
   }
 
+  @override
   Future<void> verifyDisplayMatrixId({required String matrixId}) async {
     final matrixIdFinder = find.text(matrixId);
     expect(matrixIdFinder, findsOneWidget);
   }
 
+  @override
   Future<void> verifyEmail({required String email}) async {
     final emailFinder = find.text(email);
     if (email.isEmpty) {
       expect(emailFinder, findsNothing);
       return;
     }
+    expect(emailFinder, findsOneWidget);
   }
 
+  @override
   Future<void> verifyPhoneNumber({required String phoneNumber}) async {
     final phoneNumberFinder = find.text(phoneNumber);
     if (phoneNumber.isEmpty) {
       expect(phoneNumberFinder, findsNothing);
       return;
     }
+    expect(phoneNumberFinder, findsOneWidget);
   }
 
   /// Get the display name from the ProfileInfoHeader widget
+  @override
   Future<String> getDisplayName() async {
     // Wait for ProfileInfoHeader to be visible
     await $.waitUntilVisible($(ProfileInfoHeader));
@@ -82,6 +91,7 @@ class ChatProfileInfoRobot extends CoreRobot {
   }
 
   /// Get email from the ProfileInfoContactRows widget
+  @override
   Future<String> getEmail() async {
     await $.waitUntilVisible($(ProfileInfoContactRows));
 
@@ -102,6 +112,7 @@ class ChatProfileInfoRobot extends CoreRobot {
   }
 
   /// Get phone number from the ProfileInfoContactRows widget
+  @override
   Future<String> getPhoneNumber() async {
     await $.waitUntilVisible($(ProfileInfoContactRows));
 
@@ -192,6 +203,7 @@ class ChatProfileInfoRobot extends CoreRobot {
   }
 
   /// Verify a profile action button is visible
+  @override
   Future<void> verifyProfileActionButtonVisible(
     ProfileInfoActions action, {
     bool expected = true,
@@ -218,6 +230,7 @@ class ChatProfileInfoRobot extends CoreRobot {
   }
 
   /// Tap on a profile action button
+  @override
   Future<void> tapProfileActionButton(ProfileInfoActions action) async {
     final button = getProfileActionButton(action);
     await button.waitUntilVisible();
@@ -226,6 +239,7 @@ class ChatProfileInfoRobot extends CoreRobot {
   }
 
   /// Confirm the transfer ownership dialog
+  @override
   Future<void> confirmTransferOwnership() async {
     await $.waitUntilVisible(
       $(find.byKey(TwakeDialog.showConfirmAlertDialogKey)),

--- a/integration_test/robots/group_information_robot.dart
+++ b/integration_test/robots/group_information_robot.dart
@@ -8,9 +8,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:patrol/patrol.dart';
 import '../base/core_robot.dart';
+import 'abstract/abstract_group_information_robot.dart';
 import 'twake_list_item_robot.dart';
 
-class GroupInformationRobot extends CoreRobot {
+class GroupInformationRobot extends CoreRobot
+    implements AbstractGroupInformationRobot {
   GroupInformationRobot(super.$);
 
   PatrolFinder getBackIcon() {
@@ -127,6 +129,7 @@ class GroupInformationRobot extends CoreRobot {
     return $(find.byKey(ValueKey<String>(matrixID)));
   }
 
+  @override
   Future<void> openMemberDetail({required String matrixID}) async {
     await $.scrollUntilVisible(finder: getMemberByMatrixID(matrixID));
     await getMemberByMatrixID(matrixID).tap();

--- a/integration_test/robots/search/search_view_robot.dart
+++ b/integration_test/robots/search/search_view_robot.dart
@@ -2,11 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/list_item/twake_list_item.dart';
 
 import '../../base/core_robot.dart';
+import '../abstract/abstract_search_view_robot.dart';
 import '../search_robot.dart';
 import '../twake_list_item_robot.dart';
 
-class SearchViewRobot extends SearchRobot {
+class SearchViewRobot extends SearchRobot implements AbstractSearchViewRobot {
   SearchViewRobot(super.$);
+
+  @override
+  Future<bool> searchAndOpenRoom(String roomName) async {
+    final room = await searchRoom(roomName);
+    if (room == null) {
+      return false;
+    }
+    await openRoom(room);
+    return true;
+  }
 
   Future<List<TwakeListItemRobot>> getRoomsInSearch() async {
     final List<TwakeListItemRobot> rooms = [];

--- a/integration_test/robots/web/web_chat_profile_info_robot.dart
+++ b/integration_test/robots/web/web_chat_profile_info_robot.dart
@@ -1,0 +1,83 @@
+import 'package:fluffychat/pages/profile_info/profile_info_body/profile_info_body.dart';
+import 'package:fluffychat/pages/profile_info/profile_info_body/profile_info_header.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../chat/chat_profile_info_robot.dart';
+
+/// Web-specific member profile-info robot.
+///
+/// On web (wide layout) the profile opens inside an `AlertDialog` hosting
+/// `ProfileInfoBody`, layered over the group-information pane that still
+/// shows the same member name and matrix id — so the mobile robot's
+/// unscoped `find.text(...)`/`findsOneWidget` assertions match both and
+/// fail. All reads and assertions are scoped to `ProfileInfoBody`. The
+/// avatar's fallback initial also renders as the first `Text` of
+/// `ProfileInfoHeader`, so the display name is matched on its
+/// `maxLines: 2` style instead of taking the first text.
+class WebChatProfileInfoRobot extends ChatProfileInfoRobot {
+  WebChatProfileInfoRobot(super.$);
+
+  Finder get _scope => find.byType(ProfileInfoBody);
+
+  @override
+  Future<String> getDisplayName() async {
+    await $(ProfileInfoHeader).waitUntilExists();
+    final texts = find
+        .descendant(
+          of: find.byType(ProfileInfoHeader),
+          matching: find.byType(Text),
+        )
+        .evaluate()
+        .map((element) => element.widget as Text);
+    // The avatar's fallback initial renders as the first header text
+    // (single character); the display name is the first text after it —
+    // before any presence label.
+    for (final text in texts) {
+      final data = text.data ?? '';
+      if (data.length > 1) {
+        return data;
+      }
+    }
+    return '';
+  }
+
+  @override
+  Future<void> verifyDisplayName({required String displayName}) async {
+    expect(
+      find.descendant(of: _scope, matching: find.text(displayName)),
+      findsWidgets,
+    );
+  }
+
+  @override
+  Future<void> verifyDisplayMatrixId({required String matrixId}) async {
+    expect(
+      find.descendant(of: _scope, matching: find.text(matrixId)),
+      findsWidgets,
+    );
+  }
+
+  @override
+  Future<void> verifyEmail({required String email}) async {
+    final emailFinder = find.descendant(of: _scope, matching: find.text(email));
+    if (email.isEmpty) {
+      expect(emailFinder, findsNothing);
+      return;
+    }
+    expect(emailFinder, findsWidgets);
+  }
+
+  @override
+  Future<void> verifyPhoneNumber({required String phoneNumber}) async {
+    final phoneFinder = find.descendant(
+      of: _scope,
+      matching: find.text(phoneNumber),
+    );
+    if (phoneNumber.isEmpty) {
+      expect(phoneFinder, findsNothing);
+      return;
+    }
+    expect(phoneFinder, findsWidgets);
+  }
+}

--- a/integration_test/robots/web/web_group_information_robot.dart
+++ b/integration_test/robots/web/web_group_information_robot.dart
@@ -1,0 +1,53 @@
+import 'package:fluffychat/pages/profile_info/profile_info_body/profile_info_body.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../group_information_robot.dart';
+
+/// Web-specific group-information robot.
+///
+/// On web the group info renders in the right column of the two-pane
+/// layout, so the mobile `$.scrollUntilVisible` (which drags the first
+/// `Scrollable`, i.e. the chat list of the left pane) targets the wrong
+/// pane. On the headless-Chrome viewport the member rows also sit below
+/// the fold of the right pane, where the list viewport reports them as
+/// off-stage — the default on-stage finders never match even though the
+/// element is alive. Match the row with an off-stage-inclusive finder and
+/// bring it into view with `ensureVisible` (which scrolls the row's own
+/// viewport) before tapping.
+class WebGroupInformationRobot extends GroupInformationRobot {
+  WebGroupInformationRobot(super.$);
+
+  @override
+  Future<void> openMemberDetail({required String matrixID}) async {
+    // Match the key by value (any `ValueKey` type argument) and include
+    // off-stage elements: rows outside the viewport's visible band are
+    // excluded from the default on-stage traversal.
+    final member = find.byWidgetPredicate((widget) {
+      final key = widget.key;
+      return key is ValueKey && key.value == matrixID;
+    }, skipOffstage: false);
+
+    // The member list materialises only once participants and power levels
+    // have been fetched, which can exceed the global 6s exists-timeout —
+    // poll the tree for up to 30s instead.
+    final deadline = DateTime.now().add(const Duration(seconds: 30));
+    while (member.evaluate().isEmpty && DateTime.now().isBefore(deadline)) {
+      await $.pump(const Duration(milliseconds: 500));
+    }
+    if (member.evaluate().isEmpty) {
+      throw StateError('Member "$matrixID" not found in group information');
+    }
+
+    // `ensureVisible` scrolls the right pane's own viewport; tap without
+    // the hit-test warning because the decorative Lottie animation of the
+    // empty middle pane can overlap the hit-test position.
+    await $.tester.ensureVisible(member.first);
+    await $.pump(const Duration(milliseconds: 300));
+    await $.tester.tap(member.first, warnIfMissed: false);
+    await $.pump(const Duration(seconds: 1));
+    // On web (wide layout) the member profile opens inside an `AlertDialog`
+    // hosting `ProfileInfoBody` — `ProfileInfoView` is the mobile route.
+    await $(ProfileInfoBody).waitUntilExists();
+  }
+}

--- a/integration_test/scenarios/chat_group_open_profile_scenario.dart
+++ b/integration_test/scenarios/chat_group_open_profile_scenario.dart
@@ -1,0 +1,54 @@
+import '../base/base_test_scenario.dart';
+
+/// Cross-platform scenario: open a group member's profile and verify the
+/// displayed identity fields.
+///
+/// Searches the group named by `SearchByTitle`, opens its group info,
+/// drills into the member identified by `MemberMatrixID` and checks that
+/// the display name, matrix id, email and phone number render consistently.
+///
+/// Drives the UI exclusively through the abstract robots exposed by the
+/// `RobotFactory`.
+class ChatGroupOpenProfileScenario extends BaseTestScenario {
+  ChatGroupOpenProfileScenario(super.$, super.robots);
+
+  static const _searchPhrase = String.fromEnvironment(
+    'SearchByTitle',
+    defaultValue: 'My Default Group',
+  );
+
+  static const _memberMatrixID = String.fromEnvironment(
+    'MemberMatrixID',
+    defaultValue: '@member:localhost',
+  );
+
+  @override
+  Future<void> runTestLogic() async {
+    await robots.chatListRobot().openSearchScreen();
+
+    final opened = await robots.searchViewRobot().searchAndOpenRoom(
+      _searchPhrase,
+    );
+    if (!opened) {
+      throw Exception('Test failed: Room "$_searchPhrase" was not found.');
+    }
+
+    await robots.chatGroupDetailRobot().tapOnChatBarTitle();
+    await robots.groupInformationRobot().openMemberDetail(
+      matrixID: _memberMatrixID,
+    );
+
+    final profile = robots.chatProfileInfoRobot();
+
+    // Read the values the UI rendered, then assert they are displayed
+    // consistently (same checks as the legacy imperative test).
+    final displayName = await profile.getDisplayName();
+    final email = await profile.getEmail();
+    final phoneNumber = await profile.getPhoneNumber();
+
+    await profile.verifyDisplayName(displayName: displayName);
+    await profile.verifyDisplayMatrixId(matrixId: _memberMatrixID);
+    await profile.verifyEmail(email: email);
+    await profile.verifyPhoneNumber(phoneNumber: phoneNumber);
+  }
+}

--- a/integration_test/scenarios/transfer_ownership_scenario.dart
+++ b/integration_test/scenarios/transfer_ownership_scenario.dart
@@ -1,0 +1,69 @@
+import 'package:fluffychat/presentation/enum/profile_info/profile_info_body_enum.dart';
+
+import '../base/base_test_scenario.dart';
+
+/// Cross-platform scenario: transfer group ownership to a member and verify
+/// the action disappears afterwards.
+///
+/// Pre-condition: the logged-in account owns the group named by
+/// `SearchByTitle` and `MemberMatrixID` is a joined member. Note the action
+/// mutates server state — re-running against the same homeserver without
+/// re-provisioning leaves the account without ownership.
+///
+/// Drives the UI exclusively through the abstract robots exposed by the
+/// `RobotFactory`.
+class TransferOwnershipScenario extends BaseTestScenario {
+  TransferOwnershipScenario(super.$, super.robots);
+
+  static const _searchPhrase = String.fromEnvironment(
+    'SearchByTitle',
+    defaultValue: 'My Default Group',
+  );
+
+  static const _memberMatrixID = String.fromEnvironment(
+    'MemberMatrixID',
+    defaultValue: '@member:localhost',
+  );
+
+  @override
+  Future<void> runTestLogic() async {
+    // 1. Open the group chat.
+    await robots.chatListRobot().openSearchScreen();
+    final opened = await robots.searchViewRobot().searchAndOpenRoom(
+      _searchPhrase,
+    );
+    if (!opened) {
+      throw Exception('Test failed: Room "$_searchPhrase" was not found.');
+    }
+
+    // 2. Open group info and navigate to a member's profile.
+    await robots.chatGroupDetailRobot().tapOnChatBarTitle();
+    await robots.groupInformationRobot().openMemberDetail(
+      matrixID: _memberMatrixID,
+    );
+
+    final profile = robots.chatProfileInfoRobot();
+
+    // 3. Verify transfer ownership button is visible (current user is owner).
+    await profile.verifyProfileActionButtonVisible(
+      ProfileInfoActions.transferOwnership,
+    );
+
+    // 4. Tap transfer ownership and confirm.
+    await profile.tapProfileActionButton(ProfileInfoActions.transferOwnership);
+    await profile.confirmTransferOwnership();
+
+    // 5. Wait for the operation to complete and the profile page to pop.
+    await $.pump(const Duration(seconds: 3));
+
+    // 6. After transfer, the profile page pops back to Group Info.
+    //    Re-open the same member's profile to verify the button is gone.
+    await robots.groupInformationRobot().openMemberDetail(
+      matrixID: _memberMatrixID,
+    );
+    await profile.verifyProfileActionButtonVisible(
+      ProfileInfoActions.transferOwnership,
+      expected: false,
+    );
+  }
+}

--- a/integration_test/tests/chat/chat_group_open_profile_test.dart
+++ b/integration_test/tests/chat/chat_group_open_profile_test.dart
@@ -1,56 +1,9 @@
 import '../../base/test_base.dart';
-import '../../robots/chat/chat_profile_info_robot.dart';
-import '../../robots/chat_list_robot.dart';
-import '../../robots/group_information_robot.dart';
-import '../../robots/search/search_view_robot.dart';
-import '../../scenarios/chat_scenario.dart';
-
-const defaultTime = Duration(seconds: 60);
-const searchPhrase = String.fromEnvironment(
-  'SearchByTitle',
-  defaultValue: 'My Default Group',
-);
-const forwardReceiver = String.fromEnvironment(
-  'Receiver',
-  defaultValue: 'Receiver Group',
-);
-
-int uniqueId() => DateTime.now().microsecondsSinceEpoch;
+import '../../scenarios/chat_group_open_profile_scenario.dart';
 
 void main() {
-  TestBase().twakePatrolTest(
-    description: 'Chat group open  owner profile test',
-    test: ($) async {
-      const matrixID = "@stgtest:stg.lin-saas.com";
-      await ChatListRobot($).openSearchScreen();
-
-      final room = await SearchViewRobot($).searchRoom(searchPhrase);
-
-      // Check if room was found and opened
-      if (room == null) {
-        throw Exception('Test failed: Room "$searchPhrase" was not found. ');
-      }
-
-      await SearchViewRobot($).openRoom(room);
-
-      await ChatScenario($).openGroupChatInfo();
-
-      await GroupInformationRobot($).openMemberDetail(matrixID: matrixID);
-
-      // Get data from UI
-      final displayName = await ChatProfileInfoRobot($).getDisplayName();
-
-      final email = await ChatProfileInfoRobot($).getEmail();
-
-      final phoneNumber = await ChatProfileInfoRobot($).getPhoneNumber();
-
-      await ChatProfileInfoRobot($).verifyDisplayName(displayName: displayName);
-
-      await ChatProfileInfoRobot($).verifyDisplayMatrixId(matrixId: matrixID);
-
-      await ChatProfileInfoRobot($).verifyEmail(email: email);
-
-      await ChatProfileInfoRobot($).verifyPhoneNumber(phoneNumber: phoneNumber);
-    },
+  TestBase().runPatrolTest(
+    description: 'Chat group open owner profile test',
+    scenarioBuilder: ($, robots) => ChatGroupOpenProfileScenario($, robots),
   );
 }

--- a/integration_test/tests/chat/transfer_ownership_test.dart
+++ b/integration_test/tests/chat/transfer_ownership_test.dart
@@ -1,61 +1,11 @@
-import 'package:fluffychat/presentation/enum/profile_info/profile_info_body_enum.dart';
-
 import '../../base/test_base.dart';
-import '../../robots/chat/chat_profile_info_robot.dart';
-import '../../robots/chat_list_robot.dart';
-import '../../robots/group_information_robot.dart';
-import '../../robots/search/search_view_robot.dart';
-import '../../scenarios/chat_scenario.dart';
-
-const searchPhrase = String.fromEnvironment(
-  'SearchByTitle',
-  defaultValue: 'My Default Group',
-);
-
-const memberMatrixID = String.fromEnvironment(
-  'MemberMatrixID',
-  defaultValue: '@member:localhost',
-);
+import '../../scenarios/transfer_ownership_scenario.dart';
 
 void main() {
   TestBase().runPatrolTest(
     tags: ['transfer_ownership_test_01'],
     description:
         'Transfer ownership button disappears after successful transfer',
-    test: ($) async {
-      // 1. Open the group chat
-      await ChatListRobot($).openSearchScreen();
-      final room = await SearchViewRobot($).searchRoom(searchPhrase);
-      if (room == null) {
-        throw Exception('Test failed: Room "$searchPhrase" was not found.');
-      }
-      await SearchViewRobot($).openRoom(room);
-
-      // 2. Open group info and navigate to a member's profile
-      await ChatScenario($).openGroupChatInfo();
-      await GroupInformationRobot($).openMemberDetail(matrixID: memberMatrixID);
-
-      // 3. Verify transfer ownership button is visible (current user is owner)
-      await ChatProfileInfoRobot(
-        $,
-      ).verifyProfileActionButtonVisible(ProfileInfoActions.transferOwnership);
-
-      // 4. Tap transfer ownership and confirm
-      await ChatProfileInfoRobot(
-        $,
-      ).tapProfileActionButton(ProfileInfoActions.transferOwnership);
-      await ChatProfileInfoRobot($).confirmTransferOwnership();
-
-      // 5. Wait for the operation to complete and profile page to pop
-      await $.pump(const Duration(seconds: 3));
-
-      // 6. After transfer, the profile page pops back to Group Info.
-      //    Re-open the same member's profile to verify the button is gone.
-      await GroupInformationRobot($).openMemberDetail(matrixID: memberMatrixID);
-      await ChatProfileInfoRobot($).verifyProfileActionButtonVisible(
-        ProfileInfoActions.transferOwnership,
-        expected: false,
-      );
-    },
+    scenarioBuilder: ($, robots) => TransferOwnershipScenario($, robots),
   );
 }


### PR DESCRIPTION
## What

Migrate `chat_group_open_profile_test` and `transfer_ownership_test` to the `scenarioBuilder` API (cross-platform mobile/web), Patrol-web green.

Stacked on #3117 — merge after it.

## New abstract contracts

- `AbstractSearchViewRobot.searchAndOpenRoom(roomName)`
- `AbstractGroupInformationRobot.openMemberDetail(matrixID)`
- `AbstractChatProfileInfoRobot` — profile identity reads/asserts + transfer-ownership actions

## Web-specific robots

- **`WebGroupInformationRobot`** — member rows below the fold are reported off-stage by the list viewport, so default finders miss them: match the `ValueKey` by value with `skipOffstage: false` + `ensureVisible` (mobile `$.scrollUntilVisible` drags the left-pane chat list). Profile opens as `AlertDialog` + `ProfileInfoBody` on web (mobile: `ProfileInfoView` route).
- **`WebChatProfileInfoRobot`** — assertions scoped to `ProfileInfoBody` (the pane behind the dialog shows the same name/mxid); display name skips the avatar fallback initial.

## Notes

- `chat_group_open_profile` now uses `MemberMatrixID` (default `@member:localhost`) instead of a hardcoded staging account; migrated from legacy `twakePatrolTest` to `runPatrolTest` + `scenarioBuilder`.
- `transfer_ownership` mutates server state — local re-runs need a power-level reset; CI provisions a fresh Synapse.
- `chat_group_test` deferred to PR 9b (web message menu = hover → actions → "more", shared with `forward_message`/`message_context_menu`).

## Web tests (Patrol headless Chrome, local Synapse)

| Test | Result |
|---|---|
| chat_group_open_profile_test | ✅ 1/1 |
| transfer_ownership_test | ✅ 1/1 |

15 files, single commit, all stacked-PR changes excluded from this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests validating search, group/member profile viewing, and transfer-ownership flows on mobile and web.
  * Migrated inline tests to reusable, scenario-driven test classes for clearer, maintainable test execution.
* **New Features**
  * Introduced cross-platform test helpers to drive room search, open member profiles, and confirm transfer-ownership interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->