### PR TITLE
fix(media): use actual video dimensions in sending state preview

### DIFF
--- a/lib/pages/chat/events/sending_video_widget.dart
+++ b/lib/pages/chat/events/sending_video_widget.dart
@@ -1,3 +1,6 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat/events/message_content_style.dart';
@@ -6,6 +9,7 @@ import 'package:fluffychat/presentation/model/chat/upload_file_ui_state.dart';
 import 'package:fluffychat/presentation/model/file/display_image_info.dart';
 import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
 import 'package:fluffychat/utils/extension/build_context_extension.dart';
+import 'package:fluffychat/utils/extension/image_size_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/widgets/mixins/upload_file_mixin.dart';
 import 'package:flutter/material.dart';
@@ -36,21 +40,48 @@ class _SendingVideoWidgetState extends State<SendingVideoWidget>
   @override
   Event get event => widget.event;
 
-  late final VideoWidget videoWidget;
+  late DisplayImageInfo _displayImageInfo;
+  Uint8List? _thumbnailBytes;
 
   @override
   void initState() {
     super.initState();
-    videoWidget = VideoWidget(
-      imageHeight: widget.displayImageInfo.size.height,
-      imageWidth: widget.displayImageInfo.size.width,
-      event: event,
+    _displayImageInfo = widget.displayImageInfo;
+    _loadThumbnail();
+  }
+
+  Future<void> _loadThumbnail() async {
+    final thumbnail = await widget.event.getPlaceholderMatrixImageFile(
+      getIt.get<UploadManager>(),
     );
+    if (thumbnail == null || !mounted) return;
+
+    final codec = await ui.instantiateImageCodec(thumbnail.bytes);
+    final frame = await codec.getNextFrame();
+    final image = frame.image;
+    final realSize = Size(image.width.toDouble(), image.height.toDouble());
+    image.dispose();
+
+    if (!mounted) return;
+
+    setState(() {
+      _thumbnailBytes = thumbnail.bytes;
+      _displayImageInfo = realSize.getDisplayImageInfo(context);
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     final sysColor = LinagoraSysColors.material();
+    final imageWidth = _displayImageInfo.size.width;
+    final imageHeight = _displayImageInfo.size.height;
+    final maxWidth =
+        MessageContentStyle.combinedBubbleImageWidthWithBubbleMaxWidget(
+          bubbleImageWidget: imageWidth,
+          bubbleMaxWidth: widget.bubbleWidth ?? 0,
+        );
+    final bubbleHeight = MessageContentStyle.videoBubbleHeight(imageHeight);
+
     return ClipRRect(
       borderRadius: MessageContentStyle.borderRadiusBubble,
       child: Stack(
@@ -60,18 +91,23 @@ class _SendingVideoWidgetState extends State<SendingVideoWidget>
             width: MessageStyle.mediaContentWidth(
               context: context,
               event: event,
-              calculatedWidth:
-                  MessageContentStyle.combinedBubbleImageWidthWithBubbleMaxWidget(
-                    bubbleImageWidget: widget.displayImageInfo.size.width,
-                    bubbleMaxWidth: widget.bubbleWidth ?? 0,
-                  ),
+              calculatedWidth: maxWidth,
             ),
-            height: MessageContentStyle.imageBubbleHeight(
-              widget.displayImageInfo.size.height,
-            ),
+            height: bubbleHeight,
             child: const BlurHash(hash: MessageContentStyle.defaultBlurHash),
           ),
-          videoWidget,
+          if (_thumbnailBytes != null)
+            Image.memory(
+              _thumbnailBytes!,
+              width: MessageContentStyle.imageBubbleWidth(imageWidth),
+              height: bubbleHeight,
+              cacheWidth: context.getCacheSize(
+                MessageContentStyle.imageBubbleWidth(imageWidth),
+              ),
+              cacheHeight: context.getCacheSize(bubbleHeight),
+              fit: BoxFit.cover,
+              filterQuality: FilterQuality.medium,
+            ),
           ...switch (event.status) {
             EventStatus.error => [
               IconButton(
@@ -136,59 +172,6 @@ class _SendingVideoWidgetState extends State<SendingVideoWidget>
           },
         ],
       ),
-    );
-  }
-}
-
-class VideoWidget extends StatefulWidget {
-  const VideoWidget({
-    super.key,
-    required this.imageHeight,
-    required this.imageWidth,
-    required this.event,
-  });
-
-  final double imageHeight;
-  final double imageWidth;
-  final Event event;
-
-  @override
-  State<VideoWidget> createState() => _VideoWidgetState();
-}
-
-class _VideoWidgetState extends State<VideoWidget> {
-  late final Future<MatrixImageFile?> _thumbnailFuture;
-
-  @override
-  void initState() {
-    super.initState();
-    _thumbnailFuture = widget.event.getPlaceholderMatrixImageFile(
-      getIt.get<UploadManager>(),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final placeholder = SizedBox(
-      width: widget.imageWidth,
-      height: widget.imageHeight,
-    );
-
-    return FutureBuilder(
-      future: _thumbnailFuture,
-      builder: (context, snapshot) {
-        if (snapshot.data == null) return placeholder;
-
-        return Image.memory(
-          snapshot.data!.bytes,
-          width: widget.imageWidth,
-          height: widget.imageHeight,
-          cacheWidth: context.getCacheSize(widget.imageWidth),
-          cacheHeight: context.getCacheSize(widget.imageHeight),
-          fit: BoxFit.cover,
-          filterQuality: FilterQuality.medium,
-        );
-      },
     );
   }
 }

--- a/lib/pages/chat/events/sending_video_widget.dart
+++ b/lib/pages/chat/events/sending_video_widget.dart
@@ -56,18 +56,26 @@ class _SendingVideoWidgetState extends State<SendingVideoWidget>
     );
     if (thumbnail == null || !mounted) return;
 
-    final codec = await ui.instantiateImageCodec(thumbnail.bytes);
-    final frame = await codec.getNextFrame();
-    final image = frame.image;
-    final realSize = Size(image.width.toDouble(), image.height.toDouble());
-    image.dispose();
+    try {
+      final codec = await ui.instantiateImageCodec(thumbnail.bytes);
+      try {
+        final frame = await codec.getNextFrame();
+        final image = frame.image;
+        final realSize = Size(image.width.toDouble(), image.height.toDouble());
+        image.dispose();
 
-    if (!mounted) return;
+        if (!mounted) return;
 
-    setState(() {
-      _thumbnailBytes = thumbnail.bytes;
-      _displayImageInfo = realSize.getDisplayImageInfo(context);
-    });
+        setState(() {
+          _thumbnailBytes = thumbnail.bytes;
+          _displayImageInfo = realSize.getDisplayImageInfo(context);
+        });
+      } finally {
+        codec.dispose();
+      }
+    } catch (e) {
+      Logs().w('Failed to decode video thumbnail: $e');
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- Refactor `SendingVideoWidget` to decode the placeholder thumbnail's actual pixel dimensions via `ui.instantiateImageCodec`, then recompute the display size with the correct aspect ratio
- Use `videoBubbleHeight` (matching `EventVideoPlayer`) instead of `imageBubbleHeight` for consistent sizing between sending and sent states
- Inline `VideoWidget` into `SendingVideoWidget` (no longer needed as a separate widget)

## Root cause
During video upload, the sending preview used default fallback dimensions (500×420 web / 256×320 mobile) because the event's `info` map has no `w`/`h` yet (especially on web where video metadata isn't extracted before the fake event). This caused the bubble to appear stretched until upload completed and the server-returned event provided real dimensions.

Now the widget reads the thumbnail's real dimensions once it loads and rebuilds with the correct aspect ratio.

## Test plan
- [x] Send a portrait video on web — preview matches sent state
- [x] Send a landscape video — verify correct aspect ratio
- [x] Send a square video — verify correct aspect ratio
- [x] Test on mobile (iOS/Android)

<img width="314" height="316" alt="image" src="https://github.com/user-attachments/assets/58a7bc1d-844f-4ebf-9e8a-5cff2519d4b8" />
<img width="303" height="179" alt="image" src="https://github.com/user-attachments/assets/eb650c04-8de4-4fc0-b48d-5685102a881c" />
<img width="205" height="341" alt="image" src="https://github.com/user-attachments/assets/c78d9140-ebf0-4103-b8e8-5285d242b82d" />



Fixes #3153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Enhanced outgoing video messages with more reliable, self-contained thumbnail placeholder loading and rendering.
  * Thumbnails now display only after the placeholder image bytes are successfully decoded, with sizing aligned to the resolved display dimensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->