### PR TITLE
TW-3171: Restore text field focus when switching browser tabs

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -50,6 +50,7 @@ import 'package:fluffychat/widgets/set_active_client_state.dart';
 import 'package:fluffychat/widgets/twake_app.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_app_lock/flutter_app_lock.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -414,6 +415,8 @@ class MatrixState extends State<Matrix>
       if (PlatformInfos.isWeb) {
         html.window.addEventListener('focus', onWindowFocus);
         html.window.addEventListener('blur', onWindowBlur);
+        html.document.addEventListener('visibilitychange', onVisibilityChange);
+        FocusManager.instance.addListener(_onFocusManagerChange);
       }
       await initMatrix();
       final emojiRawData = await EmojiData.builtIn();
@@ -1152,12 +1155,47 @@ class MatrixState extends State<Matrix>
     }
   }
 
+  /// Last focusable leaf [FocusNode] that had focus, updated continuously via
+  /// [FocusManager] listener so it stays valid even after the browser clears
+  /// DOM focus on tab switch.
+  FocusNode? _lastFocusedNode;
+
+  /// Called on every Flutter focus change. Saves only leaf nodes that can
+  /// actually receive input (excludes FocusScope and non-focusable nodes).
+  void _onFocusManagerChange() {
+    final current = FocusManager.instance.primaryFocus;
+    if (current != null &&
+        current.canRequestFocus &&
+        current is! FocusScopeNode) {
+      _lastFocusedNode = current;
+    }
+  }
+
+  /// Restores focus after a post-frame delay so the Flutter engine finishes
+  /// its own focus handling (view-level focus) before we override it.
+  void _restoreFocus() {
+    final node = _lastFocusedNode;
+    if (node == null || !node.canRequestFocus) return;
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      if (node.canRequestFocus) {
+        node.requestFocus();
+      }
+    });
+  }
+
   void onWindowFocus(html.Event e) {
     didChangeAppLifecycleState(AppLifecycleState.resumed);
+    _restoreFocus();
   }
 
   void onWindowBlur(html.Event e) {
     didChangeAppLifecycleState(AppLifecycleState.paused);
+  }
+
+  void onVisibilityChange(html.Event e) {
+    if (html.document.hidden != true) {
+      _restoreFocus();
+    }
   }
 
   void _setupAuthUrl({String? url}) {
@@ -1348,6 +1386,8 @@ class MatrixState extends State<Matrix>
     if (PlatformInfos.isWeb) {
       html.window.removeEventListener('focus', onWindowFocus);
       html.window.removeEventListener('blur', onWindowBlur);
+      html.document.removeEventListener('visibilitychange', onVisibilityChange);
+      FocusManager.instance.removeListener(_onFocusManagerChange);
     }
     intentFileStreamSubscription?.cancel();
     intentUriStreamSubscription?.cancel();

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1173,11 +1173,19 @@ class MatrixState extends State<Matrix>
 
   /// Restores focus after a post-frame delay so the Flutter engine finishes
   /// its own focus handling (view-level focus) before we override it.
+  ///
+  /// Re-reads [_lastFocusedNode] inside the callback to avoid overwriting a
+  /// newer focus target that may have been set between the call and execution.
+  /// Only restores if focus is still effectively unset (null or a FocusScopeNode,
+  /// which can't receive keyboard input directly).
   void _restoreFocus() {
-    final node = _lastFocusedNode;
-    if (node == null || !node.canRequestFocus) return;
+    if (_lastFocusedNode == null) return;
     SchedulerBinding.instance.addPostFrameCallback((_) {
-      if (node.canRequestFocus) {
+      final node = _lastFocusedNode;
+      if (node == null || !node.canRequestFocus) return;
+      // Only restore if no real (leaf) node has taken focus in the meantime.
+      final currentFocus = FocusManager.instance.primaryFocus;
+      if (currentFocus == null || currentFocus is FocusScopeNode) {
         node.requestFocus();
       }
     });


### PR DESCRIPTION
## Ticket
**Related issue**

- #3171 

## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**

- When you switch tabs, the browser fires focusout on Flutter's root canvas element. The Flutter engine's `_handleFocusout` in `view_focus_binding.dart` then fires a `ViewFocusEvent(unfocused)` which propagates to Flutter's `FocusManager` → `primaryFocus` becomes null. This happens before `visibilitychange/blur` fires on window, so reading `primaryFocus` at that point gives null.

## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**

- `FocusManager.addListener` fires every time focus changes — we save only non-null, non-scope, focusable nodes → we always have the last real text field                                                                                                                                                                                            
- On tab return (`onWindowFocus` or `onVisibilityChange`), `_restoreFocus()` is called                                                                                                                                                                                                                                                                     
- `addPostFrameCallback` defers the `requestFocus()` until after the engine finishes its own view-level focus handling, preventing a race condition 
- Web only

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/user-attachments/assets/21c65c4b-c432-40f0-8756-66bb0930f11c




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus restoration in Flutter web apps after switching tabs and returning to the browser window.
  * More reliably restores the last focused input/control when the page becomes visible again.
  * Reduced instances where keyboard focus could be lost after focus resumes or brief interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->