### PR TITLE
fix(integration): guard one-shot init in web_test_main to prevent CI hang

### DIFF
--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -64,6 +64,17 @@ jobs:
           dart run build_runner build --delete-conflicting-outputs
           dart pub global activate patrol_cli ${{ env.PATROL_CLI_VERSION }}
 
+      - name: Install Playwright browsers
+        run: |
+          # patrol_cli runs `npx playwright install` (without --with-deps) in
+          # its internal web_runner directory.  ubuntu-24.04 runner images >=
+          # 20260615.205.1 dropped the pre-installed Chromium, so system libs
+          # (libnss3, libatk, etc.) are missing and the install silently exits
+          # with code 1.  Pre-running with --with-deps here installs both the
+          # browser binary and the required OS packages; patrol's subsequent
+          # install is a no-op because ~/.cache/ms-playwright already has it.
+          npx playwright@1.56.0 install --with-deps chromium
+
       - name: Run Patrol Web
         timeout-minutes: 20
         env:

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -89,6 +89,7 @@ jobs:
           . ./.env.patrol-web
           set +a
           patrol test \
+            --verbose \
             --device chrome \
             --web-headless=true \
             --web-timeout 300000 \

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -65,6 +65,7 @@ jobs:
           dart pub global activate patrol_cli ${{ env.PATROL_CLI_VERSION }}
 
       - name: Run Patrol Web
+        timeout-minutes: 20
         env:
           PATROL_TEST_TARGET: ${{ inputs.patrol_test_target }}
         run: |

--- a/integration_test/base/web_test_main.dart
+++ b/integration_test/base/web_test_main.dart
@@ -35,31 +35,42 @@ const _testConfig = <String, dynamic>{
   'enable_logs': true,
 };
 
+bool _initialised = false;
+
 /// Initialise just enough for a web login test, then [runApp].
+///
+/// Guard: each [patrolTest] callback calls this, but within a single test
+/// file all callbacks share the same Dart isolate.  Calling [runApp] again
+/// is fine (it replaces the root widget), but one-shot setup like
+/// [GetItInitializer], [Hive.initFlutter], and the [AppConfig] completer
+/// must only run once — a second call would throw (duplicate GetIt
+/// registrations, double-completed Completer).
 Future<void> main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  initMatrixLogger();
+  if (!_initialised) {
+    _initialised = true;
+    WidgetsFlutterBinding.ensureInitialized();
+    initMatrixLogger();
 
-  // Skip: MediaKit.ensureInitialized()  — media player, not needed
-  // Skip: vod.init()                    — vodozemac WASM hangs in test
-  // Skip: CozyConfigManager             — Cozy integration, not needed
+    AppConfig.loadFromJson(_testConfig);
+    AppConfig.initConfigCompleter.complete(true);
 
-  // Pre-populate AppConfig so AutoHomeserverPicker can proceed immediately
-  // without fetching config.json over HTTP.  The isCompleted guard in
-  // initConfigWeb() prevents a double-complete crash.
-  AppConfig.loadFromJson(_testConfig);
-  AppConfig.initConfigCompleter.complete(true);
+    GoRouter.optionURLReflectsImperativeAPIs = true;
+    await Hive.initFlutter();
 
-  GoRouter.optionURLReflectsImperativeAPIs = true;
-  await Hive.initFlutter();
-
-  GetItInitializer().setUp();
+    GetItInitializer().setUp();
+  }
 
   Logs().nativeColors = !PlatformInfos.isIOS;
-  final clients = await ClientManager.getClients();
+  final clients = await ClientManager.getClients(initialize: false);
   final firstClient = clients.firstOrNull;
-  await firstClient?.roomsLoading;
-  await firstClient?.accountDataLoading;
+  if (firstClient != null && !firstClient.isLogged()) {
+    await firstClient
+        .init(waitForFirstSync: false, waitUntilLoadCompletedLoaded: false)
+        .timeout(
+          const Duration(seconds: 15),
+          onTimeout: () => Logs().w('web_test_main: client.init() timed out'),
+        );
+  }
 
   Logs().i('web_test_main: starting GUI with ${clients.length} client(s)');
   runApp(TwakeApp(clients: clients));


### PR DESCRIPTION
## Summary
- Guard one-shot setup (binding, AppConfig completer, Hive, GetIt) behind `_initialised` flag in `web_test_main.main()` — fixes indefinite hang when multiple `patrolTest` callbacks in the same file share a Dart isolate
- Use `getClients(initialize: false)` + manual `init()` with 15s timeout to prevent indefinite hangs during client database open
- Add `timeout-minutes: 20` to CI step as safety net

## Context
`chat_group_test.dart` has 7 tests (5 non-skipped on web). Each callback called `web_test_main.main()`, which crashed on the 2nd+ call:
- `AppConfig.initConfigCompleter.complete(true)` → `StateError` (already completed)
- `GetItInitializer().setUp()` → 123 duplicate registrations

The crash left the process wedged — no Patrol timeout could fire, causing a 25 min CI hang.

## Test plan
- [x] `scripts/run-one-web.sh integration_test/tests/chat/chat_group_test.dart` → 5 ✅, 2 ⏩, 0 ❌ (2m17s)
- [ ] CI workflow_dispatch run on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Playwright browser setup for web integration tests with a dedicated install step.
  * Added timeout controls to keep web test runs from hanging.
  * Prevented duplicate one-time startup work during web test execution.
  * Streamlined client initialization for web tests, including safe handling for first-client setup when not logged in.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->