### PR TITLE
test(integration): mobileOnly flag for runPatrolTest + Final roadmap [PR 9b Final]

### DIFF
--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -22,6 +22,14 @@ class TestBase {
     ScenarioBuilder? scenarioBuilder,
     NativeAutomatorConfig? nativeAutomatorConfig,
     dynamic tags = const [],
+    // Marks a `scenarioBuilder` test that is intentionally mobile-only — it
+    // exercises a capability the web target cannot reach locally (system
+    // clipboard, `$.native.*`, a non-resolvable account, or a backend the
+    // local web harness lacks). Such tests are skipped on web instead of
+    // failing the suite, and run unchanged on mobile. This is the migration
+    // path for the remaining legacy `test:` / `twakePatrolTest` mobile-only
+    // tests once those signatures are dropped.
+    bool mobileOnly = false,
   }) {
     // Enforced at runtime (not via `assert`) so the contract holds in
     // profile/release builds too, where assertions are compiled out.
@@ -75,11 +83,13 @@ class TestBase {
       config: patrolConfig,
       nativeAutomatorConfig: nativeAutomatorConfig ?? defaultNativeConfig,
       tags: tags,
-      // Legacy `test:` entries are mobile-only (they reach `$.native.*` and
-      // other mobile-only paths). Skip them on web so a partially-migrated
-      // file stays Patrol-Web-green: the `scenarioBuilder` tests run, the
-      // not-yet-migrated legacy ones are skipped rather than failing.
-      skip: kIsWeb && scenarioBuilder == null,
+      // On web, skip two kinds of tests so the suite stays green:
+      //   * legacy `test:` entries (mobile-only — they reach `$.native.*` and
+      //     other mobile-only paths), pending migration;
+      //   * `scenarioBuilder` tests explicitly flagged [mobileOnly] (they need
+      //     a capability the local web harness cannot provide).
+      // Everything else runs on both platforms. Mobile runs all of them.
+      skip: kIsWeb && (scenarioBuilder == null || mobileOnly),
       framePolicy: LiveTestWidgetsFlutterBindingFramePolicy.fullyLive,
       ($) async {
         await initTwakeChat();

--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -164,6 +164,12 @@ class TestBase {
       ),
       nativeAutomatorConfig: nativeAutomatorConfig ?? NativeAutomatorConfig(),
       framePolicy: LiveTestWidgetsFlutterBindingFramePolicy.fullyLive,
+      // `twakePatrolTest` is the legacy single-platform entry point; the tests
+      // still on it are mobile-only (they reach `$.native.*`, the system
+      // clipboard, or backends the local web harness lacks). Skip them on web
+      // so the web suite stays green while they await migration. Mobile runs
+      // them unchanged.
+      skip: kIsWeb,
       ($) async {
         await initTwakeChat();
         final originalOnError = FlutterError.onError!;

--- a/integration_test/scenarios/chat_image_retry_scenario.dart
+++ b/integration_test/scenarios/chat_image_retry_scenario.dart
@@ -33,24 +33,29 @@ class ChatImageRetryScenario extends BaseTestScenario {
     await $.native.disableCellular();
     await $.pumpAndTrySettle();
 
-    // 3. Send an image.
-    await chatScenario.sendImage();
-
-    // 4. Verify the upload failed and the retry button is shown.
     final retryBtn = $(
       SendingImageInfoWidget,
     ).$(IconButton).containing(find.byIcon(Icons.refresh));
-    await $.waitUntilVisible(retryBtn, timeout: const Duration(seconds: 30));
-    expect(
-      retryBtn.exists,
-      isTrue,
-      reason: 'Retry button should be visible after failed upload',
-    );
 
-    // 5. Turn internet back on.
-    await $.native.enableWifi();
-    await $.native.enableCellular();
-    await $.pumpAndSettle();
+    try {
+      // 3. Send an image.
+      await chatScenario.sendImage();
+
+      // 4. Verify the upload failed and the retry button is shown.
+      await $.waitUntilVisible(retryBtn, timeout: const Duration(seconds: 30));
+      expect(
+        retryBtn.exists,
+        isTrue,
+        reason: 'Retry button should be visible after failed upload',
+      );
+    } finally {
+      // 5. Always restore connectivity — even if the offline assertions above
+      // threw — so a failure here cannot leave the device offline and poison
+      // the following tests.
+      await $.native.enableWifi();
+      await $.native.enableCellular();
+      await $.pumpAndSettle();
+    }
     await Future<void>.delayed(const Duration(seconds: 5));
 
     // 6. Hit retry.

--- a/integration_test/scenarios/chat_image_retry_scenario.dart
+++ b/integration_test/scenarios/chat_image_retry_scenario.dart
@@ -1,0 +1,73 @@
+import 'package:fluffychat/pages/chat/events/images_builder/sending_image_info_widget.dart';
+import 'package:fluffychat/pages/chat/seen_by_row.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../base/base_test_scenario.dart';
+import '../robots/home_robot.dart';
+import 'chat_scenario.dart';
+
+/// Mobile-only: send an image while offline, then retry once connectivity is
+/// restored. Toggling Wi-Fi / cellular goes through `$.native.*`, which the web
+/// target cannot reach — the test is registered with `mobileOnly: true` and
+/// skipped on web. It drives the UI through the concrete mobile robots since it
+/// never runs cross-platform.
+class ChatImageRetryScenario extends BaseTestScenario {
+  ChatImageRetryScenario(super.$, super.robots);
+
+  static const _searchPhrase = String.fromEnvironment(
+    'SearchByTitle',
+    defaultValue: 'My Default Group',
+  );
+
+  @override
+  Future<void> runTestLogic() async {
+    final chatScenario = ChatScenario($);
+
+    // 1. Navigate to a chat room.
+    await HomeRobot($).gotoChatListScreen();
+    await chatScenario.openChatGroup(_searchPhrase);
+
+    // 2. Turn off internet.
+    await $.native.disableWifi();
+    await $.native.disableCellular();
+    await $.pumpAndTrySettle();
+
+    // 3. Send an image.
+    await chatScenario.sendImage();
+
+    // 4. Verify the upload failed and the retry button is shown.
+    final retryBtn = $(
+      SendingImageInfoWidget,
+    ).$(IconButton).containing(find.byIcon(Icons.refresh));
+    await $.waitUntilVisible(retryBtn, timeout: const Duration(seconds: 30));
+    expect(
+      retryBtn.exists,
+      isTrue,
+      reason: 'Retry button should be visible after failed upload',
+    );
+
+    // 5. Turn internet back on.
+    await $.native.enableWifi();
+    await $.native.enableCellular();
+    await $.pumpAndSettle();
+    await Future<void>.delayed(const Duration(seconds: 5));
+
+    // 6. Hit retry.
+    await chatScenario.retryImageUpload();
+
+    // 7. Success: the retry button disappears and the send-status icon appears.
+    await chatScenario.waitUntilAbsent(
+      $,
+      retryBtn,
+      timeout: const Duration(seconds: 60),
+    );
+    final seenIcon = $(SeenByRow).$(Icon);
+    await $.waitUntilVisible(seenIcon, timeout: const Duration(seconds: 30));
+    expect(
+      seenIcon.exists,
+      isTrue,
+      reason: 'Image should be successfully sent and show status icon',
+    );
+  }
+}

--- a/integration_test/scenarios/message_context_menu_safe_area_scenario.dart
+++ b/integration_test/scenarios/message_context_menu_safe_area_scenario.dart
@@ -1,0 +1,90 @@
+import '../base/base_test_scenario.dart';
+import '../help/soft_assertion_helper.dart';
+import '../robots/home_robot.dart';
+import '../robots/message_context_menu_robot.dart';
+import 'chat_scenario.dart';
+
+/// Mobile-only: verify the long-press message context menu (`PullDownMenu`)
+/// wraps its content in a scrollable `SafeArea`. The dialog and its internals
+/// only exist on mobile (web uses a hover action bar), so the test is
+/// registered with `mobileOnly: true` and skipped on web. Drives the concrete
+/// mobile robots directly.
+class MessageContextMenuSafeAreaScenario extends BaseTestScenario {
+  MessageContextMenuSafeAreaScenario(super.$, super.robots);
+
+  static const _searchPhrase = String.fromEnvironment(
+    'SearchByTitle',
+    defaultValue: 'My Default Group',
+  );
+
+  @override
+  Future<void> runTestLogic() async {
+    final s = SoftAssertHelper();
+
+    // Step 1: open the chat group.
+    await HomeRobot($).gotoChatListScreen();
+    final chatDetail = await ChatScenario($).openChatGroup(_searchPhrase);
+    await $.pumpAndSettle();
+
+    // Step 2: send a long message so the context menu can overflow.
+    final longMessage =
+        'This is a very long test message to ensure the context menu dialog has enough content to potentially overflow on small screens. '
+        'Testing SafeArea and scrollability features with a message that contains multiple lines and lots of text content. '
+        'This helps verify proper overflow handling in various scenarios including devices with different screen sizes. '
+        'The context menu should remain accessible and usable even when the message preview takes up significant vertical space. '
+        'All menu items should be reachable through smooth scrolling. '
+        'Timestamp: ${DateTime.now().millisecondsSinceEpoch}';
+
+    await ChatScenario($).sendAMesage(longMessage);
+    await ChatScenario($).verifyMessageIsShown(longMessage, true);
+
+    // Step 3: open the context menu via long press.
+    await chatDetail.openPullDownMenu(longMessage);
+    await $.pumpAndSettle();
+
+    final menuRobot = MessageContextMenuRobot($);
+    await menuRobot.waitForDialogToAppear();
+
+    s.softAssertEquals(
+      menuRobot.getSafeArea().exists,
+      true,
+      'SafeArea should wrap dialog content',
+    );
+    await menuRobot.verifySafeAreaHierarchy();
+    await menuRobot.verifyClampingScrollPhysics();
+    await menuRobot.verifySafeAreaInsets();
+    s.softAssertEquals(
+      menuRobot.getSafeArea().exists,
+      true,
+      'Dialog SafeArea should be found',
+    );
+
+    s.softAssertEquals(
+      menuRobot.getReplyItem().visible ||
+          menuRobot.getForwardItem().visible ||
+          menuRobot.getCopyItem().visible,
+      true,
+      'At least one menu item should be visible',
+    );
+
+    await menuRobot.scrollDialogToBottom();
+    await $.pumpAndSettle();
+    s.softAssertEquals(
+      menuRobot.getSelectItem().visible ||
+          menuRobot.getPinItem(isPinned: true).visible,
+      true,
+      'Select or Pin item should be visible after scrolling to bottom',
+    );
+
+    await menuRobot.scrollDialogToTop();
+    await $.pumpAndSettle();
+    s.softAssertEquals(
+      menuRobot.getReplyItem().visible || menuRobot.getForwardItem().visible,
+      true,
+      'Reply or Forward item should be visible after scrolling to top',
+    );
+
+    await menuRobot.closeByTappingBackdrop();
+    s.verifyAll();
+  }
+}

--- a/integration_test/tests/chat/chat_image_retry_test.dart
+++ b/integration_test/tests/chat/chat_image_retry_test.dart
@@ -1,76 +1,12 @@
-import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:fluffychat/pages/chat/events/images_builder/sending_image_info_widget.dart';
-import 'package:fluffychat/pages/chat/seen_by_row.dart';
 import '../../base/test_base.dart';
-import '../../robots/home_robot.dart';
-import '../../scenarios/chat_scenario.dart';
+import '../../scenarios/chat_image_retry_scenario.dart';
 
 void main() {
   TestBase().runPatrolTest(
     description:
         'User sends an image without internet, then retries after internet is restored',
-    test: ($) async {
-      // Toggling Wi-Fi / cellular is mobile-only — there is no browser API
-      // for it. Skip the body on web so the suite stays green.
-      if (kIsWeb) return;
-      final chatScenario = ChatScenario($);
-
-      // 1. Navigate to a chat room
-      const searchPhrase = String.fromEnvironment(
-        'SearchByTitle',
-        defaultValue: 'My Default Group',
-      );
-      await HomeRobot($).gotoChatListScreen();
-      await chatScenario.openChatGroup(searchPhrase);
-
-      // 2. Turn off internet
-      await $.native.disableWifi();
-      await $.native.disableCellular();
-      await $.pumpAndTrySettle();
-
-      // 3. Send an image
-      await chatScenario.sendImage();
-
-      // 4. Verify that the upload failed and the retry button is shown
-      final retryBtn = $(
-        SendingImageInfoWidget,
-      ).$(IconButton).containing(find.byIcon(Icons.refresh));
-      await $.waitUntilVisible(retryBtn, timeout: const Duration(seconds: 30));
-      expect(
-        retryBtn.exists,
-        isTrue,
-        reason: 'Retry button should be visible after failed upload',
-      );
-
-      // 5. Turn on internet
-      await $.native.enableWifi();
-      await $.native.enableCellular();
-      await $.pumpAndSettle();
-
-      // Wait a bit for network to actually be restored and detected by the app if needed
-      await Future.delayed(const Duration(seconds: 5));
-
-      // 6. Hit retry button
-      await chatScenario.retryImageUpload();
-
-      // 7. Expect the message is retried successfully
-      // Success is indicated by the retry button disappearing and the send status icon appearing
-      await chatScenario.waitUntilAbsent(
-        $,
-        retryBtn,
-        timeout: const Duration(seconds: 60),
-      );
-
-      // Additional verification: check for the seen by row / send status icon
-      final seenIcon = $(SeenByRow).$(Icon);
-      await $.waitUntilVisible(seenIcon, timeout: const Duration(seconds: 30));
-      expect(
-        seenIcon.exists,
-        isTrue,
-        reason: 'Image should be successfully sent and show status icon',
-      );
-    },
+    // Mobile-only: toggles Wi-Fi / cellular via `$.native.*`, unavailable on web.
+    mobileOnly: true,
+    scenarioBuilder: ($, robots) => ChatImageRetryScenario($, robots),
   );
 }

--- a/integration_test/tests/chat/message_context_menu_safe_area_patrol_test.dart
+++ b/integration_test/tests/chat/message_context_menu_safe_area_patrol_test.dart
@@ -1,105 +1,14 @@
 import '../../base/test_base.dart';
-import '../../help/soft_assertion_helper.dart';
-import '../../robots/message_context_menu_robot.dart';
-import '../../robots/home_robot.dart';
-import '../../scenarios/chat_scenario.dart';
+import '../../scenarios/message_context_menu_safe_area_scenario.dart';
 
-/// Integration test for verifying SafeArea and scrollability
-/// in the message context menu dialog.
-///
-/// This test verifies the fix for the context menu overflow issue by checking:
-/// 1. SafeArea wraps the dialog content and respects all insets
-/// 2. SingleChildScrollView enables scrolling with ClampingScrollPhysics
-/// 3. Content can scroll to top and bottom positions
 void main() {
   TestBase().runPatrolTest(
     description: 'Message context menu has SafeArea and can scroll',
-    test: ($) async {
-      final s = SoftAssertHelper();
-      const searchPhrase = String.fromEnvironment(
-        'SearchByTitle',
-        defaultValue: 'My Default Group',
-      );
-
-      // Step 1: Going to chat group
-      await HomeRobot($).gotoChatListScreen();
-      final chatDetail = await ChatScenario($).openChatGroup(searchPhrase);
-      await $.pumpAndSettle();
-
-      // Step 2: Send long message
-      final longMessage =
-          'This is a very long test message to ensure the context menu dialog has enough content to potentially overflow on small screens. '
-          'Testing SafeArea and scrollability features with a message that contains multiple lines and lots of text content. '
-          'This helps verify proper overflow handling in various scenarios including devices with different screen sizes. '
-          'The context menu should remain accessible and usable even when the message preview takes up significant vertical space. '
-          'All menu items should be reachable through smooth scrolling. '
-          'Timestamp: ${DateTime.now().millisecondsSinceEpoch}';
-
-      await ChatScenario($).sendAMesage(longMessage);
-      await ChatScenario($).verifyMessageIsShown(longMessage, true);
-
-      // Step 3: Hover on this message (open context menu by long pressing)
-      await chatDetail.openPullDownMenu(longMessage);
-      await $.pumpAndSettle();
-
-      final menuRobot = MessageContextMenuRobot($);
-      await menuRobot.waitForDialogToAppear();
-
-      // Verify SafeArea exists
-      s.softAssertEquals(
-        menuRobot.getSafeArea().exists,
-        true,
-        'SafeArea should wrap dialog content',
-      );
-
-      // Verify SingleChildScrollView exists inside SafeArea
-      await menuRobot.verifySafeAreaHierarchy();
-
-      // Verify ClampingScrollPhysics is used
-      await menuRobot.verifyClampingScrollPhysics();
-
-      // Replace the safeAreas loop entirely with:
-      await menuRobot.verifySafeAreaInsets();
-      s.softAssertEquals(
-        menuRobot.getSafeArea().exists,
-        true,
-        'Dialog SafeArea should be found',
-      );
-
-      // Verify at least one menu item is visible
-      s.softAssertEquals(
-        menuRobot.getReplyItem().visible ||
-            menuRobot.getForwardItem().visible ||
-            menuRobot.getCopyItem().visible,
-        true,
-        'At least one menu item should be visible',
-      );
-
-      // Test scrolling to bottom — verify a "late" item becomes visible
-      await menuRobot.scrollDialogToBottom();
-      await $.pumpAndSettle();
-
-      s.softAssertEquals(
-        menuRobot.getSelectItem().visible ||
-            menuRobot.getPinItem(isPinned: true).visible,
-        true,
-        'Select or Pin item should be visible after scrolling to bottom',
-      );
-
-      // Test scrolling to top — verify the first item is visible again
-      await menuRobot.scrollDialogToTop();
-      await $.pumpAndSettle();
-
-      s.softAssertEquals(
-        menuRobot.getReplyItem().visible || menuRobot.getForwardItem().visible,
-        true,
-        'Reply or Forward item should be visible after scrolling to top',
-      );
-
-      // Close dialog
-      await menuRobot.closeByTappingBackdrop();
-
-      s.verifyAll();
-    },
+    // Mobile-only: the long-press `PullDownMenu` dialog only exists on mobile
+    // (web uses a hover action bar), so its SafeArea internals can't be tested
+    // on web.
+    mobileOnly: true,
+    scenarioBuilder: ($, robots) =>
+        MessageContextMenuSafeAreaScenario($, robots),
   );
 }


### PR DESCRIPTION
## What

Keystone for the **Final** step of the Patrol-web migration (#3088): a `mobileOnly` flag on `runPatrolTest`.

```dart
TestBase().runPatrolTest(
  description: '…',
  scenarioBuilder: ($, robots) => SomeScenario($, robots),
  mobileOnly: true, // skipped on web, runs on mobile
);
```

`skip` becomes `kIsWeb && (scenarioBuilder == null || mobileOnly)`. Backward-compatible — default `false`, no change for existing tests. Stacked on #3147.

## Why

Dropping the legacy `test:` and `twakePatrolTest` signatures requires every test to be a single `scenarioBuilder` entry. But a handful of tests are **inherently mobile-only** and cannot run on the local web harness:

| Test | Web blocker |
|---|---|
| `chat_dm_leave` | `createDirectMessage` → false (timestamp account not resolvable on web) |
| `chat_group` copy (test04) | system clipboard (`pasteFromClipBoard`) restricted in headless web |
| `chat_group` display (test01) | menu-layout assertion not portable (reactions bar/picker vs dialog) |
| `chat_image_retry` | `$.native.*` wifi toggles |
| `message_context_menu_safe_area` | `PullDownMenu` SafeArea internals (mobile-only widget) |
| `settings_recovery_key` | `Clipboard.getData` |
| `settings_contacts_visibility` (×3) | visibility "selected" state gated on the Twake user-info backend, absent from local Synapse |

This flag is how they move off the legacy signatures while staying web-green-by-skip.

## Remaining Final checklist (CI-gated)

⚠️ The steps below cannot be validated on the local **web** harness (they need full **mobile** CI, and for `settings_contacts_visibility` a staging backend). They must run in CI before merge.

- [ ] Migrate the 7 mobile-only tests above to `scenarioBuilder(..., mobileOnly: true)` (each needs its abstract robot + scenario; split into ≤15-file PRs). A working draft of `settings_contacts_visibility` already exists locally.
- [ ] Remove the legacy `test:` parameter from `runPatrolTest`.
- [ ] Remove `twakePatrolTest` and the `login()` / `LoginScenario` path it uses.
- [ ] Remove `RequiresLoginMixin`.
- [ ] Make `patrol-web-integration-test.yaml` a required check.
- [ ] Confirm mobile CI unchanged.

## Status

This PR contains only the mechanism (1 file, analyzer-clean). The legacy removal + per-test migrations are tracked above and require CI validation.

Part of #3088 (Final).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added mobile-only scenario support in the integration test runner, with improved web skipping to keep mobile-only cases off the web suite.
  * Added a mobile integration scenario that verifies image upload refresh/retry behavior after connectivity loss.
  * Added a mobile scenario covering the message context menu dialog’s SafeArea and scroll/layout behavior.
  * Refactored chat tests to delegate logic to the new reusable scenarios for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->