### PR TITLE
TW-3135: Rewire Chat Details Search Call Sites to TextSearch (Part 6)

### DIFF
--- a/lib/pages/chat_details/assign_roles/assign_roles.dart
+++ b/lib/pages/chat_details/assign_roles/assign_roles.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
-import 'package:fluffychat/utils/search/search_engine.dart';
-import 'package:fluffychat/utils/search/search_options.dart';
+import 'package:fluffychat/utils/user_extension.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/config/default_power_level_member.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
@@ -126,17 +125,7 @@ class AssignRolesController extends State<AssignRoles>
       return;
     }
 
-    final assignedUsers = assignRolesMember;
-
-    final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
-      searchTerm,
-      assignedUsers,
-      fieldExtractors: [
-        (user) => [user.displayName ?? ''],
-        (user) => [user.id],
-      ],
-      options: const SearchOptions(diacriticSensitive: false),
-    );
+    final searchResults = assignRolesMember.searchUsers(searchTerm);
 
     Logs().d(
       "AssignRolesController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/chat_details/assign_roles/assign_roles.dart
+++ b/lib/pages/chat_details/assign_roles/assign_roles.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/utils/search/search_engine.dart';
+import 'package:fluffychat/utils/search/search_options.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/config/default_power_level_member.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
@@ -126,12 +128,12 @@ class AssignRolesController extends State<AssignRoles>
 
     final assignedUsers = assignRolesMember;
 
-    final searchResults = assignedUsers.where((user) {
-      return (user.displayName ?? '').toLowerCase().contains(
-            searchTerm.toLowerCase(),
-          ) ||
-          (user.id).toLowerCase().contains(searchTerm.toLowerCase());
-    }).toList();
+    final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
+      searchTerm,
+      assignedUsers,
+      fieldExtractors: [(user) => user.displayName, (user) => user.id],
+      options: const SearchOptions(diacriticSensitive: false),
+    );
 
     Logs().d(
       "AssignRolesController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/chat_details/assign_roles/assign_roles.dart
+++ b/lib/pages/chat_details/assign_roles/assign_roles.dart
@@ -131,7 +131,10 @@ class AssignRolesController extends State<AssignRoles>
     final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
       searchTerm,
       assignedUsers,
-      fieldExtractors: [(user) => user.displayName, (user) => user.id],
+      fieldExtractors: [
+        (user) => [user.displayName ?? ''],
+        (user) => [user.id],
+      ],
       options: const SearchOptions(diacriticSensitive: false),
     );
 

--- a/lib/pages/chat_details/assign_roles_member_picker/assign_roles_member_picker.dart
+++ b/lib/pages/chat_details/assign_roles_member_picker/assign_roles_member_picker.dart
@@ -1,7 +1,6 @@
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
-import 'package:fluffychat/utils/search/search_engine.dart';
-import 'package:fluffychat/utils/search/search_options.dart';
+import 'package:fluffychat/utils/user_extension.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
@@ -69,17 +68,7 @@ class AssignRolesPickerController extends State<AssignRolesMemberPicker>
       return;
     }
 
-    final assignedUsers = members;
-
-    final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
-      searchTerm,
-      assignedUsers,
-      fieldExtractors: [
-        (user) => [user.displayName ?? ''],
-        (user) => [user.id],
-      ],
-      options: const SearchOptions(diacriticSensitive: false),
-    );
+    final searchResults = members.searchUsers(searchTerm);
 
     Logs().d(
       "AssignRolesController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/chat_details/assign_roles_member_picker/assign_roles_member_picker.dart
+++ b/lib/pages/chat_details/assign_roles_member_picker/assign_roles_member_picker.dart
@@ -74,7 +74,10 @@ class AssignRolesPickerController extends State<AssignRolesMemberPicker>
     final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
       searchTerm,
       assignedUsers,
-      fieldExtractors: [(user) => user.displayName, (user) => user.id],
+      fieldExtractors: [
+        (user) => [user.displayName ?? ''],
+        (user) => [user.id],
+      ],
       options: const SearchOptions(diacriticSensitive: false),
     );
 

--- a/lib/pages/chat_details/assign_roles_member_picker/assign_roles_member_picker.dart
+++ b/lib/pages/chat_details/assign_roles_member_picker/assign_roles_member_picker.dart
@@ -1,5 +1,7 @@
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/utils/search/search_engine.dart';
+import 'package:fluffychat/utils/search/search_options.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
@@ -69,12 +71,12 @@ class AssignRolesPickerController extends State<AssignRolesMemberPicker>
 
     final assignedUsers = members;
 
-    final searchResults = assignedUsers.where((user) {
-      return (user.displayName ?? '').toLowerCase().contains(
-            searchTerm.toLowerCase(),
-          ) ||
-          (user.id).toLowerCase().contains(searchTerm.toLowerCase());
-    }).toList();
+    final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
+      searchTerm,
+      assignedUsers,
+      fieldExtractors: [(user) => user.displayName, (user) => user.id],
+      options: const SearchOptions(diacriticSensitive: false),
+    );
 
     Logs().d(
       "AssignRolesController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/chat_details/exceptions/exceptions.dart
+++ b/lib/pages/chat_details/exceptions/exceptions.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/utils/search/search_engine.dart';
+import 'package:fluffychat/utils/search/search_options.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
@@ -73,12 +75,12 @@ class ExceptionsController extends State<Exceptions>
 
     final exceptionUsers = exceptionsMember;
 
-    final searchResults = exceptionUsers.where((user) {
-      return (user.displayName ?? '').toLowerCase().contains(
-            searchTerm.toLowerCase(),
-          ) ||
-          (user.id).toLowerCase().contains(searchTerm.toLowerCase());
-    }).toList();
+    final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
+      searchTerm,
+      exceptionUsers,
+      fieldExtractors: [(user) => user.displayName, (user) => user.id],
+      options: const SearchOptions(diacriticSensitive: false),
+    );
 
     Logs().d(
       "ExceptionsController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/chat_details/exceptions/exceptions.dart
+++ b/lib/pages/chat_details/exceptions/exceptions.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
-import 'package:fluffychat/utils/search/search_engine.dart';
-import 'package:fluffychat/utils/search/search_options.dart';
+import 'package:fluffychat/utils/user_extension.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
@@ -73,17 +72,7 @@ class ExceptionsController extends State<Exceptions>
       return;
     }
 
-    final exceptionUsers = exceptionsMember;
-
-    final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
-      searchTerm,
-      exceptionUsers,
-      fieldExtractors: [
-        (user) => [user.displayName ?? ''],
-        (user) => [user.id],
-      ],
-      options: const SearchOptions(diacriticSensitive: false),
-    );
+    final searchResults = exceptionsMember.searchUsers(searchTerm);
 
     Logs().d(
       "ExceptionsController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/chat_details/exceptions/exceptions.dart
+++ b/lib/pages/chat_details/exceptions/exceptions.dart
@@ -78,7 +78,10 @@ class ExceptionsController extends State<Exceptions>
     final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
       searchTerm,
       exceptionUsers,
-      fieldExtractors: [(user) => user.displayName, (user) => user.id],
+      fieldExtractors: [
+        (user) => [user.displayName ?? ''],
+        (user) => [user.id],
+      ],
       options: const SearchOptions(diacriticSensitive: false),
     );
 

--- a/lib/pages/chat_details/removed/removed.dart
+++ b/lib/pages/chat_details/removed/removed.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/utils/search/search_engine.dart';
+import 'package:fluffychat/utils/search/search_options.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/room/unban_user_state.dart';
@@ -63,12 +65,12 @@ class RemovedController extends State<Removed> with SearchDebouncerMixin {
       return;
     }
 
-    final searchResults = removedMember.where((user) {
-      return (user.displayName ?? '').toLowerCase().contains(
-            searchTerm.toLowerCase(),
-          ) ||
-          (user.id).toLowerCase().contains(searchTerm.toLowerCase());
-    }).toList();
+    final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
+      searchTerm,
+      removedMember,
+      fieldExtractors: [(user) => user.displayName, (user) => user.id],
+      options: const SearchOptions(diacriticSensitive: false),
+    );
 
     Logs().d(
       "RemovedController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/chat_details/removed/removed.dart
+++ b/lib/pages/chat_details/removed/removed.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 
 import 'package:dartz/dartz.dart' hide State;
 import 'package:fluffychat/app_state/failure.dart';
-import 'package:fluffychat/utils/search/search_engine.dart';
-import 'package:fluffychat/utils/search/search_options.dart';
+import 'package:fluffychat/utils/user_extension.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/room/unban_user_state.dart';
@@ -65,15 +64,7 @@ class RemovedController extends State<Removed> with SearchDebouncerMixin {
       return;
     }
 
-    final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
-      searchTerm,
-      removedMember,
-      fieldExtractors: [
-        (user) => [user.displayName ?? ''],
-        (user) => [user.id],
-      ],
-      options: const SearchOptions(diacriticSensitive: false),
-    );
+    final searchResults = removedMember.searchUsers(searchTerm);
 
     Logs().d(
       "RemovedController::handleSearchResults: $searchTerm, results: ${searchResults.length}",

--- a/lib/pages/chat_details/removed/removed.dart
+++ b/lib/pages/chat_details/removed/removed.dart
@@ -68,7 +68,10 @@ class RemovedController extends State<Removed> with SearchDebouncerMixin {
     final searchResults = getIt.get<SearchEngine>().matchAnyField<User>(
       searchTerm,
       removedMember,
-      fieldExtractors: [(user) => user.displayName, (user) => user.id],
+      fieldExtractors: [
+        (user) => [user.displayName ?? ''],
+        (user) => [user.id],
+      ],
       options: const SearchOptions(diacriticSensitive: false),
     );
 

--- a/lib/utils/user_extension.dart
+++ b/lib/utils/user_extension.dart
@@ -3,6 +3,8 @@ import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/profile_info/profile_info_body/profile_info_body.dart';
 import 'package:fluffychat/pages/profile_info/profile_info_page.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/utils/search/search_engine.dart';
+import 'package:fluffychat/utils/search/search_options.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
@@ -90,6 +92,21 @@ extension UserExtension on User {
           ),
         ),
       ),
+    );
+  }
+}
+
+extension IterableUsersExtension on Iterable<User> {
+  List<User> searchUsers(String keyword) {
+    if (keyword.isEmpty) return toList();
+    return getIt.get<SearchEngine>().matchAnyField<User>(
+      keyword,
+      toList(),
+      fieldExtractors: [
+        (user) => [user.displayName ?? ''],
+        (user) => [user.id],
+      ],
+      options: const SearchOptions(diacriticSensitive: false),
     );
   }
 }


### PR DESCRIPTION
## Ticket
- #3135

## Impact description
Rewired the 4 searches mentioned in the ticket to the search engine. Simple changes similar to the ones in #3159 #3173 #3175, so I figured that only a demonstration through screenshots to show the affected search bars would be sufficient 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
<img width="436" height="261" alt="Screenshot From 2026-06-25 09-47-08" src="https://github.com/user-attachments/assets/8c83c8d5-91e3-41dd-92e1-ee98db27bf15" />
<img width="436" height="261" alt="Screenshot From 2026-06-25 09-44-46" src="https://github.com/user-attachments/assets/5a77a261-dfbf-442e-bc59-6c1a1cf063ee" />
<img width="447" height="713" alt="Screenshot From 2026-06-25 09-44-24" src="https://github.com/user-attachments/assets/07d27614-145f-4895-a68b-a6da3d9c6362" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved user search across role assignment, member selection, exceptions, and removed-member lists.
  * Search now matches across user names and IDs using shared logic, including diacritic-insensitive matching.

* **Bug Fixes**
  * Updated search behavior to be more consistent and accurate across the affected screens, with the same empty-term and empty-results handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->