### PR TITLE
TW-2968(fix): wrong member count in group chat

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -74,6 +74,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart';
 import 'package:fluffychat/utils/network_connection_service.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
@@ -439,7 +440,7 @@ class ChatController extends State<Chat>
   Future<void> _requestParticipants() async {
     if (room == null) return;
     try {
-      await room!.requestParticipants(
+      await room!.requestParticipantsWithSummaryReconciliation(
         Membership.values
             .whereNot((membership) => membership == Membership.leave)
             .toList(),

--- a/lib/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart
@@ -1,11 +1,10 @@
 import 'package:fluffychat/utils/logging/sentry_tracked_events.dart';
 import 'package:matrix/matrix.dart';
 
-/// Fix stale room summary member counts.
-///
-/// Servers only send `joined_member_count` and `invited_member_count` in
-/// /sync when they change: one missed delta leaves the persisted counts
-/// wrong forever, as nothing ever reconciles them with the member list.
+/// TODO(TW-2968): client-side workaround for a Synapse bug that omits
+/// member-count deltas — https://github.com/element-hq/synapse/issues/19865
+/// Remove this reconciliation once Synapse is fixed (keep the
+/// `Wrong-member-count` Sentry tag to confirm the fix landed).
 extension RoomMemberCountReconciliationExtension on Room {
   /// Only reconciles when [membershipFilter] contains both [Membership.join]
   /// and [Membership.invite]: otherwise the list is not usable.

--- a/lib/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart
@@ -1,0 +1,82 @@
+import 'package:fluffychat/utils/logging/sentry_tracked_events.dart';
+import 'package:matrix/matrix.dart';
+
+/// Fix stale room summary member counts.
+///
+/// Servers only send `joined_member_count` and `invited_member_count` in
+/// /sync when they change: one missed delta leaves the persisted counts
+/// wrong forever, as nothing ever reconciles them with the member list.
+extension RoomMemberCountReconciliationExtension on Room {
+  /// Only reconciles when [membershipFilter] contains both [Membership.join]
+  /// and [Membership.invite]: otherwise the list is not usable.
+  Future<List<User>> requestParticipantsWithSummaryReconciliation([
+    List<Membership> membershipFilter = const [
+      Membership.join,
+      Membership.invite,
+      Membership.knock,
+    ],
+    bool suppressWarning = false,
+    bool? cache,
+  ]) async {
+    final participants = await requestParticipants(
+      membershipFilter,
+      suppressWarning,
+      cache,
+    );
+    if (membershipFilter.contains(Membership.join) &&
+        membershipFilter.contains(Membership.invite)) {
+      await healSummaryMemberCounts(participants);
+    }
+    return participants;
+  }
+
+  /// Updates the summary member counts, in memory and in database, when they
+  /// diverge
+  Future<void> healSummaryMemberCounts(
+    List<User> groundTruthParticipants,
+  ) async {
+    // A synthetic JoinedRoomUpdate on a non-joined or unknown room would
+    // corrupt its membership or restore it in the room list.
+    if (membership != Membership.join || client.getRoomById(id) == null) {
+      return;
+    }
+    final joinedCount = groundTruthParticipants
+        .where((user) => user.membership == Membership.join)
+        .length;
+    final invitedCount = groundTruthParticipants
+        .where((user) => user.membership == Membership.invite)
+        .length;
+    // A joined room always has at least one joined member (the syncing user)
+    if (joinedCount == 0) {
+      return;
+    }
+    if (summary.mJoinedMemberCount == joinedCount &&
+        summary.mInvitedMemberCount == invitedCount) {
+      return;
+    }
+    Logs().w(
+      '${SentryTrackedEvents.wrongMemberCount.message}: healing summary of '
+      '$id from (joined=${summary.mJoinedMemberCount}, '
+      'invited=${summary.mInvitedMemberCount}) to (joined=$joinedCount, '
+      'invited=$invitedCount)',
+    );
+    // Feed the corrected counts through the regular sync pipeline, as if the
+    // server had sent them: same merge (heroes preserved), same persistence
+    // and UI notifications as a real summary update.
+    await client.handleSync(
+      SyncUpdate(
+        nextBatch: client.prevBatch ?? '',
+        rooms: RoomsUpdate(
+          join: {
+            id: JoinedRoomUpdate(
+              summary: RoomSummary.fromJson({
+                'm.joined_member_count': joinedCount,
+                'm.invited_member_count': invitedCount,
+              }),
+            ),
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart
@@ -63,20 +63,22 @@ extension RoomMemberCountReconciliationExtension on Room {
     // Feed the corrected counts through the regular sync pipeline, as if the
     // server had sent them: same merge (heroes preserved), same persistence
     // and UI notifications as a real summary update.
-    await client.handleSync(
-      SyncUpdate(
-        nextBatch: client.prevBatch ?? '',
-        rooms: RoomsUpdate(
-          join: {
-            id: JoinedRoomUpdate(
-              summary: RoomSummary.fromJson({
-                'm.joined_member_count': joinedCount,
-                'm.invited_member_count': invitedCount,
-              }),
-            ),
-          },
+    await client.database.transaction(() async {
+      await client.handleSync(
+        SyncUpdate(
+          nextBatch: client.prevBatch ?? '',
+          rooms: RoomsUpdate(
+            join: {
+              id: JoinedRoomUpdate(
+                summary: RoomSummary.fromJson({
+                  'm.joined_member_count': joinedCount,
+                  'm.invited_member_count': invitedCount,
+                }),
+              ),
+            },
+          ),
         ),
-      ),
-    );
+      );
+    });
   }
 }

--- a/lib/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart
@@ -66,7 +66,7 @@ extension RoomMemberCountReconciliationExtension on Room {
     await client.database.transaction(() async {
       await client.handleSync(
         SyncUpdate(
-          nextBatch: client.prevBatch ?? '',
+          nextBatch: '',
           rooms: RoomsUpdate(
             join: {
               id: JoinedRoomUpdate(

--- a/test/fake_client.dart
+++ b/test/fake_client.dart
@@ -9,6 +9,9 @@ const ssssKey = 'EsT9 RzbW VhPW yqNp cC7j ViiW 5TZB LuY4 ryyv 9guN Ysmr WDPH';
 
 class MockDatabase extends Mock implements DatabaseApi {
   @override
+  Future<void> transaction(Future<void> Function() action) => action();
+
+  @override
   Future<Map<String, dynamic>?> getClient(String name) {
     return Future.value(null);
   }

--- a/test/fake_client.dart
+++ b/test/fake_client.dart
@@ -66,14 +66,14 @@ class MockDatabase extends Mock implements DatabaseApi {
   }
 }
 
-Future<Client> getClient() async {
+Future<Client> getClient({DatabaseApi? database}) async {
   if (!vod.isInitialized()) {
     await vod.init(libraryPath: './vodozemac/debug/');
   }
   final client = Client(
     'testclient',
     httpClient: FakeMatrixApi(),
-    database: MockDatabase(),
+    database: database ?? MockDatabase(),
   );
   await client.checkHomeserver(
     Uri.parse('https://fakeServer.notExisting'),

--- a/test/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension_test.dart
+++ b/test/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension_test.dart
@@ -1,0 +1,200 @@
+import 'package:fluffychat/utils/matrix_sdk_extensions/room_member_count_reconciliation_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import '../../fake_client.dart';
+
+/// Records the summaries persisted through [storeRoomUpdate].
+class RecordingDatabase extends MockDatabase {
+  final List<JoinedRoomUpdate> storedJoinedRoomUpdates = [];
+
+  @override
+  Future<void> storeRoomUpdate(
+    String roomId,
+    SyncRoomUpdate roomUpdate,
+    Event? lastEvent,
+    Client client,
+  ) async {
+    if (roomUpdate is JoinedRoomUpdate) {
+      storedJoinedRoomUpdates.add(roomUpdate);
+    }
+  }
+
+  @override
+  Future<List<User>> getUsers(Room room) async => [];
+}
+
+void main() {
+  late RecordingDatabase database;
+  late Client client;
+
+  setUp(() async {
+    database = RecordingDatabase();
+    client = await getClient(database: database);
+  });
+
+  tearDown(() async {
+    await client.dispose(closeDatabase: false);
+  });
+
+  Room makeRoom(
+    String id, {
+    Membership membership = Membership.join,
+    int? joined,
+    int? invited,
+    List<String>? heroes,
+  }) {
+    final room = Room(
+      id: id,
+      membership: membership,
+      client: client,
+      summary: RoomSummary.fromJson({
+        if (joined != null) 'm.joined_member_count': joined,
+        if (invited != null) 'm.invited_member_count': invited,
+        if (heroes != null) 'm.heroes': heroes,
+      }),
+    );
+    client.rooms.add(room);
+    return room;
+  }
+
+  group('healSummaryMemberCounts', () {
+    test('fixes a stale summary in memory and persists it', () async {
+      final room = makeRoom(
+        '!stale:example.com',
+        joined: 1,
+        invited: 0,
+        heroes: ['@bob:example.com'],
+      );
+
+      await room.healSummaryMemberCounts([
+        User('@alice:example.com', membership: 'join', room: room),
+        User('@bob:example.com', membership: 'join', room: room),
+        User('@carol:example.com', membership: 'invite', room: room),
+      ]);
+
+      expect(room.summary.mJoinedMemberCount, 2);
+      expect(room.summary.mInvitedMemberCount, 1);
+      // The merge must not drop the heroes used for DM display names.
+      expect(room.summary.mHeroes, ['@bob:example.com']);
+
+      expect(database.storedJoinedRoomUpdates, hasLength(1));
+      final stored = database.storedJoinedRoomUpdates.single.summary;
+      expect(stored?.mJoinedMemberCount, 2);
+      expect(stored?.mInvitedMemberCount, 1);
+    });
+
+    test('does nothing when the summary already matches', () async {
+      final room = makeRoom('!uptodate:example.com', joined: 2, invited: 1);
+
+      await room.healSummaryMemberCounts([
+        User('@alice:example.com', membership: 'join', room: room),
+        User('@bob:example.com', membership: 'join', room: room),
+        User('@carol:example.com', membership: 'invite', room: room),
+      ]);
+
+      expect(room.summary.mJoinedMemberCount, 2);
+      expect(room.summary.mInvitedMemberCount, 1);
+      expect(database.storedJoinedRoomUpdates, isEmpty);
+    });
+
+    test('ignores memberships other than join and invite', () async {
+      final room = makeRoom('!banned:example.com', joined: 1, invited: 0);
+
+      await room.healSummaryMemberCounts([
+        User('@alice:example.com', membership: 'join', room: room),
+        User('@bad:example.com', membership: 'ban', room: room),
+        User('@gone:example.com', membership: 'leave', room: room),
+        User('@maybe:example.com', membership: 'knock', room: room),
+      ]);
+
+      expect(room.summary.mJoinedMemberCount, 1);
+      expect(room.summary.mInvitedMemberCount, 0);
+      expect(database.storedJoinedRoomUpdates, isEmpty);
+    });
+
+    test('does not touch rooms the user has not joined', () async {
+      final room = makeRoom(
+        '!invitedroom:example.com',
+        membership: Membership.invite,
+        joined: 1,
+        invited: 1,
+      );
+
+      await room.healSummaryMemberCounts([
+        User('@alice:example.com', membership: 'join', room: room),
+        User('@bob:example.com', membership: 'join', room: room),
+      ]);
+
+      // A JoinedRoomUpdate would have flipped the membership to join.
+      expect(room.membership, Membership.invite);
+      expect(room.summary.mJoinedMemberCount, 1);
+      expect(database.storedJoinedRoomUpdates, isEmpty);
+    });
+
+    test(
+      'does not heal from a ground truth without any joined member',
+      () async {
+        final room = makeRoom('!emptychunk:example.com', joined: 1, invited: 0);
+
+        // Pathological /members response (200 with a missing `chunk`):
+        // healing from it would zero out the counts.
+        await room.healSummaryMemberCounts([]);
+        await room.healSummaryMemberCounts([
+          User('@carol:example.com', membership: 'invite', room: room),
+        ]);
+
+        expect(room.summary.mJoinedMemberCount, 1);
+        expect(room.summary.mInvitedMemberCount, 0);
+        expect(database.storedJoinedRoomUpdates, isEmpty);
+      },
+    );
+
+    test('does not touch rooms unknown to the client', () async {
+      final room = Room(
+        id: '!archived:example.com',
+        membership: Membership.join,
+        client: client,
+        summary: RoomSummary.fromJson({'m.joined_member_count': 1}),
+      );
+
+      await room.healSummaryMemberCounts([
+        User('@alice:example.com', membership: 'join', room: room),
+        User('@bob:example.com', membership: 'join', room: room),
+      ]);
+
+      expect(client.getRoomById('!archived:example.com'), isNull);
+      expect(database.storedJoinedRoomUpdates, isEmpty);
+    });
+  });
+
+  group('requestParticipantsWithSummaryReconciliation', () {
+    test('heals the summary from the fetched member list', () async {
+      // FakeMatrixApi serves a single joined member for this room's /members.
+      final room = makeRoom('!726s6s6q:example.com', joined: 5, invited: 2);
+
+      final participants = await room
+          .requestParticipantsWithSummaryReconciliation();
+
+      expect(participants.map((user) => user.id), ['@alice:example.com']);
+      expect(room.summary.mJoinedMemberCount, 1);
+      expect(room.summary.mInvitedMemberCount, 0);
+      expect(database.storedJoinedRoomUpdates, hasLength(1));
+    });
+
+    test(
+      'skips reconciliation when the filter is not a ground truth',
+      () async {
+        final room = makeRoom('!726s6s6q:example.com', joined: 5, invited: 2);
+
+        await room.requestParticipantsWithSummaryReconciliation([
+          Membership.join,
+        ]);
+
+        expect(room.summary.mJoinedMemberCount, 5);
+        expect(room.summary.mInvitedMemberCount, 2);
+        expect(database.storedJoinedRoomUpdates, isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Ticket

Fixes #2968 

## Root cause & Context

We previously added a sentry log #2970 member to follow #2968 and I was wondering if we still had the issue or not and we have.
I made some investigation and indeed the member count comes from the room summary, and it looks like servers only send `m.joined_member_count` `m.invited_member_count` in /sync when they change. If one update is missed (gapped sync, app killed mid-sync), the persisted counts stay wrong forever: nothing ever reconciles them with the member list.
I could experiment this case with few rooms/accounts:
<img width="250" alt="photo_2026-06-12_17-20-16" src="https://github.com/user-attachments/assets/f55ed57e-ac4c-4f8e-8af4-a9d9c85a2000" /> <img width="250" alt="photo_2026-06-12_17-20-24" src="https://github.com/user-attachments/assets/7e4d3ca3-5e59-4d68-99f5-87de70ef4ddd" />

And we can verify it debugging (the room in the last screenshot with 4 members):
As you can see matrix-dart-sdk is giving us 0 and 1 but the total of the members is 4.

<img width="752" height="194" alt="Capture d’écran 2026-06-12 à 15 03 20" src="https://github.com/user-attachments/assets/83f1abaa-5942-4935-92fd-d6bcf72e0afa" />


## Changes

New `requestParticipantsWithSummaryReconciliation` extension on `Room`: after fetching the participants, if the real counts differ from the summary, the corrected values are re-injected through the sync pipeline (memory + database + UI). Called when opening a chat. Each healing is logged with the existing `Wrong-member-count` Sentry tag so we can follow the fix in production.

##  Concerns

I know this is not a perfect fix as the bug is an edge case where some informations were not stored as I said in the "Root cause" but this is a try fixing the UI client side. We should not rely on self-syncing but this is the only path I found to fix it. Maybe a more complete fix should be handled server side or within the matrix-dart-sdk but I am not sure how exatcly for now. Please feel free to help me make sure we can safely introduce this fix by testing or discussing it.

## Test recommendations

Unit tests cover the reconciliation and its guards. Manually: open a group whose displayed count is wrong, then the details page, the count should match the member list, with a `Wrong-member-count: healing summary` line in the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved chat room member count accuracy by automatically reconciling stored summary counts against the actual participant membership when requesting members (with reconciliation limited to join/invite scenarios and avoiding incorrect updates in edge cases).

* **Tests**
  * Added/expanded automated tests to verify reconciliation updates are applied only when needed, persisted exactly once when stale, and skipped when counts are already correct or reconciliation shouldn’t run.
  * Updated test client setup to allow optional database injection and streamlined transaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->