### PR TITLE
TW-3176: implement listenSyncPresence for deduplicating user presence updates

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -252,20 +252,25 @@ class MatrixState extends State<Matrix>
   void _listenSyncPresence(Client client) {
     _presenceSubscription?.cancel();
     _presenceSubscription = client.onSync.stream.listen((sync) {
-      CachedPresence? lastActivePresence;
+      // Deduplicate per user: keep only the most recent presence per userid
+      // to avoid UI flickering when a sync contains multiple events for the
+      // same user, while still emitting updates for every user in the sync.
+      final latestPerUser = <String, CachedPresence>{};
 
       for (final newPresence in sync.presence ?? []) {
         final cachedPresence = CachedPresence.fromMatrixEvent(newPresence);
+        final userId = cachedPresence.userid;
+        final existing = latestPerUser[userId];
         final newTs = cachedPresence.lastActiveTimestamp;
-        final oldTs = lastActivePresence?.lastActiveTimestamp;
-        if (lastActivePresence == null ||
+        final oldTs = existing?.lastActiveTimestamp;
+        if (existing == null ||
             (newTs != null && (oldTs == null || newTs.isAfter(oldTs)))) {
-          lastActivePresence = cachedPresence;
+          latestPerUser[userId] = cachedPresence;
         }
       }
 
-      if (lastActivePresence != null) {
-        onLatestPresenceChanged.add(lastActivePresence);
+      for (final presence in latestPerUser.values) {
+        onLatestPresenceChanged.add(presence);
       }
     });
   }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -264,7 +264,11 @@ class MatrixState extends State<Matrix>
         final newTs = cachedPresence.lastActiveTimestamp;
         final oldTs = existing?.lastActiveTimestamp;
         if (existing == null ||
-            (newTs != null && (oldTs == null || newTs.isAfter(oldTs)))) {
+            (newTs != null &&
+                (oldTs == null ||
+                    newTs.isAfter(oldTs) ||
+                    newTs.isAtSameMomentAs(oldTs))) ||
+            (newTs == null && oldTs == null)) {
           latestPerUser[userId] = cachedPresence;
         }
       }

--- a/test/utils/listen_sync_presence_test.dart
+++ b/test/utils/listen_sync_presence_test.dart
@@ -22,7 +22,11 @@ StreamSubscription<SyncUpdate> listenSyncPresence(
       final newTs = cachedPresence.lastActiveTimestamp;
       final oldTs = existing?.lastActiveTimestamp;
       if (existing == null ||
-          (newTs != null && (oldTs == null || newTs.isAfter(oldTs)))) {
+          (newTs != null &&
+              (oldTs == null ||
+                  newTs.isAfter(oldTs) ||
+                  newTs.isAtSameMomentAs(oldTs))) ||
+          (newTs == null && oldTs == null)) {
         latestPerUser[userId] = cachedPresence;
       }
     }
@@ -51,11 +55,7 @@ Map<String, Object?> _presenceEvent({
     'presence': presenceType,
     if (lastActiveAgoMs != null) 'last_active_ago': lastActiveAgoMs,
   };
-  return {
-    'type': 'm.presence',
-    'sender': userId,
-    'content': content,
-  };
+  return {'type': 'm.presence', 'sender': userId, 'content': content};
 }
 
 void main() {
@@ -79,55 +79,40 @@ void main() {
       await output.close();
     });
 
-    test(
-      'GIVEN sync contains presence for one user '
-      'THEN emits that user presence',
-      () async {
-        syncController.add(
-          _syncWith([
-            _presenceEvent(
-              userId: '@bob:example.com',
-              presenceType: 'online',
-            ),
-          ]),
-        );
+    test('GIVEN sync contains presence for one user '
+        'THEN emits that user presence', () async {
+      syncController.add(
+        _syncWith([
+          _presenceEvent(userId: '@bob:example.com', presenceType: 'online'),
+        ]),
+      );
 
-        await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
 
-        expect(emitted, hasLength(1));
-        expect(emitted.first.userid, '@bob:example.com');
-        expect(emitted.first.presence, PresenceType.online);
-      },
-    );
+      expect(emitted, hasLength(1));
+      expect(emitted.first.userid, '@bob:example.com');
+      expect(emitted.first.presence, PresenceType.online);
+    });
 
-    test(
-      'GIVEN sync contains presence for two different users '
-      'THEN emits both — the bug: previously only one was emitted',
-      () async {
-        syncController.add(
-          _syncWith([
-            _presenceEvent(
-              userId: '@bob:example.com',
-              presenceType: 'online',
-            ),
-            _presenceEvent(
-              userId: '@carol:example.com',
-              presenceType: 'offline',
-              lastActiveAgoMs: 5 * 60 * 1000, // 5 min ago
-            ),
-          ]),
-        );
+    test('GIVEN sync contains presence for two different users '
+        'THEN emits both — the bug: previously only one was emitted', () async {
+      syncController.add(
+        _syncWith([
+          _presenceEvent(userId: '@bob:example.com', presenceType: 'online'),
+          _presenceEvent(
+            userId: '@carol:example.com',
+            presenceType: 'offline',
+            lastActiveAgoMs: 5 * 60 * 1000, // 5 min ago
+          ),
+        ]),
+      );
 
-        await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
 
-        expect(emitted, hasLength(2));
-        final userIds = emitted.map((e) => e.userid).toSet();
-        expect(
-          userIds,
-          containsAll(['@bob:example.com', '@carol:example.com']),
-        );
-      },
-    );
+      expect(emitted, hasLength(2));
+      final userIds = emitted.map((e) => e.userid).toSet();
+      expect(userIds, containsAll(['@bob:example.com', '@carol:example.com']));
+    });
 
     test(
       'GIVEN sync has Bob (offline, 6 min ago) and Carol (online, just now) '
@@ -151,10 +136,12 @@ void main() {
         await Future.delayed(Duration.zero);
 
         expect(emitted, hasLength(2));
-        final bobPresence =
-            emitted.firstWhere((e) => e.userid == '@bob:example.com');
-        final carolPresence =
-            emitted.firstWhere((e) => e.userid == '@carol:example.com');
+        final bobPresence = emitted.firstWhere(
+          (e) => e.userid == '@bob:example.com',
+        );
+        final carolPresence = emitted.firstWhere(
+          (e) => e.userid == '@carol:example.com',
+        );
 
         expect(bobPresence.presence, PresenceType.offline);
         expect(carolPresence.presence, PresenceType.online);
@@ -188,17 +175,33 @@ void main() {
       },
     );
 
-    test(
-      'GIVEN sync has no presence events '
-      'THEN emits nothing',
-      () async {
-        syncController.add(SyncUpdate(nextBatch: 'batch', presence: []));
+    test('GIVEN sync has duplicate events for same user with null timestamps '
+        'THEN keeps the last event (event-order fallback)', () async {
+      syncController.add(
+        _syncWith([
+          _presenceEvent(userId: '@bob:example.com', presenceType: 'offline'),
+          _presenceEvent(
+            userId: '@bob:example.com',
+            presenceType: 'online', // later in array — should win
+          ),
+        ]),
+      );
 
-        await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
 
-        expect(emitted, isEmpty);
-      },
-    );
+      expect(emitted, hasLength(1));
+      expect(emitted.first.userid, '@bob:example.com');
+      expect(emitted.first.presence, PresenceType.online);
+    });
+
+    test('GIVEN sync has no presence events '
+        'THEN emits nothing', () async {
+      syncController.add(SyncUpdate(nextBatch: 'batch', presence: []));
+
+      await Future.delayed(Duration.zero);
+
+      expect(emitted, isEmpty);
+    });
 
     test(
       'GIVEN multiple syncs arrive '
@@ -206,10 +209,7 @@ void main() {
       () async {
         syncController.add(
           _syncWith([
-            _presenceEvent(
-              userId: '@bob:example.com',
-              presenceType: 'online',
-            ),
+            _presenceEvent(userId: '@bob:example.com', presenceType: 'online'),
           ]),
         );
         await Future.delayed(Duration.zero);

--- a/test/utils/listen_sync_presence_test.dart
+++ b/test/utils/listen_sync_presence_test.dart
@@ -1,0 +1,233 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+/// Replicates the fixed _listenSyncPresence logic from MatrixState so it can be
+/// tested in isolation without Flutter widget infrastructure.
+///
+/// Emits one [CachedPresence] per user per sync, keeping the most recent
+/// [lastActiveTimestamp] when a user appears multiple times in the same sync.
+StreamSubscription<SyncUpdate> listenSyncPresence(
+  Stream<SyncUpdate> onSync,
+  StreamController<CachedPresence> out,
+) {
+  return onSync.listen((sync) {
+    final latestPerUser = <String, CachedPresence>{};
+
+    for (final newPresence in sync.presence ?? []) {
+      final cachedPresence = CachedPresence.fromMatrixEvent(newPresence);
+      final userId = cachedPresence.userid;
+      final existing = latestPerUser[userId];
+      final newTs = cachedPresence.lastActiveTimestamp;
+      final oldTs = existing?.lastActiveTimestamp;
+      if (existing == null ||
+          (newTs != null && (oldTs == null || newTs.isAfter(oldTs)))) {
+        latestPerUser[userId] = cachedPresence;
+      }
+    }
+
+    for (final presence in latestPerUser.values) {
+      out.add(presence);
+    }
+  });
+}
+
+/// Builds a [SyncUpdate] whose presence list contains the given raw events.
+SyncUpdate _syncWith(List<Map<String, Object?>> rawPresenceEvents) {
+  return SyncUpdate(
+    nextBatch: 'batch',
+    presence: rawPresenceEvents.map((e) => Presence.fromJson(e)).toList(),
+  );
+}
+
+/// Helper to build a raw presence event map.
+Map<String, Object?> _presenceEvent({
+  required String userId,
+  required String presenceType,
+  int? lastActiveAgoMs,
+}) {
+  final content = <String, Object?>{
+    'presence': presenceType,
+    if (lastActiveAgoMs != null) 'last_active_ago': lastActiveAgoMs,
+  };
+  return {
+    'type': 'm.presence',
+    'sender': userId,
+    'content': content,
+  };
+}
+
+void main() {
+  group('listenSyncPresence', () {
+    late StreamController<SyncUpdate> syncController;
+    late StreamController<CachedPresence> output;
+    late StreamSubscription<SyncUpdate> sub;
+    late List<CachedPresence> emitted;
+
+    setUp(() {
+      syncController = StreamController<SyncUpdate>.broadcast();
+      output = StreamController<CachedPresence>.broadcast();
+      emitted = [];
+      output.stream.listen(emitted.add);
+      sub = listenSyncPresence(syncController.stream, output);
+    });
+
+    tearDown(() async {
+      await sub.cancel();
+      await syncController.close();
+      await output.close();
+    });
+
+    test(
+      'GIVEN sync contains presence for one user '
+      'THEN emits that user presence',
+      () async {
+        syncController.add(
+          _syncWith([
+            _presenceEvent(
+              userId: '@bob:example.com',
+              presenceType: 'online',
+            ),
+          ]),
+        );
+
+        await Future.delayed(Duration.zero);
+
+        expect(emitted, hasLength(1));
+        expect(emitted.first.userid, '@bob:example.com');
+        expect(emitted.first.presence, PresenceType.online);
+      },
+    );
+
+    test(
+      'GIVEN sync contains presence for two different users '
+      'THEN emits both — the bug: previously only one was emitted',
+      () async {
+        syncController.add(
+          _syncWith([
+            _presenceEvent(
+              userId: '@bob:example.com',
+              presenceType: 'online',
+            ),
+            _presenceEvent(
+              userId: '@carol:example.com',
+              presenceType: 'offline',
+              lastActiveAgoMs: 5 * 60 * 1000, // 5 min ago
+            ),
+          ]),
+        );
+
+        await Future.delayed(Duration.zero);
+
+        expect(emitted, hasLength(2));
+        final userIds = emitted.map((e) => e.userid).toSet();
+        expect(
+          userIds,
+          containsAll(['@bob:example.com', '@carol:example.com']),
+        );
+      },
+    );
+
+    test(
+      'GIVEN sync has Bob (offline, 6 min ago) and Carol (online, just now) '
+      'THEN Bob presence is still emitted — the original bug scenario',
+      () async {
+        syncController.add(
+          _syncWith([
+            _presenceEvent(
+              userId: '@bob:example.com',
+              presenceType: 'offline',
+              lastActiveAgoMs: 6 * 60 * 1000,
+            ),
+            _presenceEvent(
+              userId: '@carol:example.com',
+              presenceType: 'online',
+              lastActiveAgoMs: 0,
+            ),
+          ]),
+        );
+
+        await Future.delayed(Duration.zero);
+
+        expect(emitted, hasLength(2));
+        final bobPresence =
+            emitted.firstWhere((e) => e.userid == '@bob:example.com');
+        final carolPresence =
+            emitted.firstWhere((e) => e.userid == '@carol:example.com');
+
+        expect(bobPresence.presence, PresenceType.offline);
+        expect(carolPresence.presence, PresenceType.online);
+      },
+    );
+
+    test(
+      'GIVEN sync has duplicate events for the same user '
+      'THEN emits only one with the most recent timestamp (anti-flicker)',
+      () async {
+        syncController.add(
+          _syncWith([
+            _presenceEvent(
+              userId: '@bob:example.com',
+              presenceType: 'offline',
+              lastActiveAgoMs: 10 * 60 * 1000, // older
+            ),
+            _presenceEvent(
+              userId: '@bob:example.com',
+              presenceType: 'online',
+              lastActiveAgoMs: 2 * 60 * 1000, // more recent
+            ),
+          ]),
+        );
+
+        await Future.delayed(Duration.zero);
+
+        expect(emitted, hasLength(1));
+        expect(emitted.first.userid, '@bob:example.com');
+        expect(emitted.first.presence, PresenceType.online);
+      },
+    );
+
+    test(
+      'GIVEN sync has no presence events '
+      'THEN emits nothing',
+      () async {
+        syncController.add(SyncUpdate(nextBatch: 'batch', presence: []));
+
+        await Future.delayed(Duration.zero);
+
+        expect(emitted, isEmpty);
+      },
+    );
+
+    test(
+      'GIVEN multiple syncs arrive '
+      'THEN each sync emits its own presence updates independently',
+      () async {
+        syncController.add(
+          _syncWith([
+            _presenceEvent(
+              userId: '@bob:example.com',
+              presenceType: 'online',
+            ),
+          ]),
+        );
+        await Future.delayed(Duration.zero);
+        expect(emitted, hasLength(1));
+
+        syncController.add(
+          _syncWith([
+            _presenceEvent(
+              userId: '@carol:example.com',
+              presenceType: 'offline',
+              lastActiveAgoMs: 3 * 60 * 1000,
+            ),
+          ]),
+        );
+        await Future.delayed(Duration.zero);
+        expect(emitted, hasLength(2));
+        expect(emitted[1].userid, '@carol:example.com');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Ticket
**Related issue**

- #3176 


- The old code picked one presence per sync — the one with the most recent lastActiveTimestamp across all users. So if Bob and Carol both had presence events in the same sync, Carol's more recent timestamp would win and Bob's update was silently dropped. The UI never received Bob's presence change and stayed stuck at the stale "online xx min ago".- 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/4445c7b4-bb03-4da0-91c4-dab468379d70



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Presence synchronization now deduplicates updates per user within the same sync and shows the most recently active status for each user.
  * Improved timestamp handling, including correct behavior when timestamps are missing or equal.
* **Tests**
  * Added new unit test utilities and a comprehensive test suite covering single/multi-user syncs, de-duplication correctness, missing-timestamp fallbacks, and independence across sequential syncs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->