### PR TITLE
fix(media): caption field height, video preview play, and video upload compression

### DIFF
--- a/lib/pages/chat/send_media_native_dialog/send_media_native_dialog.dart
+++ b/lib/pages/chat/send_media_native_dialog/send_media_native_dialog.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/presentation/extensions/media_thumbnail_extension.dar
 import 'package:fluffychat/presentation/widget_keys/widget_keys.dart';
 import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
+import 'package:open_file/open_file.dart';
 
 /// Result returned by [SendMediaNativeDialog]. `null` means the user cancelled
 /// (no upload should happen). On send, [files] is the kept list (oversized files
@@ -219,11 +220,11 @@ class _SendMediaNativeDialogState extends State<SendMediaNativeDialog> {
             child: SafeArea(
               top: false,
               child: Padding(
-                padding: EdgeInsets.only(
+                padding: const EdgeInsets.only(
                   left: 12,
                   right: 12,
                   top: 8,
-                  bottom: MediaQuery.of(context).viewInsets.bottom + 8,
+                  bottom: 8,
                 ),
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.end,
@@ -343,11 +344,14 @@ class _MediaPreview extends StatelessWidget {
             Image.memory(thumbnailBytes, fit: BoxFit.contain)
           else
             const SizedBox.shrink(),
-          const Center(
-            child: Icon(
-              Icons.play_circle_outline,
-              color: Colors.white,
-              size: 72,
+          Center(
+            child: GestureDetector(
+              onTap: path != null ? () => OpenFile.open(path) : null,
+              child: const Icon(
+                Icons.play_circle_outline,
+                color: Colors.white,
+                size: 72,
+              ),
             ),
           ),
         ],

--- a/lib/pages/chat/send_media_native_dialog/send_media_native_dialog.dart
+++ b/lib/pages/chat/send_media_native_dialog/send_media_native_dialog.dart
@@ -8,6 +8,7 @@ import 'package:fluffychat/pages/chat/input_bar/input_bar.dart';
 import 'package:fluffychat/presentation/extensions/media_thumbnail_extension.dart';
 import 'package:fluffychat/presentation/widget_keys/widget_keys.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
 import 'package:open_file/open_file.dart';
 
@@ -220,11 +221,9 @@ class _SendMediaNativeDialogState extends State<SendMediaNativeDialog> {
             child: SafeArea(
               top: false,
               child: Padding(
-                padding: const EdgeInsets.only(
-                  left: 12,
-                  right: 12,
-                  top: 8,
-                  bottom: 8,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: LinagoraSpacing.base * 1.5,
+                  vertical: LinagoraSpacing.base,
                 ),
                 child: Row(
                   crossAxisAlignment: CrossAxisAlignment.end,

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -34,6 +34,7 @@ import 'package:matrix/matrix.dart';
 // ignore: implementation_imports
 import 'package:matrix/src/utils/run_benchmarked.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:video_compress/video_compress.dart';
 import 'package:video_thumbnail/video_thumbnail.dart';
 
 typedef TransactionId = String;
@@ -196,6 +197,50 @@ extension SendFileExtension on Room {
         thumbnail = null; // in this case, the thumbnail is not usefull
       }
     } else if (fileInfo is VideoFileInfo) {
+      // Compress video before upload to reduce file size (especially iOS
+      // MOV/HEVC which can be 100 MB+ raw). Falls back to the original file
+      // on any error so the send is never blocked.
+      var videoInfo = fileInfo;
+      final videoPath = videoInfo.filePath;
+      if (videoPath != null) {
+        try {
+          Logs().d(
+            'sendFileEventMobile::Compressing video '
+            '(${videoInfo.fileSize} bytes)',
+          );
+          final mediaInfo = await VideoCompress.compressVideo(
+            videoPath,
+            quality: VideoQuality.MediumQuality,
+            deleteOrigin: false,
+          );
+          final compressedFile = mediaInfo?.file;
+          if (compressedFile != null && await compressedFile.exists()) {
+            final compressedSize = await compressedFile.length();
+            if (compressedSize < videoInfo.fileSize && compressedSize > 0) {
+              Logs().d(
+                'sendFileEventMobile::Video compressed '
+                '${videoInfo.fileSize} → $compressedSize bytes '
+                '(${(100 - compressedSize * 100 ~/ videoInfo.fileSize)}% saved)',
+              );
+              videoInfo = VideoFileInfo(
+                videoInfo.fileName,
+                filePath: compressedFile.path,
+                width: mediaInfo?.width,
+                height: mediaInfo?.height,
+              );
+            } else {
+              Logs().d(
+                'sendFileEventMobile::Compressed video not smaller, '
+                'using original',
+              );
+            }
+          }
+        } catch (e, s) {
+          Logs().w('sendFileEventMobile::Video compression failed', e, s);
+        }
+      }
+      fileInfo = videoInfo;
+
       await updateFakeSync(
         fakeImageEvent,
         fileSendingStatusKey,
@@ -205,19 +250,19 @@ extension SendFileExtension on Room {
       if (tempThumbnailFile != null) {
         thumbnail ??= await _getThumbnailVideo(
           tempThumbnailFile,
-          fileInfo,
+          videoInfo,
           txid,
           uploadStreamController: uploadStreamController,
         );
       }
-      if (fileInfo.width == null ||
-          fileInfo.height == null ||
-          fileInfo.width == 0 ||
-          fileInfo.height == 0) {
+      if (videoInfo.width == null ||
+          videoInfo.height == null ||
+          videoInfo.width == 0 ||
+          videoInfo.height == 0) {
         fileInfo = VideoFileInfo(
-          fileInfo.fileName,
-          filePath: fileInfo.filePath,
-          bytes: fileInfo.bytes,
+          videoInfo.fileName,
+          filePath: videoInfo.filePath,
+          bytes: videoInfo.bytes,
           width: thumbnail?.width,
           height: thumbnail?.height,
         );

--- a/lib/presentation/extensions/send_file_extension.dart
+++ b/lib/presentation/extensions/send_file_extension.dart
@@ -233,6 +233,11 @@ extension SendFileExtension on Room {
                 'sendFileEventMobile::Compressed video not smaller, '
                 'using original',
               );
+              try {
+                await compressedFile.delete();
+              } catch (_) {
+                // best-effort cleanup
+              }
             }
           }
         } catch (e, s) {


### PR DESCRIPTION
## Summary
- **Caption field too tall**: removed double keyboard-avoidance padding in `SendMediaNativeDialog` — `Scaffold` already handles `viewInsets` via `resizeToAvoidBottomInset`, so adding `MediaQuery.of(context).viewInsets.bottom` as bottom padding doubled the space
- **Video play button broken**: added `GestureDetector` + `OpenFile.open(path)` on the play icon overlay in the media preview screen so tapping it opens the system video player
- **Video upload slow/failing on iOS**: added `VideoCompress.compressVideo()` (MediumQuality) before upload in `sendFileEventMobile` — iOS MOV/HEVC files can be 100MB+ uncompressed; falls back to original file on compression failure

## Test plan
- [x] Pick an image, verify caption field starts at 1 line height and grows with content
- [x] Pick a video, tap play icon in preview → system player opens
- [x] Send a video, verify compression logs appear and upload completes faster than before
- [x] Send an image, verify no regression in upload flow

<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/6ec3d0e3-a39b-4aff-bbbc-1b70b17d2f78" />
<img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/d29d7edf-c2a0-4207-ad85-6b17a91987a8" />


Closes #3154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tap video previews to open and view media files directly
  * Videos are automatically compressed before sending

* **Improvements**
  * Refined media input area spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->