### PR TITLE
TW-3134: Rewire Settings / Blocked Users Search to TextSearch (Part 5)

### DIFF
--- a/lib/pages/settings_dashboard/settings_blocked_users/settings_blocked_user.dart
+++ b/lib/pages/settings_dashboard/settings_blocked_users/settings_blocked_user.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/utils/search/search_engine.dart';
+import 'package:fluffychat/utils/search/search_options.dart';
 import 'package:fluffychat/pages/search/search_debouncer_mixin.dart';
 import 'package:fluffychat/pages/settings_dashboard/settings_blocked_users/settings_blocked_users_search_state.dart';
 import 'package:fluffychat/presentation/extensions/client_extension.dart';
@@ -91,12 +93,12 @@ class SettingsIgnoreListController extends State<BlockedUsers>
       return;
     }
 
-    final searchResults = blockedUsers.where((user) {
-      return (user.displayName ?? '').toLowerCase().contains(
-            searchTerm.toLowerCase(),
-          ) ||
-          (user.userId).toLowerCase().contains(searchTerm.toLowerCase());
-    }).toList();
+    final searchResults = getIt.get<SearchEngine>().matchAnyField<Profile>(
+      searchTerm,
+      blockedUsers,
+      fieldExtractors: [(user) => user.displayName, (user) => user.userId],
+      options: const SearchOptions(diacriticSensitive: false),
+    );
 
     Logs().d(
       "BlockedUsersController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/settings_dashboard/settings_blocked_users/settings_blocked_user.dart
+++ b/lib/pages/settings_dashboard/settings_blocked_users/settings_blocked_user.dart
@@ -96,7 +96,10 @@ class SettingsIgnoreListController extends State<BlockedUsers>
     final searchResults = getIt.get<SearchEngine>().matchAnyField<Profile>(
       searchTerm,
       blockedUsers,
-      fieldExtractors: [(user) => user.displayName, (user) => user.userId],
+      fieldExtractors: [
+        (user) => [user.displayName ?? ''],
+        (user) => [user.userId],
+      ],
       options: const SearchOptions(diacriticSensitive: false),
     );
 


### PR DESCRIPTION
## Ticket

- #3134

## Impact description

Simple rewiring of the blocked contacts search. Added support for diacritic-insensitive search, as well as easily customizable features through the `SearchEngine` component

## Test recommendations

Since the modifications are similar to what can be found in #3159 or #3173, I figured that unit tests wouldn't be necessary and that it would be preferable to test by directly checking the changes in the app, which has been done (see screenshots below)

## Resolved

- Web:
<img width="910" height="1155" alt="Screenshot From 2026-06-24 11-50-42" src="https://github.com/user-attachments/assets/57391213-fa72-4817-b423-6903aa253c42" />
<img width="910" height="1155" alt="Screenshot From 2026-06-24 11-50-53" src="https://github.com/user-attachments/assets/25e8d5b5-30e3-43fb-aa90-ef17b3955739" />
<img width="910" height="1155" alt="Screenshot From 2026-06-24 11-51-00" src="https://github.com/user-attachments/assets/1dd1896f-cd6d-4919-a764-9019d3b739b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocked-user search to match names and user IDs more reliably.
  * Search now handles accented characters and other diacritic variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->