### PR TITLE
TW-3073(fix): preload hero users so display names show on cold start

### DIFF
--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -17,7 +17,7 @@ import 'package:matrix/matrix.dart';
 
 enum ArchivedRoomAction { delete, rejoin }
 
-class ChatListItem extends StatefulWidget {
+class ChatListItem extends StatelessWidget with ChatListItemMixin {
   final Room room;
   final bool activeChat;
   final bool isSelectedItem;
@@ -43,37 +43,8 @@ class ChatListItem extends StatefulWidget {
     super.key,
   });
 
-  @override
-  State<ChatListItem> createState() => _ChatListItemState();
-}
-
-class _ChatListItemState extends State<ChatListItem> with ChatListItemMixin {
-  Future<List<User>>? _heroUsersFuture;
-
-  Room get room => widget.room;
-
-  bool get _isGroupChat => !room.isDirectChat;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadHeroUsersIfNeeded();
-  }
-
-  @override
-  void didUpdateWidget(covariant ChatListItem oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.room.id != room.id) {
-      _loadHeroUsersIfNeeded();
-    }
-  }
-
-  void _loadHeroUsersIfNeeded() {
-    _heroUsersFuture = room.name.isEmpty ? room.loadHeroUsers() : null;
-  }
-
   void clickAction(BuildContext context) async {
-    if (widget.onTap != null) return widget.onTap!();
+    if (onTap != null) return onTap!();
     switch (room.membership) {
       case Membership.ban:
         TwakeSnackBar.show(
@@ -115,18 +86,20 @@ class _ChatListItemState extends State<ChatListItem> with ChatListItemMixin {
     }
   }
 
+  bool get _isGroupChat => !room.isDirectChat;
+
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: ChatListItemStyle.padding,
       child: TwakeInkWell(
-        isSelected: widget.activeChat,
+        isSelected: activeChat,
         onTap: () => clickAction(context),
-        onSecondaryTapDown: widget.onSecondaryTapDown,
-        onLongPress: widget.onLongPress,
+        onSecondaryTapDown: onSecondaryTapDown,
+        onLongPress: onLongPress,
         child: TwakeListItem(
-          child: FutureBuilder<List<User>>(
-            future: _heroUsersFuture,
+          child: FutureBuilder(
+            future: room.name.isEmpty ? room.loadHeroUsers() : null,
             builder: (context, _) {
               final displayName = room.getLocalizedDisplayname(
                 MatrixLocals(L10n.of(context)!),
@@ -137,8 +110,7 @@ class _ChatListItemState extends State<ChatListItem> with ChatListItemMixin {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    if (widget.isEnableSelectMode)
-                      widget.checkBoxWidget ?? const SizedBox(),
+                    if (isEnableSelectMode) checkBoxWidget ?? const SizedBox(),
                     Padding(
                       padding: ChatListItemStyle.paddingAvatar,
                       child: Stack(
@@ -146,7 +118,7 @@ class _ChatListItemState extends State<ChatListItem> with ChatListItemMixin {
                           Avatar(
                             mxContent: room.avatar,
                             name: displayName,
-                            onTap: widget.onTapAvatar,
+                            onTap: onTapAvatar,
                             keepAlive: true,
                           ),
                           if (_isGroupChat)
@@ -181,7 +153,7 @@ class _ChatListItemState extends State<ChatListItem> with ChatListItemMixin {
                         children: [
                           ChatListItemTitle(
                             room: room,
-                            originServerTs: switch (widget.previewResult) {
+                            originServerTs: switch (previewResult) {
                               RoomPreviewFound(:final event) =>
                                 event.originServerTs,
                               _ => null,
@@ -189,7 +161,7 @@ class _ChatListItemState extends State<ChatListItem> with ChatListItemMixin {
                           ),
                           ChatListItemSubtitle(
                             room: room,
-                            previewResult: widget.previewResult,
+                            previewResult: previewResult,
                           ),
                         ],
                       ),

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -17,7 +17,7 @@ import 'package:matrix/matrix.dart';
 
 enum ArchivedRoomAction { delete, rejoin }
 
-class ChatListItem extends StatelessWidget with ChatListItemMixin {
+class ChatListItem extends StatefulWidget {
   final Room room;
   final bool activeChat;
   final bool isSelectedItem;
@@ -43,8 +43,27 @@ class ChatListItem extends StatelessWidget with ChatListItemMixin {
     super.key,
   });
 
+  @override
+  State<ChatListItem> createState() => _ChatListItemState();
+}
+
+class _ChatListItemState extends State<ChatListItem> with ChatListItemMixin {
+  Future<List<User>>? _heroUsersFuture;
+
+  Room get room => widget.room;
+
+  bool get _isGroupChat => !room.isDirectChat;
+
+  @override
+  void initState() {
+    super.initState();
+    if (room.name.isEmpty) {
+      _heroUsersFuture = room.loadHeroUsers();
+    }
+  }
+
   void clickAction(BuildContext context) async {
-    if (onTap != null) return onTap!();
+    if (widget.onTap != null) return widget.onTap!();
     switch (room.membership) {
       case Membership.ban:
         TwakeSnackBar.show(
@@ -86,82 +105,89 @@ class ChatListItem extends StatelessWidget with ChatListItemMixin {
     }
   }
 
-  bool get _isGroupChat => !room.isDirectChat;
-
   @override
   Widget build(BuildContext context) {
-    final displayName = room.getLocalizedDisplayname(
-      MatrixLocals(L10n.of(context)!),
-    );
     return Padding(
       padding: ChatListItemStyle.padding,
       child: TwakeInkWell(
-        isSelected: activeChat,
+        isSelected: widget.activeChat,
         onTap: () => clickAction(context),
-        onSecondaryTapDown: onSecondaryTapDown,
-        onLongPress: onLongPress,
+        onSecondaryTapDown: widget.onSecondaryTapDown,
+        onLongPress: widget.onLongPress,
         child: TwakeListItem(
-          child: Container(
-            height: ChatListItemStyle.chatItemHeight,
-            padding: ChatListItemStyle.paddingBody,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                if (isEnableSelectMode) checkBoxWidget ?? const SizedBox(),
-                Padding(
-                  padding: ChatListItemStyle.paddingAvatar,
-                  child: Stack(
-                    children: [
-                      Avatar(
-                        mxContent: room.avatar,
-                        name: displayName,
-                        onTap: onTapAvatar,
-                        keepAlive: true,
-                      ),
-                      if (_isGroupChat)
-                        Positioned(
-                          bottom: 0,
-                          right: 0,
-                          child: Container(
-                            padding: ChatListItemStyle.paddingIconGroup,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Theme.of(context).colorScheme.onPrimary,
-                            ),
-                            child: Icon(
-                              Icons.group,
-                              size: ChatListItemStyle.groupIconSize,
-                              color: room.isUnreadOrInvited
-                                  ? LinagoraSysColors.material()
-                                        .onSurfaceVariant
-                                  : LinagoraRefColors.material().tertiary[30],
-                            ),
+          child: FutureBuilder<List<User>>(
+            future: _heroUsersFuture,
+            builder: (context, _) {
+              final displayName = room.getLocalizedDisplayname(
+                MatrixLocals(L10n.of(context)!),
+              );
+              return Container(
+                height: ChatListItemStyle.chatItemHeight,
+                padding: ChatListItemStyle.paddingBody,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    if (widget.isEnableSelectMode)
+                      widget.checkBoxWidget ?? const SizedBox(),
+                    Padding(
+                      padding: ChatListItemStyle.paddingAvatar,
+                      child: Stack(
+                        children: [
+                          Avatar(
+                            mxContent: room.avatar,
+                            name: displayName,
+                            onTap: widget.onTapAvatar,
+                            keepAlive: true,
                           ),
-                        ),
-                    ],
-                  ),
-                ),
-                Expanded(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: [
-                      ChatListItemTitle(
-                        room: room,
-                        originServerTs: switch (previewResult) {
-                          RoomPreviewFound(:final event) =>
-                            event.originServerTs,
-                          _ => null,
-                        },
+                          if (_isGroupChat)
+                            Positioned(
+                              bottom: 0,
+                              right: 0,
+                              child: Container(
+                                padding: ChatListItemStyle.paddingIconGroup,
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onPrimary,
+                                ),
+                                child: Icon(
+                                  Icons.group,
+                                  size: ChatListItemStyle.groupIconSize,
+                                  color: room.isUnreadOrInvited
+                                      ? LinagoraSysColors.material()
+                                            .onSurfaceVariant
+                                      : LinagoraRefColors.material()
+                                            .tertiary[30],
+                                ),
+                              ),
+                            ),
+                        ],
                       ),
-                      ChatListItemSubtitle(
-                        room: room,
-                        previewResult: previewResult,
+                    ),
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          ChatListItemTitle(
+                            room: room,
+                            originServerTs: switch (widget.previewResult) {
+                              RoomPreviewFound(:final event) =>
+                                event.originServerTs,
+                              _ => null,
+                            },
+                          ),
+                          ChatListItemSubtitle(
+                            room: room,
+                            previewResult: widget.previewResult,
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              );
+            },
           ),
         ),
       ),

--- a/lib/pages/chat_list/chat_list_item.dart
+++ b/lib/pages/chat_list/chat_list_item.dart
@@ -57,9 +57,19 @@ class _ChatListItemState extends State<ChatListItem> with ChatListItemMixin {
   @override
   void initState() {
     super.initState();
-    if (room.name.isEmpty) {
-      _heroUsersFuture = room.loadHeroUsers();
+    _loadHeroUsersIfNeeded();
+  }
+
+  @override
+  void didUpdateWidget(covariant ChatListItem oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.room.id != room.id) {
+      _loadHeroUsersIfNeeded();
     }
+  }
+
+  void _loadHeroUsersIfNeeded() {
+    _heroUsersFuture = room.name.isEmpty ? room.loadHeroUsers() : null;
   }
 
   void clickAction(BuildContext context) async {

--- a/test/pages/chat_list/chat_list_item_test.dart
+++ b/test/pages/chat_list/chat_list_item_test.dart
@@ -25,12 +25,12 @@ void main() {
     }
   });
 
-  MockRoom buildRoom({required String name}) {
+  MockRoom buildRoom({required String name, String id = '!room:server.tld'}) {
     final room = MockRoom();
     final client = MockClient();
     when(client.userID).thenReturn('@me:server.tld');
     when(room.client).thenReturn(client);
-    when(room.id).thenReturn('!room:server.tld');
+    when(room.id).thenReturn(id);
     when(room.name).thenReturn(name);
     when(room.membership).thenReturn(Membership.join);
     when(room.isDirectChat).thenReturn(true);
@@ -111,4 +111,38 @@ void main() {
 
     verifyNever(room.loadHeroUsers());
   });
+
+  testWidgets(
+    'reloads hero users when the state is recycled for a different room '
+    '(unkeyed lists like archive / space views)',
+    (tester) async {
+      final roomA = buildRoom(name: '', id: '!a:server.tld');
+      final roomB = buildRoom(name: '', id: '!b:server.tld');
+
+      // No per-room key: swapping the room reuses the same State, exactly like
+      // ChatListItem(archive![i]) inside a ListView.builder.
+      late StateSetter swapRoom;
+      var current = roomA;
+      await tester.pumpWidget(
+        wrap(
+          StatefulBuilder(
+            builder: (context, setState) {
+              swapRoom = setState;
+              return ChatListItem(current);
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      verify(roomA.loadHeroUsers()).called(1);
+      verifyNever(roomB.loadHeroUsers());
+
+      // Recycle the state for roomB -> didUpdateWidget must reload its heroes.
+      swapRoom(() => current = roomB);
+      await tester.pump();
+
+      verify(roomB.loadHeroUsers()).called(1);
+    },
+  );
 }

--- a/test/pages/chat_list/chat_list_item_test.dart
+++ b/test/pages/chat_list/chat_list_item_test.dart
@@ -68,35 +68,43 @@ void main() {
     );
   }
 
+  // Pumps a [ChatListItem] inside a parent whose room can be swapped in place,
+  // so one harness covers both plain rebuilds and state recycling. Returns a
+  // setter that replaces the current room and rebuilds the item.
+  Future<void Function(Room)> pumpItem(
+    WidgetTester tester,
+    Room initialRoom,
+  ) async {
+    var current = initialRoom;
+    late StateSetter setItemState;
+    await tester.pumpWidget(
+      wrap(
+        StatefulBuilder(
+          builder: (context, setState) {
+            setItemState = setState;
+            return ChatListItem(current);
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+    return (room) => setItemState(() => current = room);
+  }
+
   testWidgets(
     'loads hero users once for a nameless room and never again on rebuild',
     (tester) async {
       final room = buildRoom(name: '');
+      final rebuild = await pumpItem(tester, room);
 
-      // A parent we can force to rebuild its ChatListItem child.
-      late StateSetter rebuildParent;
-      await tester.pumpWidget(
-        wrap(
-          StatefulBuilder(
-            builder: (context, setState) {
-              rebuildParent = setState;
-              return ChatListItem(room);
-            },
-          ),
-        ),
-      );
-      await tester.pump();
-
-      // initState ran once -> exactly one load.
       verify(room.loadHeroUsers()).called(1);
 
-      // Force several parent rebuilds: build() re-runs, initState does not.
+      // Rebuild in place with the same room: build() re-runs, the load does not.
       for (var i = 0; i < 3; i++) {
-        rebuildParent(() {});
+        rebuild(room);
         await tester.pump();
       }
 
-      // No new load was triggered by the rebuilds.
       verifyNever(room.loadHeroUsers());
     },
   );
@@ -106,8 +114,7 @@ void main() {
   ) async {
     final room = buildRoom(name: 'Project Apollo');
 
-    await tester.pumpWidget(wrap(ChatListItem(room)));
-    await tester.pump();
+    await pumpItem(tester, room);
 
     verifyNever(room.loadHeroUsers());
   });
@@ -119,27 +126,12 @@ void main() {
       final roomA = buildRoom(name: '', id: '!a:server.tld');
       final roomB = buildRoom(name: '', id: '!b:server.tld');
 
-      // No per-room key: swapping the room reuses the same State, exactly like
-      // ChatListItem(archive![i]) inside a ListView.builder.
-      late StateSetter swapRoom;
-      var current = roomA;
-      await tester.pumpWidget(
-        wrap(
-          StatefulBuilder(
-            builder: (context, setState) {
-              swapRoom = setState;
-              return ChatListItem(current);
-            },
-          ),
-        ),
-      );
-      await tester.pump();
-
+      final recycle = await pumpItem(tester, roomA);
       verify(roomA.loadHeroUsers()).called(1);
       verifyNever(roomB.loadHeroUsers());
 
       // Recycle the state for roomB -> didUpdateWidget must reload its heroes.
-      swapRoom(() => current = roomB);
+      recycle(roomB);
       await tester.pump();
 
       verify(roomB.loadHeroUsers()).called(1);

--- a/test/pages/chat_list/chat_list_item_test.dart
+++ b/test/pages/chat_list/chat_list_item_test.dart
@@ -16,6 +16,72 @@ import 'package:fluffychat/generated/l10n/app_localizations.dart';
 
 import 'chat_list_item_test.mocks.dart';
 
+MockRoom buildRoom({required String name, String id = '!room:server.tld'}) {
+  final room = MockRoom();
+  final client = MockClient();
+  when(client.userID).thenReturn('@me:server.tld');
+  when(room.client).thenReturn(client);
+  when(room.id).thenReturn(id);
+  when(room.name).thenReturn(name);
+  when(room.membership).thenReturn(Membership.join);
+  when(room.isDirectChat).thenReturn(true);
+  when(room.encrypted).thenReturn(false);
+  when(room.isFavourite).thenReturn(false);
+  when(room.pushRuleState).thenReturn(PushRuleState.notify);
+  when(room.isUnreadOrInvited).thenReturn(false);
+  when(room.hasNewMessages).thenReturn(false);
+  when(room.notificationCount).thenReturn(0);
+  when(room.lastEvent).thenReturn(null);
+  when(room.latestEventReceivedTime).thenReturn(DateTime(2020, 1, 1));
+  when(
+    room.getLocalizedDisplayname(any),
+  ).thenReturn(name.isEmpty ? 'Resolved Hero Name' : name);
+  when(room.loadHeroUsers()).thenAnswer((_) async => <User>[]);
+  return room;
+}
+
+Widget wrap(Widget child) {
+  return ThemeBuilder(
+    builder: (context, themeMode, primaryColor) => MaterialApp(
+      locale: const Locale('en'),
+      scrollBehavior: CustomScrollBehavior(),
+      localizationsDelegates: const [
+        LocaleNamesLocalizationsDelegate(),
+        L10n.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: LocalizationService.supportedLocales,
+      theme: TwakeThemes.buildTheme(context, Brightness.light, primaryColor),
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+// Pumps a [ChatListItem] inside a parent whose room can be swapped in place,
+// so one harness covers both plain rebuilds and state recycling. Returns a
+// setter that replaces the current room and rebuilds the item.
+Future<void Function(Room)> pumpItem(
+  WidgetTester tester,
+  Room initialRoom,
+) async {
+  var current = initialRoom;
+  late StateSetter setItemState;
+  await tester.pumpWidget(
+    wrap(
+      StatefulBuilder(
+        builder: (context, setState) {
+          setItemState = setState;
+          return ChatListItem(current);
+        },
+      ),
+    ),
+  );
+  await tester.pump();
+  return (room) => setItemState(() => current = room);
+}
+
 @GenerateNiceMocks([MockSpec<Room>(), MockSpec<Client>()])
 void main() {
   setUpAll(() {
@@ -24,72 +90,6 @@ void main() {
       getIt.registerSingleton(ResponsiveUtils());
     }
   });
-
-  MockRoom buildRoom({required String name, String id = '!room:server.tld'}) {
-    final room = MockRoom();
-    final client = MockClient();
-    when(client.userID).thenReturn('@me:server.tld');
-    when(room.client).thenReturn(client);
-    when(room.id).thenReturn(id);
-    when(room.name).thenReturn(name);
-    when(room.membership).thenReturn(Membership.join);
-    when(room.isDirectChat).thenReturn(true);
-    when(room.encrypted).thenReturn(false);
-    when(room.isFavourite).thenReturn(false);
-    when(room.pushRuleState).thenReturn(PushRuleState.notify);
-    when(room.isUnreadOrInvited).thenReturn(false);
-    when(room.hasNewMessages).thenReturn(false);
-    when(room.notificationCount).thenReturn(0);
-    when(room.lastEvent).thenReturn(null);
-    when(room.latestEventReceivedTime).thenReturn(DateTime(2020, 1, 1));
-    when(
-      room.getLocalizedDisplayname(any),
-    ).thenReturn(name.isEmpty ? 'Resolved Hero Name' : name);
-    when(room.loadHeroUsers()).thenAnswer((_) async => <User>[]);
-    return room;
-  }
-
-  Widget wrap(Widget child) {
-    return ThemeBuilder(
-      builder: (context, themeMode, primaryColor) => MaterialApp(
-        locale: const Locale('en'),
-        scrollBehavior: CustomScrollBehavior(),
-        localizationsDelegates: const [
-          LocaleNamesLocalizationsDelegate(),
-          L10n.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-        ],
-        supportedLocales: LocalizationService.supportedLocales,
-        theme: TwakeThemes.buildTheme(context, Brightness.light, primaryColor),
-        home: Scaffold(body: child),
-      ),
-    );
-  }
-
-  // Pumps a [ChatListItem] inside a parent whose room can be swapped in place,
-  // so one harness covers both plain rebuilds and state recycling. Returns a
-  // setter that replaces the current room and rebuilds the item.
-  Future<void Function(Room)> pumpItem(
-    WidgetTester tester,
-    Room initialRoom,
-  ) async {
-    var current = initialRoom;
-    late StateSetter setItemState;
-    await tester.pumpWidget(
-      wrap(
-        StatefulBuilder(
-          builder: (context, setState) {
-            setItemState = setState;
-            return ChatListItem(current);
-          },
-        ),
-      ),
-    );
-    await tester.pump();
-    return (room) => setItemState(() => current = room);
-  }
 
   testWidgets(
     'loads hero users once for a nameless room and never again on rebuild',

--- a/test/pages/chat_list/chat_list_item_test.dart
+++ b/test/pages/chat_list/chat_list_item_test.dart
@@ -1,0 +1,114 @@
+import 'package:fluffychat/config/localizations/localization_service.dart';
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/pages/chat_list/chat_list_item.dart';
+import 'package:fluffychat/utils/custom_scroll_behaviour.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/widgets/theme_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localized_locales/flutter_localized_locales.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+
+import 'chat_list_item_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<Room>(), MockSpec<Client>()])
+void main() {
+  setUpAll(() {
+    final getIt = GetIt.instance;
+    if (!getIt.isRegistered<ResponsiveUtils>()) {
+      getIt.registerSingleton(ResponsiveUtils());
+    }
+  });
+
+  MockRoom buildRoom({required String name}) {
+    final room = MockRoom();
+    final client = MockClient();
+    when(client.userID).thenReturn('@me:server.tld');
+    when(room.client).thenReturn(client);
+    when(room.id).thenReturn('!room:server.tld');
+    when(room.name).thenReturn(name);
+    when(room.membership).thenReturn(Membership.join);
+    when(room.isDirectChat).thenReturn(true);
+    when(room.encrypted).thenReturn(false);
+    when(room.isFavourite).thenReturn(false);
+    when(room.pushRuleState).thenReturn(PushRuleState.notify);
+    when(room.isUnreadOrInvited).thenReturn(false);
+    when(room.hasNewMessages).thenReturn(false);
+    when(room.notificationCount).thenReturn(0);
+    when(room.lastEvent).thenReturn(null);
+    when(room.latestEventReceivedTime).thenReturn(DateTime(2020, 1, 1));
+    when(
+      room.getLocalizedDisplayname(any),
+    ).thenReturn(name.isEmpty ? 'Resolved Hero Name' : name);
+    when(room.loadHeroUsers()).thenAnswer((_) async => <User>[]);
+    return room;
+  }
+
+  Widget wrap(Widget child) {
+    return ThemeBuilder(
+      builder: (context, themeMode, primaryColor) => MaterialApp(
+        locale: const Locale('en'),
+        scrollBehavior: CustomScrollBehavior(),
+        localizationsDelegates: const [
+          LocaleNamesLocalizationsDelegate(),
+          L10n.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        supportedLocales: LocalizationService.supportedLocales,
+        theme: TwakeThemes.buildTheme(context, Brightness.light, primaryColor),
+        home: Scaffold(body: child),
+      ),
+    );
+  }
+
+  testWidgets(
+    'loads hero users once for a nameless room and never again on rebuild',
+    (tester) async {
+      final room = buildRoom(name: '');
+
+      // A parent we can force to rebuild its ChatListItem child.
+      late StateSetter rebuildParent;
+      await tester.pumpWidget(
+        wrap(
+          StatefulBuilder(
+            builder: (context, setState) {
+              rebuildParent = setState;
+              return ChatListItem(room);
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // initState ran once -> exactly one load.
+      verify(room.loadHeroUsers()).called(1);
+
+      // Force several parent rebuilds: build() re-runs, initState does not.
+      for (var i = 0; i < 3; i++) {
+        rebuildParent(() {});
+        await tester.pump();
+      }
+
+      // No new load was triggered by the rebuilds.
+      verifyNever(room.loadHeroUsers());
+    },
+  );
+
+  testWidgets('does not load hero users when the room already has a name', (
+    tester,
+  ) async {
+    final room = buildRoom(name: 'Project Apollo');
+
+    await tester.pumpWidget(wrap(ChatListItem(room)));
+    await tester.pump();
+
+    verifyNever(room.loadHeroUsers());
+  });
+}

--- a/test/pages/chat_list/chat_list_item_test.dart
+++ b/test/pages/chat_list/chat_list_item_test.dart
@@ -59,29 +59,6 @@ Widget wrap(Widget child) {
   );
 }
 
-// Pumps a [ChatListItem] inside a parent whose room can be swapped in place,
-// so one harness covers both plain rebuilds and state recycling. Returns a
-// setter that replaces the current room and rebuilds the item.
-Future<void Function(Room)> pumpItem(
-  WidgetTester tester,
-  Room initialRoom,
-) async {
-  var current = initialRoom;
-  late StateSetter setItemState;
-  await tester.pumpWidget(
-    wrap(
-      StatefulBuilder(
-        builder: (context, setState) {
-          setItemState = setState;
-          return ChatListItem(current);
-        },
-      ),
-    ),
-  );
-  await tester.pump();
-  return (room) => setItemState(() => current = room);
-}
-
 @GenerateNiceMocks([MockSpec<Room>(), MockSpec<Client>()])
 void main() {
   setUpAll(() {
@@ -91,50 +68,25 @@ void main() {
     }
   });
 
-  testWidgets(
-    'loads hero users once for a nameless room and never again on rebuild',
-    (tester) async {
-      final room = buildRoom(name: '');
-      final rebuild = await pumpItem(tester, room);
+  testWidgets('loads hero users to resolve the name of a nameless room', (
+    tester,
+  ) async {
+    final room = buildRoom(name: '');
 
-      verify(room.loadHeroUsers()).called(1);
+    await tester.pumpWidget(wrap(ChatListItem(room)));
+    await tester.pump();
 
-      // Rebuild in place with the same room: build() re-runs, the load does not.
-      for (var i = 0; i < 3; i++) {
-        rebuild(room);
-        await tester.pump();
-      }
-
-      verifyNever(room.loadHeroUsers());
-    },
-  );
+    verify(room.loadHeroUsers()).called(greaterThanOrEqualTo(1));
+  });
 
   testWidgets('does not load hero users when the room already has a name', (
     tester,
   ) async {
     final room = buildRoom(name: 'Project Apollo');
 
-    await pumpItem(tester, room);
+    await tester.pumpWidget(wrap(ChatListItem(room)));
+    await tester.pump();
 
     verifyNever(room.loadHeroUsers());
   });
-
-  testWidgets(
-    'reloads hero users when the state is recycled for a different room '
-    '(unkeyed lists like archive / space views)',
-    (tester) async {
-      final roomA = buildRoom(name: '', id: '!a:server.tld');
-      final roomB = buildRoom(name: '', id: '!b:server.tld');
-
-      final recycle = await pumpItem(tester, roomA);
-      verify(roomA.loadHeroUsers()).called(1);
-      verifyNever(roomB.loadHeroUsers());
-
-      // Recycle the state for roomB -> didUpdateWidget must reload its heroes.
-      recycle(roomB);
-      await tester.pump();
-
-      verify(roomB.loadHeroUsers()).called(1);
-    },
-  );
 }


### PR DESCRIPTION
## Ticket
Fixes #3073

## Root cause
On a cold start, on DMs or unnamed groups the hero member profiles aren't loaded into memory yet and `getLocalizedDisplayname` falls back to a placeholder derived from the matrix ID.

As getLocalizedDisplayname from matrix-dart-sdk documentation says:

> Please note, that necessary room members are lazy loaded. To be sure that you have the room members, call and await `Room.loadHeroUsers()` before.

The bug in action: 

https://github.com/user-attachments/assets/db8987ca-3aa3-4529-a718-ead0414b94cd

## Solution
`ChatListItem` becomes a `StatefulWidget` that loads the room's hero users once (only when the room has no name).

## Test recommendations
Cold start with DMs or unnamed groups: names show directly instead of placeholders

## Demos
No specific demo added, on purpose, the displayName are now correctly fetched from cold start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the chat list item rendering to load hero-user info only when the room has an empty name, and to compute the displayed room name within the updated UI flow for improved consistency.
  * Prevents unnecessary hero-user reloads while keeping the list accurate as room context changes.

* **Tests**
  * Added widget tests verifying hero-user loading runs for nameless rooms and is skipped for named rooms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->