### PR TITLE
test(integration): drop legacy test: parameter — Patrol-web migration complete [PR 9b Final-4]

### DIFF
--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 import '../factories/robot_factory_provider.dart';
-import '../scenarios/login_scenario.dart';
 import 'base_test_scenario.dart';
 import 'test_app_initializer.dart';
 
@@ -159,47 +158,5 @@ class TestBase {
       password: const String.fromEnvironment('PASSWORD'),
     );
     await loginRobot.grantNotificationPermission();
-  }
-
-  void twakePatrolTest({
-    required String description,
-    required Function(PatrolIntegrationTester $) test,
-    NativeAutomatorConfig? nativeAutomatorConfig,
-  }) {
-    patrolTest(
-      description,
-      config: const PatrolTesterConfig(
-        printLogs: true,
-        visibleTimeout: Duration(minutes: 1),
-      ),
-      nativeAutomatorConfig: nativeAutomatorConfig ?? NativeAutomatorConfig(),
-      framePolicy: LiveTestWidgetsFlutterBindingFramePolicy.fullyLive,
-      // `twakePatrolTest` is the legacy single-platform entry point; the tests
-      // still on it are mobile-only (they reach `$.native.*`, the system
-      // clipboard, or backends the local web harness lacks). Skip them on web
-      // so the web suite stays green while they await migration. Mobile runs
-      // them unchanged.
-      skip: kIsWeb,
-      ($) async {
-        await initTwakeChat();
-        final originalOnError = FlutterError.onError!;
-        FlutterError.onError = (FlutterErrorDetails details) {
-          originalOnError(details);
-        };
-        await login($);
-        await test($);
-      },
-    );
-  }
-
-  Future<void> login(PatrolIntegrationTester $) async {
-    final loginScenario = LoginScenario(
-      $,
-      username: const String.fromEnvironment('USERNAME'),
-      serverUrl: const String.fromEnvironment('SERVER_URL'),
-      password: const String.fromEnvironment('PASSWORD'),
-    );
-
-    await loginScenario.login();
   }
 }

--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -17,26 +17,16 @@ class TestBase {
   ///   cross-platform migration.
   void runPatrolTest({
     required String description,
-    Function(PatrolIntegrationTester $)? test,
-    ScenarioBuilder? scenarioBuilder,
+    required ScenarioBuilder scenarioBuilder,
     NativeAutomatorConfig? nativeAutomatorConfig,
     dynamic tags = const [],
-    // Marks a `scenarioBuilder` test that is intentionally mobile-only — it
-    // exercises a capability the web target cannot reach locally (system
-    // clipboard, `$.native.*`, a non-resolvable account, or a backend the
-    // local web harness lacks). Such tests are skipped on web instead of
-    // failing the suite, and run unchanged on mobile. This is the migration
-    // path for the remaining legacy `test:` / `twakePatrolTest` mobile-only
-    // tests once those signatures are dropped.
+    // Marks a test that is intentionally mobile-only — it exercises a
+    // capability the web target cannot reach locally (system clipboard,
+    // `$.native.*`, a non-resolvable account, or a backend the local web
+    // harness lacks). Such tests are skipped on web instead of failing the
+    // suite, and run unchanged on mobile.
     bool mobileOnly = false,
   }) {
-    // Enforced at runtime (not via `assert`) so the contract holds in
-    // profile/release builds too, where assertions are compiled out.
-    if ((test == null) == (scenarioBuilder == null)) {
-      throw ArgumentError(
-        'runPatrolTest requires exactly one of `test` or `scenarioBuilder`.',
-      );
-    }
     const testTimeoutMs = int.fromEnvironment(
       'GLOBAL_TEST_TIMEOUT_MS',
       defaultValue: 120000,
@@ -82,13 +72,10 @@ class TestBase {
       config: patrolConfig,
       nativeAutomatorConfig: nativeAutomatorConfig ?? defaultNativeConfig,
       tags: tags,
-      // On web, skip two kinds of tests so the suite stays green:
-      //   * legacy `test:` entries (mobile-only — they reach `$.native.*` and
-      //     other mobile-only paths), pending migration;
-      //   * `scenarioBuilder` tests explicitly flagged [mobileOnly] (they need
-      //     a capability the local web harness cannot provide).
-      // Everything else runs on both platforms. Mobile runs all of them.
-      skip: kIsWeb && (scenarioBuilder == null || mobileOnly),
+      // On web, skip tests explicitly flagged [mobileOnly] (they need a
+      // capability the local web harness cannot provide). Everything else runs
+      // on both platforms; mobile runs all of them.
+      skip: kIsWeb && mobileOnly,
       framePolicy: LiveTestWidgetsFlutterBindingFramePolicy.fullyLive,
       ($) async {
         await initTwakeChat();
@@ -131,12 +118,8 @@ class TestBase {
           originalOnError(details);
         };
         await loginAndRun($);
-        if (scenarioBuilder != null) {
-          final robots = createRobotFactory($);
-          await scenarioBuilder($, robots).runTestLogic();
-        } else {
-          await test!($);
-        }
+        final robots = createRobotFactory($);
+        await scenarioBuilder($, robots).runTestLogic();
       },
     );
   }

--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -79,49 +79,52 @@ class TestBase {
       framePolicy: LiveTestWidgetsFlutterBindingFramePolicy.fullyLive,
       ($) async {
         await initTwakeChat();
-        // `FlutterError.onError` is a global static. Capture the current
-        // handler and restore it on teardown so each test's wrapper does not
-        // stack onto the previous one's, which would compound the filtering
-        // and could hide or duplicate failures across tests.
-        final originalOnError =
-            FlutterError.onError ?? FlutterError.presentError;
-        addTearDown(() => FlutterError.onError = originalOnError);
-        FlutterError.onError = (FlutterErrorDetails details) {
-          // A couple of pre-existing, web-only rendering assertions fire under
-          // the narrow headless-web harness and are unrelated to the test
-          // logic:
-          //   * a benign `RenderFlex` overflow in a few app layouts (e.g. the
-          //     reply preview above the composer);
-          //   * `chat_web_scrollbar` momentarily reporting its `ScrollController`
-          //     attached to multiple scroll views while the layout rebuilds
-          //     (e.g. entering message-select mode).
-          // `onError` would otherwise fail the test, so on web we log and
-          // swallow only these specific cases. Mobile stays strict, and other
-          // overflow errors still fail the test on web.
-          final message = details.exceptionAsString();
-          final stack = details.stack?.toString() ?? '';
-          // Require the exact framework assertion in addition to the
-          // `chat_web_scrollbar` stack frame, so an unrelated regression from
-          // that file is not silently swallowed.
-          final isKnownScrollbarAttachAssertion =
-              stack.contains('chat_web_scrollbar') &&
-              message.contains(
-                'ScrollController attached to multiple scroll views',
-              );
-          final isBenignWebError =
-              message.contains('A RenderFlex overflowed by') ||
-              isKnownScrollbarAttachAssertion;
-          if (kIsWeb && isBenignWebError) {
-            FlutterError.dumpErrorToConsole(details);
-            return;
-          }
-          originalOnError(details);
-        };
+        _installWebBenignErrorFilter();
         await loginAndRun($);
         final robots = createRobotFactory($);
         await scenarioBuilder($, robots).runTestLogic();
       },
     );
+  }
+
+  /// On web, swallows a couple of pre-existing, benign rendering assertions
+  /// that fire under the narrow headless-web harness and are unrelated to the
+  /// test logic (see [_isBenignWebError]). Mobile stays strict.
+  ///
+  /// `FlutterError.onError` is a global static, so the previous handler is
+  /// captured and restored on teardown — otherwise each test's wrapper would
+  /// stack onto the last one's, compounding the filtering.
+  void _installWebBenignErrorFilter() {
+    final originalOnError = FlutterError.onError ?? FlutterError.presentError;
+    addTearDown(() => FlutterError.onError = originalOnError);
+    FlutterError.onError = (FlutterErrorDetails details) {
+      if (kIsWeb && _isBenignWebError(details)) {
+        FlutterError.dumpErrorToConsole(details);
+        return;
+      }
+      originalOnError(details);
+    };
+  }
+
+  /// Whether [details] is one of the known, benign web-only rendering
+  /// assertions:
+  ///   * a `RenderFlex` overflow in a few app layouts (e.g. the reply preview
+  ///     above the composer);
+  ///   * `chat_web_scrollbar` momentarily reporting its `ScrollController`
+  ///     attached to multiple scroll views while the layout rebuilds (e.g.
+  ///     entering message-select mode).
+  ///
+  /// The scrollbar case requires the exact framework assertion in addition to
+  /// the `chat_web_scrollbar` stack frame, so an unrelated regression from that
+  /// file is not silently swallowed.
+  static bool _isBenignWebError(FlutterErrorDetails details) {
+    final message = details.exceptionAsString();
+    final stack = details.stack?.toString() ?? '';
+    final isKnownScrollbarAttachAssertion =
+        stack.contains('chat_web_scrollbar') &&
+        message.contains('ScrollController attached to multiple scroll views');
+    return message.contains('A RenderFlex overflowed by') ||
+        isKnownScrollbarAttachAssertion;
   }
 
   Future<void> initTwakeChat() async {

--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -18,7 +18,6 @@ class TestBase {
   void runPatrolTest({
     required String description,
     required ScenarioBuilder scenarioBuilder,
-    NativeAutomatorConfig? nativeAutomatorConfig,
     dynamic tags = const [],
     // Marks a test that is intentionally mobile-only — it exercises a
     // capability the web target cannot reach locally (system clipboard,
@@ -70,7 +69,7 @@ class TestBase {
       description,
       timeout: testTimeout,
       config: patrolConfig,
-      nativeAutomatorConfig: nativeAutomatorConfig ?? defaultNativeConfig,
+      nativeAutomatorConfig: defaultNativeConfig,
       tags: tags,
       // On web, skip tests explicitly flagged [mobileOnly] (they need a
       // capability the local web harness cannot provide). Everything else runs

--- a/integration_test/scenarios/chat_dm_leave_scenario.dart
+++ b/integration_test/scenarios/chat_dm_leave_scenario.dart
@@ -89,18 +89,23 @@ class ChatDmLeaveScenario extends BaseTestScenario {
     await searchRobot.enterSearchText(timestampAccount);
 
     // Wait for search results to appear instead of pumpAndSettle
-    // (pumpAndSettle times out due to TextField cursor animation)
-    await $.waitUntilVisible($(TwakeListItem), timeout: _kNavigationTimeout);
+    // (pumpAndSettle times out due to TextField cursor animation).
+    // Match the row for this exact account so we don't open an unrelated chat
+    // if the search ever returns more than one result.
+    final searchResult = $(
+      TwakeListItem,
+    ).containing(find.textContaining(timestampAccount));
+    await $.waitUntilVisible(searchResult.first, timeout: _kNavigationTimeout);
 
-    // Verify search result exists
+    // Verify the search result for this account exists.
     s.softAssertEquals(
-      $(TwakeListItem).exists,
+      searchResult.exists,
       true,
       'Chat is not found in search results',
     );
 
-    // Open the chat from search results
-    await $(TwakeListItem).first.tap();
+    // Open the chat from search results.
+    await searchResult.first.tap();
     await $.waitUntilVisible($(ChatView));
 
     // Open chat profile info (DM-specific method)


### PR DESCRIPTION
## What

The genuinely final step: every integration test is now a single `scenarioBuilder` entry, so the legacy `test:` parameter on `runPatrolTest` has zero callers. Remove it:
- the `test:` param + the exactly-one-of validation;
- the web-skip-legacy branch (`skip` is now just `kIsWeb && mobileOnly`);
- the `test!($)` fallback (`scenarioBuilder` is now `required`).

After this, **no legacy test signature remains** (`twakePatrolTest` was removed in #3150; `RequiresLoginMixin` does not exist in the codebase).

## Dependencies

- Stacked on **#3150** (base).
- Also requires **#3146** (migrates `chat_group` test09 / message-info — the last `test:` caller). Its commit is cherry-picked here so this branch compiles standalone → expect a **trivial `chat_group_test.dart` conflict** when #3146 and this both land (different test entries; keep all).

## Validation (Patrol headless Chrome, local Synapse)

- `chat_group_test`: **5 passed** (reply / delete / edit / select / message-info), 2 skipped (display / copy — `mobileOnly`), **0 failed**.
- `message_context_menu_safe_area`: ⏩ skipped, 0 failed.
- No `test:` / `twakePatrolTest` callers remain; `integration_test` analyzes clean.

⚠️ Web-validated only — mobile (FTL / local) still to run to confirm the `mobileOnly` tests behave unchanged.

Closes the Patrol-web migration (#3088).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the integration test framework to use a scenario-only runner, removing legacy entry points and related branching behavior.
  * Improved web test handling by refining skip conditions and isolating benign headless rendering error filtering.

* **Bug Fixes**
  * Improved reliability of the DM leave flow by waiting for a specific search result row before opening the chat, reducing intermittent timing-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->