### PR TITLE
feat(onboarding): value-driven pre-auth onboarding

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3229,5 +3229,169 @@
   "@videoCallJoinCall": {
     "type": "text",
     "placeholders": {}
+  },
+  "onboardingContinue": "Continue",
+  "@onboardingContinue": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingLater": "Maybe later",
+  "@onboardingLater": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingHookTitle": "Welcome to Twake",
+  "@onboardingHookTitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingHookSubtitle": "A few quick questions to show you what makes us different.",
+  "@onboardingHookSubtitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingIntentTitle": "What brings you here?",
+  "@onboardingIntentTitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingIntentSubtitle": "We'll tailor Twake to the way you use it.",
+  "@onboardingIntentSubtitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingIntentCloseOnes": "My close ones",
+  "@onboardingIntentCloseOnes": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingIntentWork": "Work",
+  "@onboardingIntentWork": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingIntentBoth": "Both",
+  "@onboardingIntentBoth": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingContactsTitle": "Find the people you know already on Twake",
+  "@onboardingContactsTitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingContactsSubtitle": "We match your address book privately. Nothing leaves your phone without you, and you can erase it anytime.",
+  "@onboardingContactsSubtitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingContactsAllow": "Allow access to contacts",
+  "@onboardingContactsAllow": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingPayoffLoading": "Looking for the people you know…",
+  "@onboardingPayoffLoading": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingPayoffTitle": "{count, plural, =1{1 of your contacts is already here} other{{count} of your contacts are already here}}",
+  "@onboardingPayoffTitle": {
+    "type": "text",
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "onboardingPayoffSubtitle": "Your people are waiting for you on Twake.",
+  "@onboardingPayoffSubtitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingPayoffMoreContacts": "{count, plural, =1{and 1 more contact} other{and {count} more contacts}}",
+  "@onboardingPayoffMoreContacts": {
+    "type": "text",
+    "placeholders": {
+      "count": {}
+    }
+  },
+  "onboardingPayoffStartChatting": "Start chatting",
+  "@onboardingPayoffStartChatting": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingPayoffEmptyTitle": "You're all set",
+  "@onboardingPayoffEmptyTitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingPayoffEmptySubtitle": "Invite your close ones to join you on Twake.",
+  "@onboardingPayoffEmptySubtitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingPayoffContinue": "Continue",
+  "@onboardingPayoffContinue": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingAnswerDontCare": "I don't care",
+  "@onboardingAnswerDontCare": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingAnswerDontKnow": "I don't really know",
+  "@onboardingAnswerDontKnow": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingAnswerConcerned": "It worries me",
+  "@onboardingAnswerConcerned": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingPrivacyQuestion": "Who can read your private conversations?",
+  "@onboardingPrivacyQuestion": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingPrivacyValue": "On Twake, your messages are end-to-end encrypted and hosted in Europe. No one can read them — not even us.",
+  "@onboardingPrivacyValue": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingAiQuestion": "Are you fine with your messages feeding AI models?",
+  "@onboardingAiQuestion": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingAiValue": "Twake never trains any AI on your conversations. Your words stay yours.",
+  "@onboardingAiValue": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingSovereigntyQuestion": "Does relying on US tech giants for your messages bother you?",
+  "@onboardingSovereigntyQuestion": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingSovereigntyValue": "Twake is open source, sovereign and European. No lock-in: your data belongs to you, and you can leave with it.",
+  "@onboardingSovereigntyValue": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingNotificationsTitle": "Never miss a message",
+  "@onboardingNotificationsTitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingNotificationsSubtitle": "Turn on notifications to know when your people message you. You stay in control — switch them off anytime.",
+  "@onboardingNotificationsSubtitle": {
+    "type": "text",
+    "placeholders": {}
+  },
+  "onboardingNotificationsAllow": "Turn on notifications",
+  "@onboardingNotificationsAllow": {
+    "type": "text",
+    "placeholders": {}
   }
 }

--- a/lib/config/go_routes/app_routes.dart
+++ b/lib/config/go_routes/app_routes.dart
@@ -23,6 +23,8 @@ import 'package:fluffychat/pages/login/on_auth_redirect.dart';
 import 'package:fluffychat/pages/new_group/new_group.dart';
 import 'package:fluffychat/pages/new_group/new_group_chat_info.dart';
 import 'package:fluffychat/pages/new_private_chat/new_private_chat.dart';
+import 'package:fluffychat/pages/onboarding/onboarding.dart';
+import 'package:fluffychat/pages/onboarding/onboarding_payoff_page.dart';
 import 'package:fluffychat/pages/personal_qr/personal_qr.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_3pid/settings_3pid.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_app_language/settings_app_language.dart';
@@ -44,6 +46,7 @@ import 'package:fluffychat/pages/twake_welcome/twake_welcome.dart';
 import 'package:fluffychat/presentation/model/chat/chat_router_input_argument.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
 import 'package:fluffychat/presentation/model/forward/forward_argument.dart';
+import 'package:fluffychat/utils/onboarding_settings.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/widgets/layouts/adaptive_layout/app_adaptive_scaffold.dart';
@@ -112,10 +115,16 @@ class RootRoute extends GoRouteData with $RootRoute {
   const RootRoute();
 
   @override
-  FutureOr<String?> redirect(BuildContext context, GoRouterState state) =>
-      Matrix.of(context).isLoggedInClient()
-      ? const RoomsRoute().location
-      : const HomeRoute().location;
+  FutureOr<String?> redirect(BuildContext context, GoRouterState state) async {
+    // Onboarding runs before authentication: show it on first app launch
+    // (mobile only) until completed, then route to auth or the chat list.
+    if (PlatformInfos.isMobile && !await OnboardingSettings.isCompleted()) {
+      return const OnboardingRoute().location;
+    }
+    return Matrix.of(context).isLoggedInClient()
+        ? const RoomsRoute().location
+        : const HomeRoute().location;
+  }
 
   // Never displayed — always redirects.
   @override
@@ -190,6 +199,29 @@ class HomeHomeserverPickerRoute extends GoRouteData
           arg: HomeserverPickerArg(type: HomeserverPickerType.singleAccount),
         ),
       );
+}
+
+@TypedGoRoute<OnboardingRoute>(path: '/onboarding')
+class OnboardingRoute extends GoRouteData with $OnboardingRoute {
+  const OnboardingRoute();
+
+  // Pre-auth: reachable while logged out, no redirect guard.
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      _defaultPage(context, const Onboarding());
+}
+
+@TypedGoRoute<OnboardingPayoffRoute>(path: '/onboarding/payoff')
+class OnboardingPayoffRoute extends GoRouteData with $OnboardingPayoffRoute {
+  const OnboardingPayoffRoute();
+
+  @override
+  FutureOr<String?> redirect(BuildContext context, GoRouterState state) =>
+      _loggedOutRedirect(context, state);
+
+  @override
+  Page<void> buildPage(BuildContext context, GoRouterState state) =>
+      _defaultPage(context, const OnboardingPayoffPage());
 }
 
 @TypedGoRoute<OnAuthRedirectRoute>(path: '/onAuthRedirect')

--- a/lib/pages/login/login.dart
+++ b/lib/pages/login/login.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:fluffychat/presentation/model/client_login_state_event.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:fluffychat/widgets/layouts/agruments/logged_in_body_args.dart';
 import 'package:fluffychat/widgets/layouts/agruments/logged_in_other_account_body_args.dart';
 import 'package:fluffychat/widgets/twake_app.dart';
@@ -141,10 +142,17 @@ class LoginController extends State<Login> {
     }
   }
 
-  void _handleFirstLoggedIn(Client client) {
+  void _handleFirstLoggedIn(Client client) async {
     if (!mounted) return;
 
     TwakeDialog.hideLoadingDialog(context);
+
+    // If onboarding (pre-auth) got contacts permission, reveal the matched
+    // contacts now that an access token is available.
+    if (PlatformInfos.isMobile && await Permission.contacts.isGranted) {
+      TwakeApp.router.go('/onboarding/payoff');
+      return;
+    }
 
     TwakeApp.router.go(
       '/rooms',

--- a/lib/pages/onboarding/onboarding.dart
+++ b/lib/pages/onboarding/onboarding.dart
@@ -1,0 +1,117 @@
+import 'package:fluffychat/pages/onboarding/onboarding_view.dart';
+import 'package:fluffychat/utils/onboarding_settings.dart';
+import 'package:fluffychat/utils/permission_service.dart';
+import 'package:fluffychat/widgets/twake_app.dart';
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+enum OnboardingStep {
+  hook,
+  privacy,
+  ai,
+  sovereignty,
+  notifications,
+  contacts;
+
+  bool get isLast => this == OnboardingStep.values.last;
+}
+
+/// Pre-auth value onboarding. A short hook, three "eye-opening" questions that
+/// each surface a concern Twake answers (privacy, AI, sovereignty), then the
+/// notifications and contacts permission asks. The contacts match reveal
+/// (payoff) runs after the first login — see [OnboardingPayoffPage].
+class Onboarding extends StatefulWidget {
+  const Onboarding({super.key});
+
+  @override
+  State<Onboarding> createState() => OnboardingController();
+}
+
+class OnboardingController extends State<Onboarding> {
+  static const Duration animationDuration = Duration(milliseconds: 300);
+  static const Curve animationCurve = Curves.easeInOut;
+
+  final PageController pageController = PageController();
+
+  final PermissionHandlerService _permissionService =
+      PermissionHandlerService();
+
+  final ValueNotifier<OnboardingStep> currentStepNotifier = ValueNotifier(
+    OnboardingStep.hook,
+  );
+
+  final ValueNotifier<bool> isRequestingContactsNotifier = ValueNotifier(false);
+
+  final ValueNotifier<bool> isRequestingNotificationsNotifier = ValueNotifier(
+    false,
+  );
+
+  void onPageChanged(int index) {
+    currentStepNotifier.value = OnboardingStep.values[index];
+  }
+
+  void goToNextStep() {
+    final current = currentStepNotifier.value;
+    if (current.isLast) {
+      _finishOnboarding();
+      return;
+    }
+    _animateTo(OnboardingStep.values[current.index + 1]);
+  }
+
+  void _animateTo(OnboardingStep step) {
+    pageController.animateToPage(
+      step.index,
+      duration: animationDuration,
+      curve: animationCurve,
+    );
+  }
+
+  Future<void> onRequestNotificationsPermission() async {
+    if (isRequestingNotificationsNotifier.value) return;
+    isRequestingNotificationsNotifier.value = true;
+    try {
+      await Permission.notification.request();
+      if (!mounted) return;
+      goToNextStep();
+    } finally {
+      if (mounted) isRequestingNotificationsNotifier.value = false;
+    }
+  }
+
+  Future<void> onRequestContactsPermission() async {
+    if (isRequestingContactsNotifier.value) return;
+    isRequestingContactsNotifier.value = true;
+    try {
+      // Request the OS permission now; the actual address-book sync runs
+      // after login (when an access token is available).
+      await _permissionService.requestContactsPermissionActions();
+      if (!mounted) return;
+      goToNextStep();
+    } finally {
+      if (mounted) isRequestingContactsNotifier.value = false;
+    }
+  }
+
+  void onSkipStep() => goToNextStep();
+
+  Future<void> _finishOnboarding() async {
+    await OnboardingSettings.setCompleted();
+    if (!mounted) return;
+    // Hand back to the root route, which sends the user to the auth screen
+    // (or straight to the chat list if already logged in).
+    TwakeApp.router.go('/');
+  }
+
+  @override
+  void dispose() {
+    pageController.dispose();
+    currentStepNotifier.dispose();
+    isRequestingContactsNotifier.dispose();
+    isRequestingNotificationsNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => OnboardingView(controller: this);
+}

--- a/lib/pages/onboarding/onboarding_payoff_page.dart
+++ b/lib/pages/onboarding/onboarding_payoff_page.dart
@@ -1,0 +1,71 @@
+import 'package:dartz/dartz.dart' hide State;
+import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/app_state/success.dart';
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/domain/contact_manager/contacts_manager.dart';
+import 'package:fluffychat/pages/onboarding/steps/onboarding_payoff_step.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/twake_app.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+/// Shown right after the first login when contacts permission was granted
+/// during onboarding. Runs the address-book sync and reveals the contacts
+/// already on Twake (the onboarding payoff), then lands on the chat list.
+class OnboardingPayoffPage extends StatefulWidget {
+  const OnboardingPayoffPage({super.key});
+
+  @override
+  State<OnboardingPayoffPage> createState() => _OnboardingPayoffPageState();
+}
+
+class _OnboardingPayoffPageState extends State<OnboardingPayoffPage> {
+  final ContactsManager _contactsManager = getIt.get<ContactsManager>();
+
+  final ValueNotifier<bool> _syncStartedNotifier = ValueNotifier(true);
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _startSync());
+  }
+
+  void _startSync() {
+    final userId = Matrix.of(context).client.userID;
+    if (userId == null) {
+      _finish();
+      return;
+    }
+    _contactsManager.initialSynchronizeContacts(
+      isAvailableSupportPhonebookContacts: true,
+      withMxId: userId,
+      forceRun: true,
+    );
+  }
+
+  void _finish() => TwakeApp.router.go('/rooms');
+
+  @override
+  void dispose() {
+    _syncStartedNotifier.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: LinagoraSysColors.material().background,
+      body: SafeArea(
+        child: OnboardingPayoffStep(
+          syncStartedNotifier: _syncStartedNotifier,
+          phonebookContactsListenable: _phonebookListenable,
+          onFinish: _finish,
+        ),
+      ),
+    );
+  }
+
+  ValueListenable<Either<Failure, Success>> get _phonebookListenable =>
+      _contactsManager.getPhonebookContactsNotifier();
+}

--- a/lib/pages/onboarding/onboarding_view.dart
+++ b/lib/pages/onboarding/onboarding_view.dart
@@ -1,0 +1,102 @@
+import 'package:fluffychat/pages/onboarding/onboarding.dart';
+import 'package:fluffychat/pages/onboarding/onboarding_view_style.dart';
+import 'package:fluffychat/pages/onboarding/steps/onboarding_contacts_step.dart';
+import 'package:fluffychat/pages/onboarding/steps/onboarding_hook_step.dart';
+import 'package:fluffychat/pages/onboarding/steps/onboarding_notifications_step.dart';
+import 'package:fluffychat/pages/onboarding/steps/onboarding_question_step.dart';
+import 'package:flutter/material.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+class OnboardingView extends StatelessWidget {
+  final OnboardingController controller;
+
+  const OnboardingView({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final colors = LinagoraSysColors.material();
+    return Scaffold(
+      backgroundColor: colors.background,
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: PageView(
+                controller: controller.pageController,
+                physics: const NeverScrollableScrollPhysics(),
+                onPageChanged: controller.onPageChanged,
+                children: [
+                  OnboardingHookStep(onContinue: controller.goToNextStep),
+                  OnboardingQuestionStep(
+                    question: l10n.onboardingPrivacyQuestion,
+                    valueReveal: l10n.onboardingPrivacyValue,
+                    onContinue: controller.goToNextStep,
+                  ),
+                  OnboardingQuestionStep(
+                    question: l10n.onboardingAiQuestion,
+                    valueReveal: l10n.onboardingAiValue,
+                    onContinue: controller.goToNextStep,
+                  ),
+                  OnboardingQuestionStep(
+                    question: l10n.onboardingSovereigntyQuestion,
+                    valueReveal: l10n.onboardingSovereigntyValue,
+                    onContinue: controller.goToNextStep,
+                  ),
+                  OnboardingNotificationsStep(
+                    isRequestingNotifier:
+                        controller.isRequestingNotificationsNotifier,
+                    onAllow: controller.onRequestNotificationsPermission,
+                    onSkip: controller.onSkipStep,
+                  ),
+                  OnboardingContactsStep(
+                    isRequestingNotifier:
+                        controller.isRequestingContactsNotifier,
+                    onAllow: controller.onRequestContactsPermission,
+                    onSkip: controller.onSkipStep,
+                  ),
+                ],
+              ),
+            ),
+            _PageIndicator(currentStepNotifier: controller.currentStepNotifier),
+            const SizedBox(height: 16.0),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PageIndicator extends StatelessWidget {
+  final ValueNotifier<OnboardingStep> currentStepNotifier;
+
+  const _PageIndicator({required this.currentStepNotifier});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = LinagoraSysColors.material();
+    return ValueListenableBuilder<OnboardingStep>(
+      valueListenable: currentStepNotifier,
+      builder: (context, current, _) {
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: OnboardingStep.values.map((step) {
+            final isActive = step == current;
+            return Container(
+              width: OnboardingViewStyle.pageIndicatorSize,
+              height: OnboardingViewStyle.pageIndicatorSize,
+              margin: const EdgeInsets.symmetric(
+                horizontal: OnboardingViewStyle.pageIndicatorSpacing / 2,
+              ),
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: isActive ? colors.primary : colors.outlineVariant,
+              ),
+            );
+          }).toList(),
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/onboarding/onboarding_view_style.dart
+++ b/lib/pages/onboarding/onboarding_view_style.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class OnboardingViewStyle {
+  static const EdgeInsets screenPadding = EdgeInsets.symmetric(
+    horizontal: 24.0,
+    vertical: 32.0,
+  );
+
+  static const double iconBadgeSize = 88.0;
+  static const double iconSize = 40.0;
+
+  static const double titleSpacing = 24.0;
+  static const double subtitleSpacing = 16.0;
+
+  static const double optionSpacing = 12.0;
+  static const EdgeInsets optionPadding = EdgeInsets.symmetric(
+    horizontal: 16.0,
+    vertical: 16.0,
+  );
+  static const double optionRadius = 16.0;
+
+  static const double buttonHeight = 52.0;
+  static const double buttonRadius = 100.0;
+
+  static const double pageIndicatorSize = 8.0;
+  static const double pageIndicatorSpacing = 8.0;
+
+  static const double avatarSize = 44.0;
+  static const double avatarItemSpacing = 12.0;
+}

--- a/lib/pages/onboarding/steps/onboarding_contacts_step.dart
+++ b/lib/pages/onboarding/steps/onboarding_contacts_step.dart
@@ -1,0 +1,80 @@
+import 'package:fluffychat/pages/onboarding/onboarding_view_style.dart';
+import 'package:fluffychat/pages/onboarding/widgets/onboarding_primary_button.dart';
+import 'package:flutter/material.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+class OnboardingContactsStep extends StatelessWidget {
+  final ValueNotifier<bool> isRequestingNotifier;
+  final VoidCallback onAllow;
+  final VoidCallback onSkip;
+
+  const OnboardingContactsStep({
+    super.key,
+    required this.isRequestingNotifier,
+    required this.onAllow,
+    required this.onSkip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final colors = LinagoraSysColors.material();
+    final theme = Theme.of(context);
+    return Padding(
+      padding: OnboardingViewStyle.screenPadding,
+      child: Column(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: OnboardingViewStyle.iconBadgeSize,
+                  height: OnboardingViewStyle.iconBadgeSize,
+                  decoration: BoxDecoration(
+                    color: colors.secondaryContainer,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.contacts_outlined,
+                    size: OnboardingViewStyle.iconSize,
+                    color: colors.primary,
+                  ),
+                ),
+                const SizedBox(height: OnboardingViewStyle.titleSpacing),
+                Text(
+                  l10n.onboardingContactsTitle,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: colors.onSurface,
+                  ),
+                ),
+                const SizedBox(height: OnboardingViewStyle.subtitleSpacing),
+                Text(
+                  l10n.onboardingContactsSubtitle,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          ValueListenableBuilder<bool>(
+            valueListenable: isRequestingNotifier,
+            builder: (context, isRequesting, _) {
+              return OnboardingPrimaryButton(
+                label: l10n.onboardingContactsAllow,
+                isLoading: isRequesting,
+                onTap: onAllow,
+              );
+            },
+          ),
+          const SizedBox(height: 8.0),
+          OnboardingTextButton(label: l10n.onboardingLater, onTap: onSkip),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding/steps/onboarding_hook_step.dart
+++ b/lib/pages/onboarding/steps/onboarding_hook_step.dart
@@ -1,0 +1,65 @@
+import 'package:fluffychat/pages/onboarding/onboarding_view_style.dart';
+import 'package:fluffychat/pages/onboarding/widgets/onboarding_primary_button.dart';
+import 'package:flutter/material.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+class OnboardingHookStep extends StatelessWidget {
+  final VoidCallback onContinue;
+
+  const OnboardingHookStep({super.key, required this.onContinue});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final colors = LinagoraSysColors.material();
+    final theme = Theme.of(context);
+    return Padding(
+      padding: OnboardingViewStyle.screenPadding,
+      child: Column(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: OnboardingViewStyle.iconBadgeSize,
+                  height: OnboardingViewStyle.iconBadgeSize,
+                  decoration: BoxDecoration(
+                    color: colors.secondaryContainer,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.shield_outlined,
+                    size: OnboardingViewStyle.iconSize,
+                    color: colors.primary,
+                  ),
+                ),
+                const SizedBox(height: OnboardingViewStyle.titleSpacing),
+                Text(
+                  l10n.onboardingHookTitle,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: colors.onSurface,
+                  ),
+                ),
+                const SizedBox(height: OnboardingViewStyle.subtitleSpacing),
+                Text(
+                  l10n.onboardingHookSubtitle,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          OnboardingPrimaryButton(
+            label: l10n.onboardingContinue,
+            onTap: onContinue,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding/steps/onboarding_notifications_step.dart
+++ b/lib/pages/onboarding/steps/onboarding_notifications_step.dart
@@ -1,0 +1,80 @@
+import 'package:fluffychat/pages/onboarding/onboarding_view_style.dart';
+import 'package:fluffychat/pages/onboarding/widgets/onboarding_primary_button.dart';
+import 'package:flutter/material.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+class OnboardingNotificationsStep extends StatelessWidget {
+  final ValueNotifier<bool> isRequestingNotifier;
+  final VoidCallback onAllow;
+  final VoidCallback onSkip;
+
+  const OnboardingNotificationsStep({
+    super.key,
+    required this.isRequestingNotifier,
+    required this.onAllow,
+    required this.onSkip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final colors = LinagoraSysColors.material();
+    final theme = Theme.of(context);
+    return Padding(
+      padding: OnboardingViewStyle.screenPadding,
+      child: Column(
+        children: [
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  width: OnboardingViewStyle.iconBadgeSize,
+                  height: OnboardingViewStyle.iconBadgeSize,
+                  decoration: BoxDecoration(
+                    color: colors.secondaryContainer,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.notifications_outlined,
+                    size: OnboardingViewStyle.iconSize,
+                    color: colors.primary,
+                  ),
+                ),
+                const SizedBox(height: OnboardingViewStyle.titleSpacing),
+                Text(
+                  l10n.onboardingNotificationsTitle,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: colors.onSurface,
+                  ),
+                ),
+                const SizedBox(height: OnboardingViewStyle.subtitleSpacing),
+                Text(
+                  l10n.onboardingNotificationsSubtitle,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          ValueListenableBuilder<bool>(
+            valueListenable: isRequestingNotifier,
+            builder: (context, isRequesting, _) {
+              return OnboardingPrimaryButton(
+                label: l10n.onboardingNotificationsAllow,
+                isLoading: isRequesting,
+                onTap: onAllow,
+              );
+            },
+          ),
+          const SizedBox(height: 8.0),
+          OnboardingTextButton(label: l10n.onboardingLater, onTap: onSkip),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding/steps/onboarding_payoff_step.dart
+++ b/lib/pages/onboarding/steps/onboarding_payoff_step.dart
@@ -1,0 +1,229 @@
+import 'package:dartz/dartz.dart' hide State;
+import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/app_state/success.dart';
+import 'package:fluffychat/domain/app_state/contact/get_phonebook_contact_state.dart';
+import 'package:fluffychat/domain/model/contact/contact.dart';
+import 'package:fluffychat/pages/onboarding/onboarding_view_style.dart';
+import 'package:fluffychat/pages/onboarding/widgets/onboarding_primary_button.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+class OnboardingPayoffStep extends StatelessWidget {
+  static const int _maxAvatars = 3;
+
+  final ValueNotifier<bool> syncStartedNotifier;
+  final ValueListenable<Either<Failure, Success>> phonebookContactsListenable;
+  final VoidCallback onFinish;
+
+  const OnboardingPayoffStep({
+    super.key,
+    required this.syncStartedNotifier,
+    required this.phonebookContactsListenable,
+    required this.onFinish,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: OnboardingViewStyle.screenPadding,
+      child: ValueListenableBuilder<bool>(
+        valueListenable: syncStartedNotifier,
+        builder: (context, syncStarted, _) {
+          if (!syncStarted) {
+            return _PayoffContent(
+              matched: const [],
+              isLoading: false,
+              onFinish: onFinish,
+            );
+          }
+          return ValueListenableBuilder<Either<Failure, Success>>(
+            valueListenable: phonebookContactsListenable,
+            builder: (context, state, __) {
+              final matched = _matchedContacts(state);
+              final isLoading = _isLoading(state);
+              return _PayoffContent(
+                matched: matched,
+                isLoading: isLoading,
+                onFinish: onFinish,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  bool _isLoading(Either<Failure, Success> state) {
+    return state.fold((failure) => false, (success) {
+      if (success is GetPhonebookContactsLoading) return true;
+      if (success is GetPhonebookContactsSuccess) {
+        return success.progress < 100;
+      }
+      return true;
+    });
+  }
+
+  List<Contact> _matchedContacts(Either<Failure, Success> state) {
+    return state.fold(
+      (failure) => const [],
+      (success) =>
+          success is GetPhonebookContactsSuccess ? success.contacts : const [],
+    );
+  }
+}
+
+class _PayoffContent extends StatelessWidget {
+  final List<Contact> matched;
+  final bool isLoading;
+  final VoidCallback onFinish;
+
+  const _PayoffContent({
+    required this.matched,
+    required this.isLoading,
+    required this.onFinish,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final colors = LinagoraSysColors.material();
+    final theme = Theme.of(context);
+    final hasMatches = matched.isNotEmpty;
+
+    return Column(
+      children: [
+        Expanded(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (isLoading) ...[
+                CircularProgressIndicator(color: colors.primary),
+                const SizedBox(height: OnboardingViewStyle.titleSpacing),
+                Text(
+                  l10n.onboardingPayoffLoading,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
+                ),
+              ] else ...[
+                Text(
+                  hasMatches
+                      ? l10n.onboardingPayoffTitle(matched.length)
+                      : l10n.onboardingPayoffEmptyTitle,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: colors.onSurface,
+                  ),
+                ),
+                const SizedBox(height: OnboardingViewStyle.subtitleSpacing),
+                Text(
+                  hasMatches
+                      ? l10n.onboardingPayoffSubtitle
+                      : l10n.onboardingPayoffEmptySubtitle,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: colors.onSurfaceVariant,
+                  ),
+                ),
+                if (hasMatches) ...[
+                  const SizedBox(height: OnboardingViewStyle.titleSpacing),
+                  _MatchedAvatars(matched: matched),
+                ],
+              ],
+            ],
+          ),
+        ),
+        OnboardingPrimaryButton(
+          label: hasMatches
+              ? l10n.onboardingPayoffStartChatting
+              : l10n.onboardingPayoffContinue,
+          onTap: isLoading ? null : onFinish,
+        ),
+      ],
+    );
+  }
+}
+
+class _MatchedAvatars extends StatelessWidget {
+  final List<Contact> matched;
+
+  const _MatchedAvatars({required this.matched});
+
+  String _initials(Contact contact) {
+    final name = contact.displayName?.trim() ?? '';
+    if (name.isEmpty) return '?';
+    final parts = name.split(RegExp(r'\s+'));
+    if (parts.length == 1) return parts.first.characters.first.toUpperCase();
+    return (parts.first.characters.first + parts.last.characters.first)
+        .toUpperCase();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = LinagoraSysColors.material();
+    final theme = Theme.of(context);
+    final visible = matched.take(OnboardingPayoffStep._maxAvatars).toList();
+    final remaining = matched.length - visible.length;
+    return Column(
+      children: [
+        for (final contact in visible)
+          Padding(
+            padding: const EdgeInsets.only(
+              bottom: OnboardingViewStyle.avatarItemSpacing,
+            ),
+            child: Row(
+              children: [
+                _InitialsAvatar(initials: _initials(contact)),
+                const SizedBox(width: 12.0),
+                Expanded(
+                  child: Text(
+                    contact.displayName ?? '',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: colors.onSurface,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        if (remaining > 0)
+          Text(
+            L10n.of(context)!.onboardingPayoffMoreContacts(remaining),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: colors.onSurfaceVariant,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _InitialsAvatar extends StatelessWidget {
+  final String initials;
+
+  const _InitialsAvatar({required this.initials});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = LinagoraSysColors.material();
+    return Container(
+      width: OnboardingViewStyle.avatarSize,
+      height: OnboardingViewStyle.avatarSize,
+      decoration: BoxDecoration(
+        color: colors.secondaryContainer,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        initials,
+        style: Theme.of(
+          context,
+        ).textTheme.titleMedium?.copyWith(color: colors.primary),
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding/steps/onboarding_question_step.dart
+++ b/lib/pages/onboarding/steps/onboarding_question_step.dart
@@ -1,0 +1,165 @@
+import 'package:fluffychat/pages/onboarding/onboarding_view_style.dart';
+import 'package:fluffychat/pages/onboarding/widgets/onboarding_primary_button.dart';
+import 'package:flutter/material.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+/// A single "eye-opening" question: a concern framed as a question, three
+/// answers (don't care / don't know / concerned), and a single value reveal
+/// shown once any answer is picked.
+class OnboardingQuestionStep extends StatefulWidget {
+  final String question;
+  final String valueReveal;
+  final VoidCallback onContinue;
+
+  const OnboardingQuestionStep({
+    super.key,
+    required this.question,
+    required this.valueReveal,
+    required this.onContinue,
+  });
+
+  @override
+  State<OnboardingQuestionStep> createState() => _OnboardingQuestionStepState();
+}
+
+class _OnboardingQuestionStepState extends State<OnboardingQuestionStep> {
+  int? _selectedIndex;
+
+  List<String> _answers(L10n l10n) => [
+    l10n.onboardingAnswerDontCare,
+    l10n.onboardingAnswerDontKnow,
+    l10n.onboardingAnswerConcerned,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    final colors = LinagoraSysColors.material();
+    final theme = Theme.of(context);
+    final answers = _answers(l10n);
+    final hasAnswered = _selectedIndex != null;
+
+    return Padding(
+      padding: OnboardingViewStyle.screenPadding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 8.0),
+          Text(
+            widget.question,
+            style: theme.textTheme.headlineMedium?.copyWith(
+              color: colors.onSurface,
+            ),
+          ),
+          const SizedBox(height: OnboardingViewStyle.titleSpacing),
+          for (var i = 0; i < answers.length; i++)
+            Padding(
+              padding: const EdgeInsets.only(
+                bottom: OnboardingViewStyle.optionSpacing,
+              ),
+              child: _AnswerOption(
+                label: answers[i],
+                isSelected: _selectedIndex == i,
+                onTap: () => setState(() => _selectedIndex = i),
+              ),
+            ),
+          Expanded(
+            child: AnimatedSwitcher(
+              duration: const Duration(milliseconds: 250),
+              child: hasAnswered
+                  ? Align(
+                      key: const ValueKey('reveal'),
+                      alignment: Alignment.topLeft,
+                      child: Container(
+                        margin: const EdgeInsets.only(top: 8.0),
+                        padding: OnboardingViewStyle.optionPadding,
+                        decoration: BoxDecoration(
+                          color: colors.secondaryContainer,
+                          borderRadius: BorderRadius.circular(
+                            OnboardingViewStyle.optionRadius,
+                          ),
+                        ),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Icon(
+                              Icons.verified_user_outlined,
+                              color: colors.primary,
+                            ),
+                            const SizedBox(width: 12.0),
+                            Expanded(
+                              child: Text(
+                                widget.valueReveal,
+                                style: theme.textTheme.bodyLarge?.copyWith(
+                                  color: colors.onSurface,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+            ),
+          ),
+          OnboardingPrimaryButton(
+            label: l10n.onboardingContinue,
+            onTap: hasAnswered ? widget.onContinue : null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AnswerOption extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _AnswerOption({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = LinagoraSysColors.material();
+    final theme = Theme.of(context);
+    return Material(
+      color: isSelected ? colors.secondaryContainer : colors.surface,
+      borderRadius: BorderRadius.circular(OnboardingViewStyle.optionRadius),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(OnboardingViewStyle.optionRadius),
+        onTap: onTap,
+        child: Container(
+          padding: OnboardingViewStyle.optionPadding,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(
+              OnboardingViewStyle.optionRadius,
+            ),
+            border: Border.all(
+              color: isSelected ? colors.primary : colors.outline,
+              width: isSelected ? 2.0 : 1.0,
+            ),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  label,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: colors.onSurface,
+                  ),
+                ),
+              ),
+              if (isSelected) Icon(Icons.check, color: colors.primary),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/onboarding/widgets/onboarding_primary_button.dart
+++ b/lib/pages/onboarding/widgets/onboarding_primary_button.dart
@@ -1,0 +1,79 @@
+import 'package:fluffychat/pages/onboarding/onboarding_view_style.dart';
+import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+
+class OnboardingPrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onTap;
+  final bool isLoading;
+
+  const OnboardingPrimaryButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = LinagoraSysColors.material();
+    return SizedBox(
+      width: double.infinity,
+      height: OnboardingViewStyle.buttonHeight,
+      child: Material(
+        color: colors.primary,
+        borderRadius: BorderRadius.circular(OnboardingViewStyle.buttonRadius),
+        clipBehavior: Clip.hardEdge,
+        child: InkWell(
+          onTap: isLoading ? null : onTap,
+          child: Center(
+            child: isLoading
+                ? SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2.5,
+                      color: colors.onPrimary,
+                    ),
+                  )
+                : Text(
+                    label,
+                    style: Theme.of(
+                      context,
+                    ).textTheme.labelLarge?.copyWith(color: colors.onPrimary),
+                  ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class OnboardingTextButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onTap;
+
+  const OnboardingTextButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = LinagoraSysColors.material();
+    return SizedBox(
+      width: double.infinity,
+      height: OnboardingViewStyle.buttonHeight,
+      child: TextButton(
+        onPressed: onTap,
+        child: Text(
+          label,
+          style: Theme.of(
+            context,
+          ).textTheme.labelLarge?.copyWith(color: colors.onSurfaceVariant),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -231,12 +231,10 @@ mixin class ContactsViewControllerMixin {
     required Client client,
     required MatrixLocalizations matrixLocalizations,
   }) async {
-    if (PlatformInfos.isMobile &&
-        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
-      await displayContactPermissionDialog(context);
-    } else {
-      await _initWarningBanner();
-    }
+    // Contacts permission is asked during onboarding, not via an automatic
+    // dialog on the Contacts page. Returning users who haven't granted access
+    // still see the warning banner (which can re-trigger the request).
+    await _initWarningBanner();
     _refreshAllContacts(
       context: context,
       client: client,

--- a/lib/utils/onboarding_settings.dart
+++ b/lib/utils/onboarding_settings.dart
@@ -1,0 +1,20 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Device-level flag tracking whether the value-onboarding flow has been
+/// completed (or explicitly skipped). Stored per device because the flow is
+/// about local permissions (contacts, notifications), not account state.
+class OnboardingSettings {
+  static const String _onboardingCompletedKey = 'onboarding_completed';
+
+  const OnboardingSettings._();
+
+  static Future<bool> isCompleted() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_onboardingCompletedKey) ?? false;
+  }
+
+  static Future<void> setCompleted() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_onboardingCompletedKey, true);
+  }
+}


### PR DESCRIPTION
## Why

New users land on an empty app — no content, no wow moment, high friction. Most never reach an aha and churn early. This onboarding shows Twake's **value before the empty state** and triggers an early engagement that lifts retention.

It's not a feature tour: three "eye-opening" questions surface concerns Twake answers (privacy, AI, sovereignty), turning each answer into a value reveal.

## What

Pre-auth flow on first launch (mobile), then auth (or chat list if already logged in):

| Step | Goal |
|---|---|
| Hook | Short welcome |
| Privacy / AI / Sovereignty | Value questions → single value reveal each |
| Notifications | Explain the benefit, ask permission |
| Contacts | See who's already on Twake, ask permission |

- Permissions asked in context, framed by value (OS request lives here now).
- Removes the abrupt auto contacts-permission dialog on the Contacts page (banner kept; other entry points untouched).
- Matched-contacts reveal (payoff) runs **after the first login**, where an access token is available.

<img width="660" height="1434" alt="IMG_6118" src="https://github.com/user-attachments/assets/5e2a2a4d-a5ca-4244-9602-822da1e3e1b8" />
<img width="660" height="1434" alt="IMG_6119" src="https://github.com/user-attachments/assets/5f2a98c9-bdcd-43a1-bd4e-48683aead3eb" />
<img width="660" height="1434" alt="IMG_6120" src="https://github.com/user-attachments/assets/383a7e4a-0de4-48b9-a716-0b19cc36590c" />
<img width="660" height="1434" alt="IMG_6123" src="https://github.com/user-attachments/assets/8b9277f9-08ff-4bda-8686-c34c1b1ca999" />
<img width="660" height="1434" alt="IMG_6124" src="https://github.com/user-attachments/assets/76ddc56b-022d-42e8-a6fd-226b7ca36a8b" />
<img width="660" height="1434" alt="IMG_6125" src="https://github.com/user-attachments/assets/34d70f8e-5acc-4fe2-9d13-8afcb7e0b700" />


## Notes

- Mobile only; web skips straight to auth.
- Completion flag persisted per device (`SharedPreferences`).
- Generated files (`*.g.dart`, l10n) are gitignored — rebuilt via `build_runner` / `gen-l10n`.
- Tests are a follow-up.
