### PR TITLE
fix(web): guard ChatWebScrollbar against multi-attached ScrollController

### DIFF
--- a/lib/pages/chat/chat_web_scrollbar.dart
+++ b/lib/pages/chat/chat_web_scrollbar.dart
@@ -50,16 +50,31 @@ class _ChatWebScrollbarState extends State<ChatWebScrollbar> {
     if (mounted) setState(() {});
   }
 
+  /// The single attached [ScrollPosition], or `null` when the controller has
+  /// zero or more than one attached scroll view.
+  ///
+  /// During web layout rebuilds (e.g. entering message multi-select mode) the
+  /// same [ScrollController] can momentarily be attached to two [Scrollable]s.
+  /// Reading [ScrollController.position] in that state trips the framework
+  /// assertion `_positions.length == 1`, so every access goes through here.
+  ScrollPosition? get _attachedPosition {
+    final controller = widget.controller;
+    if (controller.positions.length != 1) return null;
+    return controller.position;
+  }
+
   bool get _hasScrollableContent {
-    if (!widget.controller.hasClients) return false;
-    final position = widget.controller.position;
-    if (!position.hasContentDimensions) return false;
+    final position = _attachedPosition;
+    if (position == null || !position.hasContentDimensions) return false;
     return (position.maxScrollExtent - position.minScrollExtent) > 0;
   }
 
   /// Computes thumb [top] offset and [height] within a track of [trackHeight].
+  ///
+  /// Returns a zero-height thumb when no single scroll position is attached.
   ({double top, double height}) _thumbMetrics(double trackHeight) {
-    final position = widget.controller.position;
+    final position = _attachedPosition;
+    if (position == null) return (top: 0.0, height: 0.0);
     final totalExtent = position.maxScrollExtent - position.minScrollExtent;
 
     // Thumb height proportional to viewport vs total content
@@ -82,8 +97,8 @@ class _ChatWebScrollbarState extends State<ChatWebScrollbar> {
   }
 
   void _onThumbDragUpdate(DragUpdateDetails details, double trackHeight) {
-    if (!widget.controller.hasClients) return;
-    final position = widget.controller.position;
+    final position = _attachedPosition;
+    if (position == null) return;
     final totalExtent = position.maxScrollExtent - position.minScrollExtent;
     if (totalExtent <= 0) return;
 
@@ -100,8 +115,8 @@ class _ChatWebScrollbarState extends State<ChatWebScrollbar> {
   }
 
   void _onTrackTap(TapUpDetails details, double trackHeight) {
-    if (!widget.controller.hasClients) return;
-    final position = widget.controller.position;
+    final position = _attachedPosition;
+    if (position == null) return;
     final totalExtent = position.maxScrollExtent - position.minScrollExtent;
     if (totalExtent <= 0) return;
 
@@ -156,8 +171,8 @@ class _ChatWebScrollbarState extends State<ChatWebScrollbar> {
             // Forward wheel/trackpad scroll events so they reach the
             // underlying scrollable even when the pointer is over the gutter.
             onPointerSignal: (event) {
-              if (event is PointerScrollEvent && widget.controller.hasClients) {
-                final position = widget.controller.position;
+              final position = _attachedPosition;
+              if (event is PointerScrollEvent && position != null) {
                 final newPixels = (position.pixels + event.scrollDelta.dy)
                     .clamp(position.minScrollExtent, position.maxScrollExtent);
                 widget.controller.jumpTo(newPixels);

--- a/test/pages/chat/chat_web_scrollbar_test.dart
+++ b/test/pages/chat/chat_web_scrollbar_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pages/chat/chat_web_scrollbar.dart';
+
+Widget _wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+// The scrollbar thumb is the only `MouseRegion` using the grab cursor, so its
+// presence/absence is a precise signal for "is the scrollbar track shown".
+final Finder _thumbFinder = find.byWidgetPredicate(
+  (w) => w is MouseRegion && w.cursor == SystemMouseCursors.grab,
+);
+
+ListView _tallList(ScrollController controller, String prefix) => ListView(
+  controller: controller,
+  children: List.generate(
+    50,
+    (i) => SizedBox(height: 40, child: Text('$prefix$i')),
+  ),
+);
+
+void main() {
+  testWidgets(
+    'renders child and shows no thumb when no scroll view is attached',
+    _noScrollViewAttached,
+  );
+
+  testWidgets(
+    'does not trip the `_positions.length == 1` assertion when the controller '
+    'is attached to multiple scroll views',
+    _multipleScrollViewsAttached,
+  );
+
+  testWidgets(
+    'shows the thumb when exactly one scrollable view is attached',
+    _singleScrollViewAttached,
+  );
+}
+
+Future<void> _noScrollViewAttached(WidgetTester tester) async {
+  final controller = ScrollController();
+  addTearDown(controller.dispose);
+
+  await tester.pumpWidget(
+    _wrap(
+      ChatWebScrollbar(
+        controller: controller,
+        child: const SizedBox(width: 100, height: 100),
+      ),
+    ),
+  );
+
+  expect(tester.takeException(), isNull);
+  expect(_thumbFinder, findsNothing);
+}
+
+Future<void> _multipleScrollViewsAttached(WidgetTester tester) async {
+  final controller = ScrollController();
+  addTearDown(controller.dispose);
+
+  // Two scrollables sharing one controller -> `controller.positions.length` is
+  // 2, which is the transient state that occurs on web while entering message
+  // multi-select mode.
+  await tester.pumpWidget(
+    _wrap(
+      Column(
+        children: [
+          Expanded(
+            child: ChatWebScrollbar(
+              controller: controller,
+              child: _tallList(controller, 'a'),
+            ),
+          ),
+          Expanded(child: _tallList(controller, 'b')),
+        ],
+      ),
+    ),
+  );
+
+  expect(tester.takeException(), isNull);
+  // With more than one attached position the scrollbar treats it as "no single
+  // scroll position" and renders no thumb instead of crashing.
+  expect(_thumbFinder, findsNothing);
+}
+
+Future<void> _singleScrollViewAttached(WidgetTester tester) async {
+  final controller = ScrollController();
+  addTearDown(controller.dispose);
+
+  await tester.pumpWidget(
+    _wrap(
+      SizedBox(
+        height: 200,
+        child: ChatWebScrollbar(
+          controller: controller,
+          child: _tallList(controller, 'c'),
+        ),
+      ),
+    ),
+  );
+  // Let the initial ScrollMetricsNotification rebuild the thumb.
+  await tester.pumpAndSettle();
+
+  expect(tester.takeException(), isNull);
+  expect(_thumbFinder, findsOneWidget);
+}


### PR DESCRIPTION
## Problem
Entering message multi-select mode rebuilds the web chat layout, briefly attaching the same `ScrollController` to two `Scrollable`s. Reading `ScrollController.position` then trips the framework assertion `_positions.length == 1`.

## Fix
All position access goes through a single `_attachedPosition` getter that returns `null` unless exactly one scroll view is attached. `null` is treated as "no scrollable content" (zero-height thumb, no-op scroll).

## Context
Surfaced by the web Patrol migration (#3128), which only swallowed the assertion in tests. This fixes the root cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scrollbar stability by making its thumb and metrics only activate when a single scrollable area is reliably attached.
  * Prevented potential framework assertion crashes during transient multi-scroll attachment scenarios.
  * Updated thumb dragging, track tapping, and wheel/trackpad scrolling to ignore input when scrolling isn’t available.
  * Refined scrollbar content detection to avoid incorrect thumb sizing or display.

* **Tests**
  * Added widget tests covering thumb visibility when no scrollable is attached, multi-attachment safety, and correct thumb rendering for a single attached scrollable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->