### PR TITLE
fix(linkify): prevent filenames from opening new tab in message caption

### DIFF
--- a/lib/utils/extension/url_extension.dart
+++ b/lib/utils/extension/url_extension.dart
@@ -1,0 +1,50 @@
+const _fileExtensions = {
+  // Documents
+  'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
+  'odt', 'ods', 'odp', 'txt', 'csv', 'tsv', 'rtf',
+  // Markup / data
+  'md', 'json', 'xml', 'yaml', 'yml', 'toml', 'ini', 'cfg', 'conf',
+  // Images
+  'png', 'jpg', 'jpeg', 'gif', 'svg', 'webp', 'bmp', 'ico', 'tiff',
+  // Video / audio
+  'mp4', 'mkv', 'avi', 'mov', 'webm', 'mp3', 'wav', 'ogg', 'flac', 'aac',
+  // Archives
+  'zip', 'tar', 'gz', 'bz2', 'xz', '7z', 'rar', 'pkg', 'dmg', 'iso',
+  'apk', 'ipa', 'exe', 'msi',
+  // Code
+  'py', 'js', 'ts', 'jsx', 'tsx', 'dart', 'java', 'kt', 'swift',
+  'go', 'rs', 'c', 'cpp', 'h', 'cs', 'php', 'rb', 'sh', 'bash',
+  'zsh', 'fish', 'ps1', 'sql', 'html', 'css', 'scss',
+  // Fonts
+  'ttf', 'otf', 'woff', 'woff2',
+  // Misc
+  'log', 'lock', 'env',
+};
+
+bool _hasExplicitScheme(String url) =>
+    url.startsWith('http://') || url.startsWith('https://');
+
+bool _hasUrlStructuralIndicator(String url) =>
+    url.contains('/') || url.contains('?') || url.contains('#');
+
+bool _hasKnownFileExtension(String url) {
+  final lastDot = url.lastIndexOf('.');
+  if (lastDot == -1) return false;
+  return _fileExtensions.contains(url.substring(lastDot + 1).toLowerCase());
+}
+
+/// Returns true if [url] looks like a filename falsely detected as a URL
+/// by a linkify parser (e.g. "test.md" parsed as Moldova TLD).
+///
+/// Criteria:
+/// - no explicit http/https scheme
+/// - no path, query string, or fragment (structural URL indicators)
+/// - last dot-delimited segment matches a known file extension
+///   (multi-dot names like `my.report.pdf` or `archive.tar.gz` supported)
+bool isFilenameUrl(String? url) {
+  if (url == null) return false;
+  if (url.isEmpty) return false;
+  if (_hasExplicitScheme(url)) return false;
+  if (_hasUrlStructuralIndicator(url)) return false;
+  return _hasKnownFileExtension(url);
+}

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview.dart
@@ -1,7 +1,8 @@
-import 'package:fluffychat/presentation/widget_keys/widget_keys.dart';
 import 'package:fluffychat/pages/chat/events/formatted_text_widget.dart';
 import 'package:fluffychat/presentation/mixins/linkify_mixin.dart';
 import 'package:fluffychat/presentation/widget_keys/link_preview_keys.dart';
+import 'package:fluffychat/presentation/widget_keys/widget_keys.dart';
+import 'package:fluffychat/utils/extension/url_extension.dart';
 import 'package:fluffychat/utils/string_extension.dart';
 import 'package:fluffychat/widgets/native_link_span.dart';
 import 'package:fluffychat/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart';
@@ -52,15 +53,21 @@ class TwakeLinkPreview extends StatelessWidget with LinkifyMixin {
               linkStyle: linkStyle,
               linkTypes: const [LinkType.url, LinkType.phone, LinkType.date],
               textAlign: TextAlign.start,
-              onTapDownLink: (tapDownDetails, link) => handleOnTappedLinkHtml(
-                context: context,
-                details: tapDownDetails,
-                link: link,
-              ),
+              onTapDownLink: (tapDownDetails, link) {
+                if (link.type == LinkType.url && isFilenameUrl(link.value)) {
+                  return;
+                }
+                handleOnTappedLinkHtml(
+                  context: context,
+                  details: tapDownDetails,
+                  link: link,
+                );
+              },
               linkBuilder: (link, style) {
                 if (link.type != LinkType.url) return null;
                 final url = link.value;
                 if (url == null) return null;
+                if (isFilenameUrl(url)) return null;
                 return buildNativeLinkSpan(
                   url: url,
                   childrenSpan: TextSpan(text: url, style: style),

--- a/test/utils/extension/url_extension_test.dart
+++ b/test/utils/extension/url_extension_test.dart
@@ -1,0 +1,162 @@
+import 'package:fluffychat/utils/extension/url_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('isFilenameUrl', () {
+    group('GIVEN url is null\n', () {
+      test('THEN returns false', () {
+        expect(isFilenameUrl(null), isFalse);
+      });
+    });
+
+    group('GIVEN url has explicit scheme\n', () {
+      test('WHEN https scheme'
+          'THEN returns false', () {
+        expect(isFilenameUrl('https://example.com/test.md'), isFalse);
+      });
+
+      test('WHEN http scheme'
+          'THEN returns false', () {
+        expect(isFilenameUrl('http://example.com/test.md'), isFalse);
+      });
+
+      test('WHEN https scheme with no path'
+          'THEN returns false', () {
+        expect(isFilenameUrl('https://test.md'), isFalse);
+      });
+    });
+
+    group('GIVEN url is a bare domain (no scheme)\n', () {
+      test('WHEN .com domain'
+          'THEN returns false', () {
+        expect(isFilenameUrl('google.com'), isFalse);
+      });
+
+      test('WHEN .io domain'
+          'THEN returns false', () {
+        expect(isFilenameUrl('github.io'), isFalse);
+      });
+
+      test('WHEN .org domain'
+          'THEN returns false', () {
+        expect(isFilenameUrl('wikipedia.org'), isFalse);
+      });
+
+      test('WHEN bare domain with path'
+          'THEN returns false', () {
+        expect(isFilenameUrl('example.com/page'), isFalse);
+      });
+    });
+
+    group(
+      'GIVEN url looks like a filename (no scheme, single dot, known extension)\n',
+      () {
+        test('WHEN .md extension (markdown)'
+            'THEN returns true', () {
+          expect(isFilenameUrl('test.md'), isTrue);
+        });
+
+        test('WHEN .pdf extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('document.pdf'), isTrue);
+        });
+
+        test('WHEN .xlsx extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('report.xlsx'), isTrue);
+        });
+
+        test('WHEN .zip extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('archive.zip'), isTrue);
+        });
+
+        test('WHEN .png extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('image.png'), isTrue);
+        });
+
+        test('WHEN .dart extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('main.dart'), isTrue);
+        });
+
+        test('WHEN .py extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('script.py'), isTrue);
+        });
+
+        test('WHEN .mp4 extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('video.mp4'), isTrue);
+        });
+
+        test('WHEN extension is uppercase'
+            'THEN returns true (case-insensitive)', () {
+          expect(isFilenameUrl('TEST.MD'), isTrue);
+        });
+
+        test('WHEN extension is mixed case'
+            'THEN returns true (case-insensitive)', () {
+          expect(isFilenameUrl('Report.Pdf'), isTrue);
+        });
+
+        test('WHEN multi-dot filename'
+            'THEN returns true', () {
+          expect(isFilenameUrl('my.report.pdf'), isTrue);
+        });
+
+        test('WHEN multi-dot filename with version'
+            'THEN returns true', () {
+          expect(isFilenameUrl('v1.0.zip'), isTrue);
+        });
+
+        test('WHEN multi-dot compound extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('archive.tar.gz'), isTrue);
+        });
+
+        test('WHEN multi-dot with markdown extension'
+            'THEN returns true', () {
+          expect(isFilenameUrl('sub.test.md'), isTrue);
+        });
+      },
+    );
+
+    group('GIVEN url looks like filename but has URL structure\n', () {
+      test('WHEN has path separator after extension'
+          'THEN returns false', () {
+        expect(isFilenameUrl('test.md/path'), isFalse);
+      });
+
+      test('WHEN has query string'
+          'THEN returns false', () {
+        expect(isFilenameUrl('test.md?query=1'), isFalse);
+      });
+
+      test('WHEN has fragment'
+          'THEN returns false', () {
+        expect(isFilenameUrl('test.md#section'), isFalse);
+      });
+    });
+
+    group('GIVEN url has no dot\n', () {
+      test('THEN returns false', () {
+        expect(isFilenameUrl('noextension'), isFalse);
+      });
+    });
+
+    group('GIVEN url has unknown extension\n', () {
+      test('WHEN extension not in file extension list'
+          'THEN returns false', () {
+        expect(isFilenameUrl('test.xyz123'), isFalse);
+      });
+    });
+
+    group('GIVEN empty string\n', () {
+      test('THEN returns false', () {
+        expect(isFilenameUrl(''), isFalse);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes https://github.com/linagora/twake-on-matrix/issues/3124

## Problem

The `linkfy_text` package detects filenames like `test.md` as URLs
(`.md` = Moldova ccTLD). This registers a tap handler that calls
`UrlLauncher.launchUrl()`, opening a new browser tab instead of doing nothing.

## Solution

Extracted `isFilenameUrl()` in `lib/utils/extension/url_extension.dart`.
A string is classified as a filename (not a URL) when **all** of these hold:
- no `http://` / `https://` scheme
- no `/`, `?`, or `#` (structural URL indicators)
- the **last** dot-delimited segment matches a known file extension set
  (multi-dot names like `my.report.pdf` and `archive.tar.gz` supported)

`TwakeLinkPreview` calls `isFilenameUrl()` in both `linkBuilder`
(prevents rendering as a clickable span) and `onTapDownLink` (skips
`UrlLauncher` call). Result: filename text in captions is plain, non-clickable.

## Trade-off

**Extension blocklist vs. TLD allowlist** — blocklist covers common formats
exhaustively; may miss rare custom extensions. The alternative (whitelist
known web TLDs) would be more principled but requires a much larger list
and still risks false negatives on new TLDs.

We classify on the **last** segment only (no dot-count restriction), so
multi-dot filenames work. The only residual ambiguity is a real multi-dot
domain whose final label collides with a file extension that is also a TLD
(e.g. `blog.example.md`, `.sh`, `.rs`) — these become non-clickable. Such
strings are effectively never typed in a caption, so we accept it in favor
of consistent filename handling. `google.com`, `github.io`, `wikipedia.org`
are unaffected.

## Unit tests — `isFilenameUrl` (28/28)

| Input | Expected | Result |
|---|---|---|
| `null` | `false` | ✅ |
| `""` | `false` | ✅ |
| `"https://example.com/test.md"` | `false` (explicit https) | ✅ |
| `"http://example.com/test.md"` | `false` (explicit http) | ✅ |
| `"https://test.md"` | `false` (explicit https, no path) | ✅ |
| `"google.com"` | `false` (bare .com domain) | ✅ |
| `"github.io"` | `false` (bare .io domain) | ✅ |
| `"wikipedia.org"` | `false` (bare .org domain) | ✅ |
| `"example.com/page"` | `false` (bare domain with path) | ✅ |
| `"test.md"` | `true` (markdown filename) | ✅ |
| `"document.pdf"` | `true` | ✅ |
| `"report.xlsx"` | `true` | ✅ |
| `"archive.zip"` | `true` | ✅ |
| `"image.png"` | `true` | ✅ |
| `"main.dart"` | `true` | ✅ |
| `"script.py"` | `true` | ✅ |
| `"video.mp4"` | `true` | ✅ |
| `"TEST.MD"` | `true` (case-insensitive) | ✅ |
| `"Report.Pdf"` | `true` (mixed case) | ✅ |
| `"my.report.pdf"` | `true` (multi-dot filename) | ✅ |
| `"v1.0.zip"` | `true` (multi-dot with version) | ✅ |
| `"archive.tar.gz"` | `true` (compound extension) | ✅ |
| `"sub.test.md"` | `true` (multi-dot, known extension) | ✅ |
| `"test.md/path"` | `false` (has path separator) | ✅ |
| `"test.md?query=1"` | `false` (has query string) | ✅ |
| `"test.md#section"` | `false` (has fragment) | ✅ |
| `"noextension"` | `false` (no dot) | ✅ |
| `"test.xyz123"` | `false` (unknown extension) | ✅ |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved link handling so file-like text is recognized separately from web URLs.
  * Added support for identifying filename-style links, including multi-dot names like `archive.tar.gz`.
* **Bug Fixes**
  * Prevented filename-like links from being treated as tappable web links.
  * Reduced false positives for strings with explicit schemes, paths, queries, or fragments.
* **Tests**
  * Added a test suite to validate filename-URL detection across common cases and edge conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->