### PR TITLE
TW-3106: Fix cannot jump to the proper notification on android

### DIFF
--- a/lib/utils/background_push.dart
+++ b/lib/utils/background_push.dart
@@ -337,6 +337,11 @@ class BackgroundPush {
     final instance = BackgroundPush.clientOnly(client);
     instance._matrixState = matrixState;
     instance.onFcmError = onFcmError;
+    // Trigger push setup immediately once MatrixState is available.
+    // ChatList.initState() calls setupPush() via backgroundPush?, but that
+    // can race with initMatrix assigning backgroundPush — calling here
+    // ensures cold-start notification routing is never skipped.
+    unawaited(instance.setupPush());
     return instance;
   }
 
@@ -460,14 +465,26 @@ class BackgroundPush {
   }
 
   bool _wentToRoomOnStartup = false;
+  bool _setupPushCompleted = false;
 
   Future<void> setupPush() async {
-    Logs().d("SetupPush");
+    Logs().d(
+      'SetupPush: loginState=${client.onLoginStateChanged.value} '
+      'isMobile=${PlatformInfos.isMobile} '
+      'matrixState=${_matrixState != null}',
+    );
     if (client.onLoginStateChanged.value != LoginState.loggedIn ||
         !PlatformInfos.isMobile ||
         _matrixState == null) {
+      Logs().d('SetupPush: early return - conditions not met');
       return;
     }
+    // Guard against double-invocation (factory + ChatList both call setupPush).
+    if (_setupPushCompleted) {
+      Logs().d('SetupPush: already completed, skip');
+      return;
+    }
+    _setupPushCompleted = true;
     // Do not setup unifiedpush if this has been initialized by
     // an unifiedpush action
     if (upAction) {
@@ -480,10 +497,17 @@ class BackgroundPush {
       await setupPushGateway();
     }
 
+    // Use flutter_local_notifications launch details to handle cold-start
     // ignore: unawaited_futures
     _flutterLocalNotificationsPlugin.getNotificationAppLaunchDetails().then((
       details,
     ) {
+      Logs().d(
+        '[Push] getNotificationAppLaunchDetails: '
+        'details=$details '
+        'didLaunch=${details?.didNotificationLaunchApp} '
+        'payload=${details?.notificationResponse?.payload}',
+      );
       if (details == null ||
           !details.didNotificationLaunchApp ||
           _wentToRoomOnStartup ||

--- a/lib/utils/logging/sentry_tracked_events.dart
+++ b/lib/utils/logging/sentry_tracked_events.dart
@@ -2,9 +2,18 @@ enum SentryTrackedEvents {
   // ── Sample (isExample: true → ignored by SentryLogger) ───────────────────
   failedToLoadTimeline('Failed to load timeline', isExample: true),
   // ── Active tracked events ─────────────────────────────────────────────────
-  // pushHelperCrashed('Push Helper has crashed'),
+  pushHelperCrashed('Push Helper has crashed'),
   missingLastMessage('Missing-last-message'),
-  wrongMemberCount('Wrong-member-count');
+  wrongMemberCount('Wrong-member-count'),
+  notificationGoToRoomFailed('[Push] Failed to open room'),
+  notificationPayloadParseFailed(
+    '[Push] onSelectNotification: failed to parse payload',
+  ),
+  notificationGetTokenFailed('[Push] cannot get token'),
+  notificationGetInitialFailed('[Push] Failed to get initial notification'),
+  iOSNotificationPayloadParseFailed(
+    '[Push] iOSUserSelectedNoti: failed to parse payload',
+  );
 
   const SentryTrackedEvents(this.message, {this.isExample = false});
 

--- a/lib/utils/logging/sentry_tracked_events.dart
+++ b/lib/utils/logging/sentry_tracked_events.dart
@@ -2,7 +2,7 @@ enum SentryTrackedEvents {
   // ── Sample (isExample: true → ignored by SentryLogger) ───────────────────
   failedToLoadTimeline('Failed to load timeline', isExample: true),
   // ── Active tracked events ─────────────────────────────────────────────────
-  pushHelperCrashed('Push Helper has crashed'),
+  pushHelperCrashed('Push Helper has crashed!'),
   missingLastMessage('Missing-last-message'),
   wrongMemberCount('Wrong-member-count'),
   notificationGoToRoomFailed('[Push] Failed to open room'),

--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -95,7 +95,6 @@ Future<void> _tryPushHelper(
       iOS: DarwinInitializationSettings(),
     ),
     onDidReceiveNotificationResponse: onSelectNotification,
-    //onDidReceiveBackgroundNotificationResponse: onSelectNotification,
   );
 
   client ??= (await ClientManager.getClients(initialize: false)).first;


### PR DESCRIPTION
## Ticket
**Related issue**

- #3106

## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**

-   Android only. Affects users who fully kill the app then tap a push notification — they land on the chat list instead of the specific room.

## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**

-  Android only. Affects users who fully kill the app then tap a push notification — they land on the chat list instead of the specific room.

## Impact description
**If this is not a bug, please explain how the changes affect the project**

- Fixed Android cold-start notification routing — users who kill the app and tap a push notification now land directly in the correct chat room.

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/66a89808-8528-45ee-911e-306f9066d9a5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a cold-start race that could cause missed or misrouted push notifications.
  * Improved cold-start notification launch handling with clearer decision logging during notification-based app launches.

* **Chores**
  * Expanded push-related Sentry tracking to cover additional notification and payload parsing failures.
  * Enhanced push setup debug logging to help diagnose notification routing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->