### PR TITLE
feat(web): background Web Push notifications (VAPID)

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -1,6 +1,9 @@
 {
   "@@locale": "en",
   "@@last_modified": "2021-08-14 12:38:37.885451",
+  "enableNotificationsExplanation": "Turn on notifications to be alerted about new messages, even when Twake is closed.",
+  "webPushOnThisBrowser": "Notifications on this browser",
+  "webPushPermissionDeniedHint": "Notifications are blocked. Allow them for this site in your browser settings, then toggle this on.",
   "passwordsDoNotMatch": "Passwords do not match!",
   "pleaseEnterValidEmail": "Please enter a valid email address.",
   "repeatPassword": "Repeat password",
@@ -1466,6 +1469,7 @@
     "placeholders": {}
   },
   "openAppToReadMessages": "Open app to read messages",
+  "newMessage": "New message",
   "@openAppToReadMessages": {
     "type": "text",
     "placeholders": {}

--- a/assets/l10n/intl_fr.arb
+++ b/assets/l10n/intl_fr.arb
@@ -1270,6 +1270,8 @@
     "placeholders": {}
   },
   "openAppToReadMessages": "Ouvrez l'application pour lire le message",
+  "newMessage": "Nouveau message",
+  "enableNotificationsExplanation": "Activez les notifications pour être alerté des nouveaux messages, même quand Twake est fermé.",
   "@openAppToReadMessages": {
     "type": "text",
     "placeholders": {}

--- a/assets/l10n/intl_ru.arb
+++ b/assets/l10n/intl_ru.arb
@@ -1258,6 +1258,8 @@
     "placeholders": {}
   },
   "openAppToReadMessages": "Открыть приложение для чтения сообщений",
+  "newMessage": "Новое сообщение",
+  "enableNotificationsExplanation": "Включите уведомления, чтобы получать оповещения о новых сообщениях, даже когда Twake закрыт.",
   "@openAppToReadMessages": {
     "type": "text",
     "placeholders": {}

--- a/assets/l10n/intl_vi.arb
+++ b/assets/l10n/intl_vi.arb
@@ -1520,6 +1520,8 @@
     "placeholders": {}
   },
   "openAppToReadMessages": "Mở ứng dụng để đọc tin nhắn",
+  "newMessage": "Tin nhắn mới",
+  "enableNotificationsExplanation": "Bật thông báo để được nhắc về tin nhắn mới, ngay cả khi Twake đã đóng.",
   "@openAppToReadMessages": {
     "type": "text",
     "placeholders": {}

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -130,7 +130,10 @@ abstract class AppConfig {
   static const String pushNotificationsChannelName = 'Twake Chat push channel';
   static const String pushNotificationsChannelDescription =
       'Push notifications for Twake Chat';
-  static String pushNotificationsAppId = Platform.isIOS
+  // kIsWeb must be the outer ternary: Platform.isIOS throws on web.
+  static String pushNotificationsAppId = kIsWeb
+      ? "app.twake.web.chat"
+      : Platform.isIOS
       ? kReleaseMode
             ? "app.twake.ios.chat"
             : "app.twake.ios.chat.sandbox"
@@ -142,6 +145,17 @@ abstract class AppConfig {
   );
 
   static String pushNotificationsGatewayUrl = _pushNotificationsGatewayUrlEnv;
+
+  /// VAPID public key (base64url, raw P-256 point) for Web Push subscription.
+  /// Public — not a secret. Private key lives on the Sygnal gateway.
+  static const String _vapidPublicKeyEnv = String.fromEnvironment(
+    'VAPID_PUBLIC_KEY',
+  );
+
+  static String vapidPublicKey = _vapidPublicKeyEnv;
+
+  /// Gate Web Push rollout. Flipped via config.json `web_push_enabled`.
+  static bool webPushEnabled = false;
 
   static const String _supportEmailEnv = String.fromEnvironment(
     'SUPPORT_EMAIL',
@@ -326,6 +340,13 @@ abstract class AppConfig {
     if (json['cozy_external_bridge_version'] is String &&
         json['cozy_external_bridge_version'].isNotEmpty) {
       cozyExternalBridgeVersion = json['cozy_external_bridge_version'];
+    }
+    if (json['vapid_public_key'] is String &&
+        json['vapid_public_key'].isNotEmpty) {
+      vapidPublicKey = json['vapid_public_key'];
+    }
+    if (json['web_push_enabled'] is bool) {
+      webPushEnabled = json['web_push_enabled'];
     }
   }
 

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -26,6 +26,7 @@ import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/utils/tor_stub.dart'
     if (dart.library.html) 'package:tor_detector_web/tor_detector_web.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
+import 'package:fluffychat/utils/web_push/web_push.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/layouts/agruments/app_adaptive_scaffold_body_args.dart';
 import 'package:fluffychat/widgets/layouts/agruments/logged_in_body_args.dart';
@@ -40,6 +41,7 @@ import 'package:flutter_svg/svg.dart';
 import 'package:fluffychat/config/go_routes/app_routes.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
+import 'package:universal_html/html.dart' as html;
 
 import '../../../utils/account_bundles.dart';
 import '../../widgets/matrix.dart';
@@ -78,6 +80,7 @@ class ChatListController extends State<ChatList>
         GoToGroupChatMixin,
         TwakeContextMenuMixin {
   final responsive = getIt.get<ResponsiveUtils>();
+  bool _webPushPermissionSoftAskShown = false;
 
   final ValueNotifier<bool> expandRoomsForAllNotifier = ValueNotifier(true);
 
@@ -450,7 +453,8 @@ class ChatListController extends State<ChatList>
       });
 
       // Process cached sharing intents after first sync
-      matrixState.processCachedSharingIntents();
+      await matrixState.processCachedSharingIntents();
+      await _maybeShowWebPushPermissionSoftAsk();
     });
   }
 
@@ -467,7 +471,58 @@ class ChatListController extends State<ChatList>
     });
 
     // Process cached sharing intents after first sync
-    matrixState.processCachedSharingIntents();
+    await matrixState.processCachedSharingIntents();
+    await _maybeShowWebPushPermissionSoftAsk();
+  }
+
+  Future<void> _maybeShowWebPushPermissionSoftAsk() async {
+    if (!kIsWeb || _webPushPermissionSoftAskShown) return;
+    _webPushPermissionSoftAskShown = true;
+
+    await AppConfig.initConfigCompleter.future;
+    if (!mounted ||
+        !AppConfig.webPushEnabled ||
+        AppConfig.vapidPublicKey.isEmpty ||
+        await isWebPushDisabledByUser()) {
+      return;
+    }
+
+    if (html.Notification.permission == 'granted') {
+      await setupWebPush(activeClient);
+      return;
+    }
+    if (html.Notification.permission != 'default') return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted || html.Notification.permission != 'default') return;
+      final granted = await showDialog<bool>(
+        context: context,
+        barrierDismissible: false,
+        builder: (dialogContext) => AlertDialog(
+          icon: const Icon(Icons.notifications_active_outlined),
+          title: Text(L10n.of(dialogContext)!.notifications),
+          content: Text(L10n.of(dialogContext)!.enableNotificationsExplanation),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: Text(L10n.of(dialogContext)!.deny),
+            ),
+            TextButton(
+              onPressed: () async {
+                final permission = await html.Notification.requestPermission();
+                if (dialogContext.mounted) {
+                  Navigator.of(dialogContext).pop(permission == 'granted');
+                }
+              },
+              child: Text(L10n.of(dialogContext)!.allow),
+            ),
+          ],
+        ),
+      );
+      if (granted == true && mounted) {
+        await setWebPushEnabled(activeClient, true);
+      }
+    });
   }
 
   void editBundlesForAccount(String? userId, String? activeBundle) async {

--- a/lib/pages/settings_dashboard/settings_notifications/settings_notifications.dart
+++ b/lib/pages/settings_dashboard/settings_notifications/settings_notifications.dart
@@ -1,5 +1,8 @@
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
+import 'package:fluffychat/utils/web_push/web_push.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:adaptive_dialog/adaptive_dialog.dart';
@@ -90,6 +93,36 @@ class SettingsNotifications extends StatefulWidget {
 }
 
 class SettingsNotificationsController extends State<SettingsNotifications> {
+  /// Web Push on this browser. null while loading; web-only.
+  bool? webPushActive;
+  bool webPushPermissionDenied = false;
+
+  bool get showWebPushTile => kIsWeb && AppConfig.webPushEnabled;
+
+  @override
+  void initState() {
+    super.initState();
+    if (showWebPushTile) _loadWebPushStatus();
+  }
+
+  Future<void> _loadWebPushStatus() async {
+    final active = await isWebPushActive();
+    if (!mounted) return;
+    setState(() {
+      webPushActive = active;
+      webPushPermissionDenied = isWebPushPermissionDenied();
+    });
+  }
+
+  /// Single place to enable/disable Web Push: persists the choice (so a disabled
+  /// pusher stays gone) and (re)subscribes or tears down accordingly.
+  Future<void> toggleWebPush(bool enabled) async {
+    await TwakeDialog.showFutureLoadingDialogFullScreen(
+      future: () => setWebPushEnabled(Matrix.of(context).client, enabled),
+    );
+    await _loadWebPushStatus();
+  }
+
   bool? getNotificationSetting(NotificationSettingsItem item) {
     final pushRules = Matrix.of(context).client.globalPushRules;
     if (pushRules == null) return null;

--- a/lib/pages/settings_dashboard/settings_notifications/settings_notifications_view.dart
+++ b/lib/pages/settings_dashboard/settings_notifications/settings_notifications_view.dart
@@ -67,6 +67,30 @@ class SettingsNotificationsView extends StatelessWidget {
                             ),
                       ),
                 ),
+                if (controller.showWebPushTile) ...{
+                  const Divider(thickness: 1),
+                  SwitchListTile.adaptive(
+                    value: controller.webPushActive ?? false,
+                    title: Text(
+                      L10n.of(context)!.webPushOnThisBrowser,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurface,
+                      ),
+                    ),
+                    subtitle: controller.webPushPermissionDenied
+                        ? Text(
+                            L10n.of(context)!.webPushPermissionDeniedHint,
+                            style: Theme.of(context).textTheme.bodySmall
+                                ?.copyWith(
+                                  color: Theme.of(context).colorScheme.error,
+                                ),
+                          )
+                        : null,
+                    onChanged: controller.webPushPermissionDenied
+                        ? null
+                        : (enabled) => controller.toggleWebPush(enabled),
+                  ),
+                },
                 if (!Matrix.of(context).client.allPushNotificationsMuted) ...{
                   const Divider(thickness: 1),
                   ListTile(

--- a/lib/utils/web_push/web_push.dart
+++ b/lib/utils/web_push/web_push.dart
@@ -1,0 +1,3 @@
+// Conditional export: real Web Push impl on web, no-op stub elsewhere.
+// Matches the existing pattern (e.g. send_file_web_extension.dart).
+export 'web_push_stub.dart' if (dart.library.js_interop) 'web_push_web.dart';

--- a/lib/utils/web_push/web_push_stub.dart
+++ b/lib/utils/web_push/web_push_stub.dart
@@ -1,0 +1,16 @@
+import 'package:matrix/matrix.dart';
+
+/// No-op on non-web platforms. Mobile uses [BackgroundPush] instead.
+Future<void> setupWebPush(Client client) async {}
+
+Future<void> removeWebPush(Client client, {bool unsubscribe = true}) async {}
+
+Future<bool> isWebPushActive() async => false;
+
+Future<bool> isWebPushDisabledByUser() async => false;
+
+bool isWebPushActiveSync() => false;
+
+bool isWebPushPermissionDenied() => false;
+
+Future<void> setWebPushEnabled(Client client, bool enabled) async {}

--- a/lib/utils/web_push/web_push_web.dart
+++ b/lib/utils/web_push/web_push_web.dart
@@ -1,0 +1,300 @@
+import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:collection/collection.dart';
+import 'package:matrix/matrix.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web/web.dart' as web;
+
+import '../../config/app_config.dart';
+import '../../config/localizations/localization_service.dart';
+import '../../generated/l10n/app_localizations.dart';
+import '../platform_infos.dart';
+
+/// Local opt-out: the browser push subscription is per-device, so the choice to
+/// turn Web Push off lives in [SharedPreferences], not account data. While set,
+/// [setupWebPush] is a no-op — this is what makes a pusher deletion from the
+/// notification settings actually stick (otherwise the next reload re-creates
+/// it). Toggled through [setWebPushEnabled].
+const _webPushDisabledKey = 'web_push_disabled_by_user';
+
+Future<bool> _isWebPushDisabledByUser() async {
+  final prefs = await SharedPreferences.getInstance();
+  return prefs.getBool(_webPushDisabledKey) ?? false;
+}
+
+Future<bool> isWebPushDisabledByUser() => _isWebPushDisabledByUser();
+
+/// Cached, synchronous "Web Push is delivering" flag, updated by [setupWebPush].
+/// The in-app (Dart) notification path uses it to know whether the service
+/// worker already owns notifications: true → suppress the in-app one (avoid a
+/// duplicate); explicit opt-out is checked separately.
+bool _webPushActive = false;
+bool isWebPushActiveSync() => _webPushActive;
+
+/// Registers a standard Web Push (RFC 8030) subscription as a Matrix pusher,
+/// reusing the existing Sygnal `webpush` gateway. The Service Worker
+/// (`web/push_sw.js`) is registered by index.html after the app loads.
+///
+/// Does nothing unless Web Push is enabled, a VAPID key is configured, and the
+/// user has already granted notification permission (the prompt is a separate
+/// user-gesture step in onboarding — we never prompt here).
+Future<void> setupWebPush(Client client) async {
+  // Wait for config.json to load: on a warm start setupWebPush can run before
+  // loadFromJson, leaving webPushEnabled/vapidPublicKey at their defaults.
+  _webPushActive = false;
+  await AppConfig.initConfigCompleter.future;
+  if (!AppConfig.webPushEnabled) {
+    Logs().i('[WebPush] disabled (web_push_enabled=false)');
+    return;
+  }
+  if (AppConfig.vapidPublicKey.isEmpty) {
+    Logs().w('[WebPush] no VAPID public key configured');
+    return;
+  }
+  if (!client.isLogged()) return;
+  if (await _isWebPushDisabledByUser()) {
+    Logs().i('[WebPush] disabled by user (notification settings)');
+    return;
+  }
+  if (web.Notification.permission != 'granted') {
+    Logs().i('[WebPush] notification permission not granted');
+    return;
+  }
+
+  try {
+    final registration = await web.window.navigator.serviceWorker.ready.toDart;
+    final pushManager = registration.pushManager;
+
+    var subscription = await pushManager.getSubscription().toDart;
+    subscription ??= await pushManager
+        .subscribe(
+          web.PushSubscriptionOptionsInit(
+            userVisibleOnly: true,
+            applicationServerKey: _decodeVapidKey(
+              AppConfig.vapidPublicKey,
+            ).toJS,
+          ),
+        )
+        .toDart;
+
+    final sub = _WebPushSubscription.from(subscription);
+    if (!sub.isComplete) {
+      Logs().w('[WebPush] Subscription missing p256dh/auth, skipping');
+      return;
+    }
+    await _registerPusher(client, sub);
+    _webPushActive = true;
+  } catch (e, s) {
+    Logs().e('[WebPush] setup failed', e, s);
+  }
+}
+
+/// The subscription fields Sygnal's webpush pushkind needs.
+class _WebPushSubscription {
+  final String endpoint;
+  final String p256dh;
+  final String auth;
+
+  const _WebPushSubscription(this.endpoint, this.p256dh, this.auth);
+
+  factory _WebPushSubscription.from(web.PushSubscription sub) =>
+      _WebPushSubscription(
+        sub.endpoint,
+        _subKey(sub, 'p256dh'),
+        _subKey(sub, 'auth'),
+      );
+
+  bool get isComplete => p256dh.isNotEmpty && auth.isNotEmpty;
+}
+
+/// Whether Web Push is currently active on this browser: feature enabled, a
+/// VAPID key is set, the OS/browser permission is granted, and the user hasn't
+/// opted out. Drives the notification-settings toggle.
+Future<bool> isWebPushActive() async {
+  await AppConfig.initConfigCompleter.future;
+  if (!AppConfig.webPushEnabled || AppConfig.vapidPublicKey.isEmpty) {
+    return false;
+  }
+  if (web.Notification.permission != 'granted') return false;
+  return !(await _isWebPushDisabledByUser());
+}
+
+/// Whether the browser permission was permanently denied — the user must
+/// re-enable it in the browser site settings; the app can't re-prompt.
+bool isWebPushPermissionDenied() => web.Notification.permission == 'denied';
+
+/// Single entry point to enable/disable Web Push from the notification
+/// settings. Enabling clears the opt-out, requests permission if needed and
+/// (re)registers the pusher; disabling persists the opt-out and tears down the
+/// subscription + pusher so it does not silently come back on the next reload.
+Future<void> setWebPushEnabled(Client client, bool enabled) async {
+  final prefs = await SharedPreferences.getInstance();
+  if (enabled) {
+    await prefs.setBool(_webPushDisabledKey, false);
+    if (web.Notification.permission == 'default') {
+      await web.Notification.requestPermission().toDart;
+    }
+    await setupWebPush(client);
+  } else {
+    await prefs.setBool(_webPushDisabledKey, true);
+    await removeWebPush(client, unsubscribe: true);
+  }
+}
+
+/// Removes this client's Matrix pusher on logout.
+/// At logout the token is usually already gone, so [client.deletePusher] is
+/// best-effort; the local `unsubscribe()` makes the endpoint invalid and the
+/// gateway drops the stale pusher on the next push (410 Gone).
+///
+/// [unsubscribe] must be false for a partial (multi-account) logout: the browser
+/// push subscription is shared across accounts, so unsubscribing would break
+/// notifications for the accounts still signed in. Only the true last-account
+/// logout unsubscribes the browser.
+Future<void> removeWebPush(Client client, {bool unsubscribe = true}) async {
+  _webPushActive = false;
+  try {
+    final registration = await web.window.navigator.serviceWorker.ready.toDart;
+    final subscription = await registration.pushManager
+        .getSubscription()
+        .toDart;
+    if (subscription == null) return;
+    // pushkey == p256dh (Sygnal webpush contract).
+    final p256dh = _subKey(subscription, 'p256dh');
+    if (client.isLogged() && p256dh.isNotEmpty) {
+      final pushers = await client.getPushers().catchError((_) => <Pusher>[]);
+      final pusher = pushers?.firstWhereOrNull((p) => p.pushkey == p256dh);
+      if (pusher != null) await client.deletePusher(pusher);
+    }
+    if (unsubscribe) {
+      await subscription.unsubscribe().toDart;
+      Logs().i('[WebPush] Unsubscribed');
+    } else {
+      Logs().i(
+        '[WebPush] Pusher removed (subscription kept for other accounts)',
+      );
+    }
+  } catch (e, s) {
+    Logs().w('[WebPush] removeWebPush failed', e, s);
+  }
+}
+
+// event_id_only (same as mobile): the push carries NO message content — only
+// event_id/room_id. The SW shows a generic notification and the app fetches the
+// content when the user clicks it. No message content ever transits the push
+// service (FCM/Google), which is the privacy contract we keep on every platform.
+const String _webPusherFormat = 'event_id_only';
+
+Future<void> _registerPusher(Client client, _WebPushSubscription sub) async {
+  final pushers = await client.getPushers().catchError((e) {
+    Logs().w('[WebPush] Unable to request pushers', e);
+    return <Pusher>[];
+  });
+
+  // Remove every other web pusher for this device's app so the homeserver
+  // pushes to exactly one endpoint — leftover pushers from earlier
+  // subscriptions cause duplicate notifications. Runs even when the current
+  // pusher already exists. (Tradeoff: a second browser signed into the same
+  // account is evicted and re-registers on its next load.)
+  await _removeOtherWebPushers(client, pushers, sub.p256dh);
+
+  if (pushers?.any((p) => _isCurrentWebPusher(p, sub)) ?? false) {
+    Logs().i('[WebPush] Pusher already set');
+    return;
+  }
+
+  await client.postPusher(_buildWebPusher(client, sub), append: false);
+  Logs().i('[WebPush] Pusher registered');
+}
+
+/// Sygnal webpush contract: pushkey == p256dh, endpoint + auth in data.
+bool _isCurrentWebPusher(Pusher p, _WebPushSubscription sub) =>
+    p.pushkey == sub.p256dh &&
+    p.appId == AppConfig.pushNotificationsAppId &&
+    p.data.url.toString() == AppConfig.pushNotificationsGatewayUrl &&
+    p.data.additionalProperties['endpoint'] == sub.endpoint &&
+    p.data.additionalProperties['auth'] == sub.auth &&
+    p.data.additionalProperties['events_only'] == true &&
+    const DeepCollectionEquality().equals(
+      p.data.additionalProperties['default_payload'],
+      _localizedDefaultPayload(),
+    ) &&
+    p.data.format == _webPusherFormat;
+
+/// Remove web pushers for this app whose pushkey isn't the current p256dh:
+/// stale subscriptions and pre-contract endpoint-keyed pushers. Keeps exactly
+/// one live pusher so the homeserver doesn't fan out duplicate pushes.
+Future<void> _removeOtherWebPushers(
+  Client client,
+  List<Pusher>? pushers,
+  String currentP256dh,
+) async {
+  final stale =
+      pushers?.where(
+        (p) =>
+            p.appId == AppConfig.pushNotificationsAppId &&
+            p.pushkey != currentP256dh,
+      ) ??
+      const [];
+  for (final pusher in stale) {
+    try {
+      await client.deletePusher(pusher);
+      Logs().i('[WebPush] Removed stale web pusher');
+    } catch (e) {
+      Logs().w('[WebPush] Failed to remove stale pusher', e);
+    }
+  }
+}
+
+Pusher _buildWebPusher(Client client, _WebPushSubscription sub) {
+  final clientName = PlatformInfos.clientName;
+  return Pusher(
+    pushkey: sub.p256dh,
+    appId: AppConfig.pushNotificationsAppId,
+    appDisplayName: clientName,
+    deviceDisplayName: client.deviceName ?? clientName,
+    lang: 'en',
+    data: PusherData(
+      url: Uri.parse(AppConfig.pushNotificationsGatewayUrl),
+      format: _webPusherFormat,
+      // events_only: Sygnal drops pushes with no event_id (e.g. unread-count
+      // clears). Without it, userVisibleOnly:true forces the SW to show a
+      // phantom notification on every count change. (Sygnal webpush docs.)
+      additionalProperties: {
+        'endpoint': sub.endpoint,
+        'auth': sub.auth,
+        'events_only': true,
+        'default_payload': _localizedDefaultPayload(),
+      },
+    ),
+    kind: 'http',
+  );
+}
+
+/// Generic notification text in the account's app language. Sygnal echoes
+/// default_payload in every push, so the service worker can title/body the
+/// notification in the user's language. With event_id_only the push carries no
+/// event content — these are just localized, NEUTRAL boilerplate, never message
+/// content and never assuming encryption (the SW can't know the room type).
+/// Re-registered when the language changes (compared in [_isCurrentWebPusher]
+/// + a currentLocale listener in matrix.dart).
+Map<String, String> _localizedDefaultPayload() {
+  final l10n = lookupL10n(LocalizationService.currentLocale.value);
+  return {'title': AppConfig.applicationName, 'body': l10n.newMessage};
+}
+
+/// Subscription key (`p256dh` / `auth`) as unpadded base64url.
+String _subKey(web.PushSubscription sub, String name) {
+  final buffer = sub.getKey(name);
+  if (buffer == null) return '';
+  final bytes = buffer.toDart.asUint8List();
+  return base64Url.encode(bytes).replaceAll('=', '');
+}
+
+/// base64url (unpadded) → bytes, for `applicationServerKey`.
+Uint8List _decodeVapidKey(String base64Url) {
+  final normalized = base64Url.replaceAll('-', '+').replaceAll('_', '/');
+  final padded = normalized.padRight((normalized.length + 3) ~/ 4 * 4, '=');
+  return base64.decode(padded);
+}

--- a/lib/widgets/local_notifications_extension.dart
+++ b/lib/widgets/local_notifications_extension.dart
@@ -17,6 +17,7 @@ import 'package:universal_html/js.dart' as js;
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/utils/web_push/web_push.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 extension LocalNotificationsExtension on MatrixState {
@@ -27,8 +28,13 @@ extension LocalNotificationsExtension on MatrixState {
 
   void showLocalNotification(EventUpdate eventUpdate) async {
     final roomId = eventUpdate.roomID;
+    // On web the settings toggle owns all browser notifications for this tab:
+    // active Web Push is handled by push_sw.js; explicit opt-out suppresses the
+    // legacy Notification API fallback too.
+    if (kIsWeb && (isWebPushActiveSync() || await isWebPushDisabledByUser())) {
+      return;
+    }
     if (activeRoomId == roomId) {
-      if (kIsWeb && webHasFocus) return;
       if (PlatformInfos.isLinux && DesktopLifecycle.instance.isActive.value) {
         return;
       }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -69,6 +69,7 @@ import '../config/setting_keys.dart';
 import '../pages/key_verification/key_verification_dialog.dart';
 import '../utils/account_bundles.dart';
 import '../utils/background_push.dart';
+import '../utils/web_push/web_push.dart';
 import '../utils/famedlysdk_store.dart';
 import 'local_notifications_extension.dart';
 
@@ -385,6 +386,10 @@ class MatrixState extends State<Matrix>
   final onKeyVerificationRequestSub = <String, StreamSubscription>{};
   final onNotification = <String, StreamSubscription>{};
   final onLoginStateChanged = <String, StreamSubscription<LoginState>>{};
+
+  /// Re-registers the Web Push pusher when the app language changes so its
+  /// (generic) notification text follows the account language.
+  VoidCallback? _webPushLocaleListener;
   final onUiaRequest = <String, StreamSubscription<UiaRequest>>{};
   final StreamController<ClientLoginStateEvent> onClientLoginStateChanged =
       StreamController.broadcast();
@@ -527,8 +532,24 @@ class MatrixState extends State<Matrix>
       uiaRequestHandler,
     );
     if (PlatformInfos.isWeb || PlatformInfos.isLinux) {
-      currentClient.onSync.stream.first.then((s) async {
-        await _requestNotificationPermission();
+      Future<void> initWebNotifications() async {
+        if (kIsWeb) {
+          // ignore: unawaited_futures
+          setupWebPush(currentClient);
+          // Re-register on language change (and once the locale resolves after
+          // a cold start) so the generic notification text matches the account
+          // language. removeListener+addListener keeps a single live listener.
+          final listener = _webPushLocaleListener;
+          if (listener != null) {
+            LocalizationService.currentLocale.removeListener(listener);
+          }
+          _webPushLocaleListener = () => setupWebPush(currentClient);
+          LocalizationService.currentLocale.addListener(
+            _webPushLocaleListener!,
+          );
+        } else {
+          await _requestNotificationPermission();
+        }
         onNotification[name] ??= currentClient.onEvent.stream
             .where(
               (e) =>
@@ -539,7 +560,17 @@ class MatrixState extends State<Matrix>
                   e.content['sender'] != currentClient.userID,
             )
             .listen(showLocalNotification);
-      });
+      }
+
+      // On a warm start the first sync may already have happened before this
+      // listener attaches, so onSync.stream.first would never fire and web push
+      // setup would silently be skipped. Run immediately if already synced.
+      if (currentClient.prevBatch != null) {
+        // ignore: unawaited_futures
+        initWebNotifications();
+      } else {
+        currentClient.onSync.stream.first.then((_) => initWebNotifications());
+      }
     }
     currentClient.onToDeviceEvent.stream.listen((deviceEvent) {
       if (deviceEvent.type == TwakeEventTypes.addressBookUpdatedEventType) {
@@ -563,12 +594,11 @@ class MatrixState extends State<Matrix>
       final isInsideCozy = await CozyConfigManager().isInsideCozy;
       if (isInsideCozy) {
         CozyConfigManager().requestNotificationPermission();
-      } else {
-        html.Notification.requestPermission();
+        return;
       }
-    } catch (e) {
-      html.Notification.requestPermission();
-    }
+    } catch (_) {}
+
+    await html.Notification.requestPermission();
   }
 
   void _listenLoginStateChanged(LoginState state, Client client) async {
@@ -596,6 +626,10 @@ class MatrixState extends State<Matrix>
       backgroundPush?.cancelKeychainSyncForClient(currentClient);
       await backgroundPush?.removePusherForClient(currentClient);
     }
+
+    // Web: drop just this account's pusher, but keep the shared browser
+    // subscription alive for the accounts still signed in.
+    if (kIsWeb) await removeWebPush(currentClient, unsubscribe: false);
 
     await _cancelSubs(currentClient.clientName);
     widget.clients.remove(currentClient);
@@ -705,6 +739,11 @@ class MatrixState extends State<Matrix>
     onNotification.remove(name);
     await onUiaRequest[name]?.cancel();
     onUiaRequest.remove(name);
+    final webPushListener = _webPushLocaleListener;
+    if (webPushListener != null) {
+      LocalizationService.currentLocale.removeListener(webPushListener);
+      _webPushLocaleListener = null;
+    }
   }
 
   Future<void> initMatrix() async {
@@ -1210,6 +1249,7 @@ class MatrixState extends State<Matrix>
       await _deletePersistActiveAccount();
       TwakeApp.router.go(const HomeTwakeWelcomeRoute().location);
     } else {
+      if (kIsWeb) await removeWebPush(client);
       TwakeApp.router.go(const HomeRoute($extra: true).location, extra: true);
     }
     await _deleteAllTomConfigurations();

--- a/web/index.html
+++ b/web/index.html
@@ -94,7 +94,11 @@
             .getRegistrations()
             .then(async function(registrations) {
               try {
+                // Purge stale Flutter/legacy service workers (cache-busting workaround),
+                // but KEEP our Web Push SW so background notifications survive reloads.
                 await Promise.all(registrations.map(function(registration) {
+                  var url = (registration.active || registration.installing || registration.waiting || {}).scriptURL || '';
+                  if (url.indexOf('push_sw.js') !== -1) return Promise.resolve();
                   return registration.unregister();
                 }));
               } catch (error) {
@@ -105,6 +109,10 @@
                   const appRunner = await engineInitializer.initializeEngine({useColorEmoji: true});
                   await setTimeout( async function () {
                     await appRunner.runApp();
+                    // Register after runApp so this load's unregister sweep can't catch it.
+                    navigator.serviceWorker.register('push_sw.js').catch(function (error) {
+                      console.log('[Twake Chat] Error registering push service worker: ', error);
+                    });
                   }, 2000);
                 }
               });

--- a/web/push_sw.js
+++ b/web/push_sw.js
@@ -1,0 +1,99 @@
+/* Twake Chat — Web Push service worker (RFC 8030).
+ * Pusher is event_id_only (same privacy contract as mobile): the push carries
+ * NO message content — only event_id/room_id. The SW shows a generic
+ * notification; the app fetches the content when the user clicks it. No message
+ * content ever transits the push service. Sygnal's events_only flag suppresses
+ * content-less count-clear pushes, so every push maps to a real event
+ * (satisfies userVisibleOnly).
+ * ponytail: no JS test harness in this Flutter repo; covered by the manual
+ * chrome://discards freeze repro in the plan's acceptance criteria.
+ */
+
+// skipWaiting is required: without it a new SW version installs but stays in
+// `waiting` behind the old active worker while any tab is open, so users get
+// stuck on a stale worker until they manually unregister it (DevTools) — the
+// exact problem testers hit. skipWaiting promotes the new version to active on
+// the next load, replacing the old one with no user action.
+// No clients.claim(): a push SW only needs `push`/`notificationclick` on its
+// active worker, never to control app windows. (Verified: claim fires a
+// `controllerchange` but does NOT reload this app — flutter.js registers no SW
+// and has no controllerchange handler. Omitting claim is simply correct, not a
+// reload fix.)
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('push', function (event) {
+  var data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (e) {
+    data = {};
+  }
+  // event_id_only: Sygnal flattens the payload, so we get { event_id, room_id,
+  // counts, ... } plus the pusher's default_payload merged in at top level.
+  // title/body come from default_payload — generic, app-localized strings set
+  // at registration in the account language (NOT message content). Fall back to
+  // English constants if absent (e.g. a pre-default_payload pusher).
+  var n = data.notification || data || {};
+  var roomId = n.room_id || '';
+  var eventId = n.event_id || '';
+  var title = n.title || 'Twake Chat';
+  var body = n.body || 'New message';
+
+  // The SW is the single notification owner on web (foreground + background).
+  // Always show; the event_id tag dedupes repeats/retries of the same event.
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: body,
+      icon: 'icons/Icon-192.png',
+      badge: 'icons/Icon-192.png',
+      tag: eventId || roomId || 'twake-message',
+      renotify: true,
+      data: { roomId: roomId, eventId: eventId },
+    })
+  );
+});
+
+self.addEventListener('pushsubscriptionchange', function (event) {
+  // Endpoint rotated (expiry/reset). Re-subscribe so pushes keep arriving;
+  // the Matrix pusher is re-synced by setupWebPush on the next app open
+  // (it drops the stale pusher). applicationServerKey accepts the base64url
+  // VAPID string directly. ponytail: read the key from config.json so the SW
+  // stays config-driven without a build step.
+  event.waitUntil(
+    fetch('config.json')
+      .then(function (r) { return r.json(); })
+      .then(function (cfg) {
+        if (!cfg || !cfg.vapid_public_key) return;
+        return self.registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: cfg.vapid_public_key,
+        });
+      })
+      .catch(function (error) {
+        console.log('[Twake Chat] pushsubscriptionchange re-subscribe failed: ', error);
+      })
+  );
+});
+
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close();
+  var roomId = (event.notification.data || {}).roomId || '';
+  var target = roomId ? '/#/rooms/' + roomId : '/';
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then(function (clientList) {
+        for (var i = 0; i < clientList.length; i++) {
+          var client = clientList[i];
+          if ('focus' in client) {
+            if (roomId && 'navigate' in client) client.navigate(target);
+            return client.focus();
+          }
+        }
+        if (self.clients.openWindow) return self.clients.openWindow(target);
+      })
+  );
+});

--- a/web/script.js
+++ b/web/script.js
@@ -1,27 +1,23 @@
 function handleNotifications(title, body, icon, roomid, eventId) {
     if ('Notification' in window) {
-        Notification.requestPermission().then(function(permission) {
-            if (permission === 'granted') {
-                var notification = new Notification(title, {
-                    body: body,
-                    icon: icon,
-                });
-
-                notification.onclick = function() {
-                    console.log('JsFunction::handleNotifications(): On click notification');
-                    var hrefSplit = window.location.href.split('/');
-                    var indexRooms = hrefSplit.indexOf('rooms');
-                    var redirectURL = hrefSplit.splice(0, indexRooms + 1).join('/') + '/' + roomid + (eventId ? '?event=' + eventId : '')
-                    window.parent.parent.focus();
-                    window.location.href = redirectURL;
-                    notification.close();
-                };
-            } else {
-                console.log('Permission for notifications denied');
-            }
-        }).catch(function(err) {
-            console.error('Error requesting permission:', err);
+        if (Notification.permission !== 'granted') {
+            console.log('Notifications not granted');
+            return;
+        }
+        var notification = new Notification(title, {
+            body: body,
+            icon: icon,
         });
+
+        notification.onclick = function() {
+            console.log('JsFunction::handleNotifications(): On click notification');
+            var hrefSplit = window.location.href.split('/');
+            var indexRooms = hrefSplit.indexOf('rooms');
+            var redirectURL = hrefSplit.splice(0, indexRooms + 1).join('/') + '/' + roomid + (eventId ? '?event=' + eventId : '')
+            window.parent.parent.focus();
+            window.location.href = redirectURL;
+            notification.close();
+        };
     } else {
         console.log('Notifications not supported in this browser');
     }


### PR DESCRIPTION
## What

Background **Web Push** notifications on Flutter Web — delivered even when the tab is closed or frozen. Reuses the existing Sygnal `webpush` gateway (`push.twake.app`) + VAPID. Mobile/desktop paths untouched (web-only branches; a no-op stub on other platforms).

## How it works

| Step | Detail |
|------|--------|
| Subscribe | `pushManager.subscribe` with the VAPID public key (config.json `vapid_public_key`); pusher registered with `pushkey = p256dh`, `endpoint`/`auth` in `data` |
| Format | **`event_id_only`** (same privacy contract as mobile): the push carries **no message content** — only `event_id`/`room_id`. Nothing sensitive transits the push service |
| Notification text | generic, in the **account's app language**: pusher `default_payload = {title: app name, body: localized "New message"}` (Sygnal echoes it; the SW reads it). Re-registered when the app language changes |
| `events_only` | Sygnal drops content-less pushes (unread-count clears), so `userVisibleOnly:true` never forces a phantom notification |
| Service worker | `web/push_sw.js`: single notification owner (foreground + background), `skipWaiting` (no `clients.claim` → no forced reload), dedupe by `event_id`, click → `/#/rooms/<id>`. Never reads message content |
| Permission | in-app soft-ask dialog before the native prompt (only when undecided), so the one-shot native prompt fires on a real user gesture |

## Settings integration

Settings → Notifications gains a **web-only toggle** ("Notifications on this browser"):
- **off** persists an opt-out (per-browser) and tears down the subscription + pusher; `setupWebPush` honors the opt-out so it does **not** silently come back on reload (no phantom pusher);
- **on** clears it, requests permission if needed, re-registers;
- reflects the browser permission-denied state (toggle disabled + hint).

## Verification (live, end-to-end)

- Delivery confirmed foreground **and** background (tab frozen via `chrome://discards`) on Chrome and Arc: Sygnal → FCM → SW → `showNotification`.
- Push carrying message content → SW still shows the generic text (no leak).
- Notification follows the account language (FR account → "Nouveau message").
- Pusher: `app_id = app.twake.web.chat`, `format = event_id_only`, `events_only = true`, localized `default_payload`, `endpoint`/`auth` present, gateway `push.twake.app`.
- Mobile/desktop unaffected (web-gated; stub no-ops; unchanged mobile `app_id`).

## Notes

- Notification language is per-browser (the Twake app language of that browser); Matrix has no server-side account language.
- One web pusher per account: a second browser re-registers and supersedes the previous one (no simultaneous multi-browser).
- iOS Safari: push only as an installed PWA (browser limitation) — graceful no-op otherwise.
- Arc: if no push, check `chrome://gcm-internals` → `Connection State` must be `CONNECTED`.
- `web_push_enabled` + `vapid_public_key` ship via the deployed `config.json`; VAPID **private** key stays on Sygnal.
- Local browser testing must use a **release** build (`flutter build web` served statically); `flutter run -d web-server` (debug) overloads the DDC module loader and the app fails to boot — unrelated to push.
