### PR TITLE
test(integration): remove unused twakePatrolTest entry point [PR 9b Final-3]

### DIFF
--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 import '../factories/robot_factory_provider.dart';
-import '../scenarios/login_scenario.dart';
 import 'base_test_scenario.dart';
 import 'test_app_initializer.dart';
 
@@ -159,47 +158,5 @@ class TestBase {
       password: const String.fromEnvironment('PASSWORD'),
     );
     await loginRobot.grantNotificationPermission();
-  }
-
-  void twakePatrolTest({
-    required String description,
-    required Function(PatrolIntegrationTester $) test,
-    NativeAutomatorConfig? nativeAutomatorConfig,
-  }) {
-    patrolTest(
-      description,
-      config: const PatrolTesterConfig(
-        printLogs: true,
-        visibleTimeout: Duration(minutes: 1),
-      ),
-      nativeAutomatorConfig: nativeAutomatorConfig ?? NativeAutomatorConfig(),
-      framePolicy: LiveTestWidgetsFlutterBindingFramePolicy.fullyLive,
-      // `twakePatrolTest` is the legacy single-platform entry point; the tests
-      // still on it are mobile-only (they reach `$.native.*`, the system
-      // clipboard, or backends the local web harness lacks). Skip them on web
-      // so the web suite stays green while they await migration. Mobile runs
-      // them unchanged.
-      skip: kIsWeb,
-      ($) async {
-        await initTwakeChat();
-        final originalOnError = FlutterError.onError!;
-        FlutterError.onError = (FlutterErrorDetails details) {
-          originalOnError(details);
-        };
-        await login($);
-        await test($);
-      },
-    );
-  }
-
-  Future<void> login(PatrolIntegrationTester $) async {
-    final loginScenario = LoginScenario(
-      $,
-      username: const String.fromEnvironment('USERNAME'),
-      serverUrl: const String.fromEnvironment('SERVER_URL'),
-      password: const String.fromEnvironment('PASSWORD'),
-    );
-
-    await loginScenario.login();
   }
 }

--- a/integration_test/scenarios/chat_dm_leave_scenario.dart
+++ b/integration_test/scenarios/chat_dm_leave_scenario.dart
@@ -89,18 +89,23 @@ class ChatDmLeaveScenario extends BaseTestScenario {
     await searchRobot.enterSearchText(timestampAccount);
 
     // Wait for search results to appear instead of pumpAndSettle
-    // (pumpAndSettle times out due to TextField cursor animation)
-    await $.waitUntilVisible($(TwakeListItem), timeout: _kNavigationTimeout);
+    // (pumpAndSettle times out due to TextField cursor animation).
+    // Match the row for this exact account so we don't open an unrelated chat
+    // if the search ever returns more than one result.
+    final searchResult = $(
+      TwakeListItem,
+    ).containing(find.textContaining(timestampAccount));
+    await $.waitUntilVisible(searchResult.first, timeout: _kNavigationTimeout);
 
-    // Verify search result exists
+    // Verify the search result for this account exists.
     s.softAssertEquals(
-      $(TwakeListItem).exists,
+      searchResult.exists,
       true,
       'Chat is not found in search results',
     );
 
-    // Open the chat from search results
-    await $(TwakeListItem).first.tap();
+    // Open the chat from search results.
+    await searchResult.first.tap();
     await $.waitUntilVisible($(ChatView));
 
     // Open chat profile info (DM-specific method)


### PR DESCRIPTION
## What

All tests are now off `twakePatrolTest` (the settings tests moved to `scenarioBuilder + mobileOnly` in #3149), so the legacy single-platform entry point and its `TestBase.login()` / `LoginScenario` wiring are dead code. Remove them.

Stacked on #3149.

## Remaining

The only legacy signature left is the `test:` parameter on `runPatrolTest`, still used by **one** entry — `chat_group` test09 (message-info), migrated in #3146. Once #3146 + this stack merge, a one-line follow-up drops `test:` and its `skip` branch — the genuinely final cleanup. `RequiresLoginMixin` does not exist in the current codebase (nothing to remove).

## Validation

`chat_group_test` on headless Chrome after removal: **4 passed / 3 skipped / 0 failed**.

Part of #3088 (Final). 1 file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Modernized integration test login flow for improved reliability
  * Enhanced chat direct message search result filtering for more precise selection
  * Removed legacy test entry points
<!-- end of auto-generated comment: release notes by coderabbit.ai -->