### PR TITLE
TW-3137: rewire input bar sticker picker search to text search (Part 7)

### DIFF
--- a/lib/pages/chat/input_bar/input_bar.dart
+++ b/lib/pages/chat/input_bar/input_bar.dart
@@ -23,7 +23,6 @@ import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'package:linagora_design_flutter/linagora_design_flutter.dart';
 import 'package:matrix/matrix.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
-import 'package:slugify/slugify.dart';
 
 class InputBar extends StatefulWidget {
   final Room? room;
@@ -96,12 +95,14 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
     );
     final List<Map<String, String?>> ret = <Map<String, String?>>[];
     const maxResults = 30;
+    final engine = getIt.get<SearchEngine>();
+    const opts = SearchOptions(diacriticSensitive: false);
 
     final commandMatch = RegExp(r'^/(\w*)$').firstMatch(searchText);
     if (commandMatch != null && widget.room != null) {
       final commandSearch = commandMatch[1]!.toLowerCase();
       for (final command in widget.room!.client.commands.keys) {
-        if (command.contains(commandSearch)) {
+        if (engine.matchesText(commandSearch, command, options: opts)) {
           ret.add({'type': 'command', 'name': command});
         }
 
@@ -109,7 +110,8 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
       }
     }
     final emojiMatch = RegExp(
-      r'(?:\s|^):(?:([-\w]+)~)?([-\w]+)$',
+      r'(?:\s|^):(?:([-\w\p{L}]+)~)?([-\w\p{L}]+)$',
+      unicode: true,
     ).firstMatch(searchText);
     if (emojiMatch != null && widget.room != null) {
       final packSearch = emojiMatch[1];
@@ -118,7 +120,7 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
       if (packSearch == null || packSearch.isEmpty) {
         for (final pack in emotePacks.entries) {
           for (final emote in pack.value.images.entries) {
-            if (emote.key.toLowerCase().contains(emoteSearch)) {
+            if (engine.matchesText(emoteSearch, emote.key, options: opts)) {
               ret.add({
                 'type': 'emote',
                 'name': emote.key,
@@ -138,7 +140,7 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
         }
       } else if (emotePacks[packSearch] != null) {
         for (final emote in emotePacks[packSearch]!.images.entries) {
-          if (emote.key.toLowerCase().contains(emoteSearch)) {
+          if (engine.matchesText(emoteSearch, emote.key, options: opts)) {
             ret.add({
               'type': 'emote',
               'name': emote.key,
@@ -161,7 +163,7 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
             (element) => [
               element.name,
               ...element.keywords,
-            ].any((element) => element.toLowerCase().contains(emoteSearch)),
+            ].any((kw) => kw.toLowerCase().contains(emoteSearch)),
           )
           .toList();
       // sort by the index of the search term in the name in order to have
@@ -197,9 +199,10 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
     // It ensures that the username starts with the @ symbol,
     // is preceded by either a space or appears at the beginning of a line,
     // and captures the username (excluding the @ symbol) for further use
-    const userMentionsRegex = r'(?:\s|^)@([-\w]*)$';
-
-    final userMatch = RegExp(userMentionsRegex).firstMatch(searchText);
+    final userMatch = RegExp(
+      r'(?:\s|^)@([-\w\p{L}]*)$',
+      unicode: true,
+    ).firstMatch(searchText);
     if (userMatch != null && widget.room != null) {
       final userSearch = userMatch[1]!.toLowerCase();
       final users = widget.room!
@@ -207,12 +210,16 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
           .where((user) => user.senderId != widget.room!.client.userID)
           .toList();
       for (final user in users) {
-        if ((user.displayName != null &&
-                (user.displayName!.toLowerCase().contains(userSearch) ||
-                    slugify(
-                      user.displayName!.toLowerCase(),
-                    ).contains(userSearch))) ||
-            user.id.split(':')[0].toLowerCase().contains(userSearch)) {
+        if (engine.matchesText(
+              userSearch,
+              user.displayName ?? '',
+              options: opts,
+            ) ||
+            engine.matchesText(
+              userSearch,
+              user.id.split(':')[0],
+              options: opts,
+            )) {
           ret.add({
             'type': 'user',
             'mxid': user.id,
@@ -232,8 +239,6 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
     ).firstMatch(searchText);
     if (roomMatch != null && widget.room != null) {
       final roomSearch = roomMatch[1]!;
-      const roomOpts = SearchOptions(diacriticSensitive: false);
-      final engine = getIt.get<SearchEngine>();
       final eligibleRooms = widget.room!.client.rooms
           .where((r) => r.getState(EventTypes.RoomTombstone) == null)
           .toList();
@@ -252,7 +257,7 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
           },
           (Room room) => [room.name],
         ],
-        options: roomOpts,
+        options: opts,
       );
       for (final r in matchedRooms) {
         ret.add({

--- a/lib/pages/chat/input_bar/input_bar.dart
+++ b/lib/pages/chat/input_bar/input_bar.dart
@@ -322,7 +322,7 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
       }
       insertText = ':${isUnique ? '' : '${insertPack!}~'}$insertEmote: ';
       startText = replaceText.replaceAllMapped(
-        RegExp(r'(\s|^)(:(?:[-\w]+~)?[-\w]+)$'),
+        RegExp(r'(\s|^)(:(?:[-\w\p{L}]+~)?[-\w\p{L}]+)$', unicode: true),
         (Match m) => '${m[1]}$insertText',
       );
     }
@@ -332,10 +332,8 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
       // match and capture usernames that start with the @ symbol,
       // where the @ symbol is either preceded by a whitespace character
       // or appears at the beginning of a line.
-      const insertMentionsRegex = r'(\s|^)(@[-\w]*)$';
-
       startText = replaceText.replaceAllMapped(
-        RegExp(insertMentionsRegex),
+        RegExp(r'(\s|^)(@[-\w\p{L}]*)$', unicode: true),
         (Match m) => '${m[1]}$insertText',
       );
     }

--- a/lib/pages/chat/input_bar/input_bar.dart
+++ b/lib/pages/chat/input_bar/input_bar.dart
@@ -100,9 +100,8 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
 
     final commandMatch = RegExp(r'^/(\w*)$').firstMatch(searchText);
     if (commandMatch != null && widget.room != null) {
-      final commandSearch = commandMatch[1]!.toLowerCase();
       for (final command in widget.room!.client.commands.keys) {
-        if (engine.matchesText(commandSearch, command, options: opts)) {
+        if (engine.matchesText(commandMatch[1]!, command, options: opts)) {
           ret.add({'type': 'command', 'name': command});
         }
 
@@ -163,7 +162,7 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
             (element) => [
               element.name,
               ...element.keywords,
-            ].any((kw) => kw.toLowerCase().contains(emoteSearch)),
+            ].any((kw) => engine.matchesText(emoteSearch, kw, options: opts)),
           )
           .toList();
       // sort by the index of the search term in the name in order to have
@@ -204,19 +203,18 @@ class _InputBarState extends State<InputBar> with PasteImageMixin {
       unicode: true,
     ).firstMatch(searchText);
     if (userMatch != null && widget.room != null) {
-      final userSearch = userMatch[1]!.toLowerCase();
       final users = widget.room!
           .getParticipants()
           .where((user) => user.senderId != widget.room!.client.userID)
           .toList();
       for (final user in users) {
         if (engine.matchesText(
-              userSearch,
+              userMatch[1]!,
               user.displayName ?? '',
               options: opts,
             ) ||
             engine.matchesText(
-              userSearch,
+              userMatch[1]!,
               user.id.split(':')[0],
               options: opts,
             )) {

--- a/lib/pages/chat/sticker_picker_dialog.dart
+++ b/lib/pages/chat/sticker_picker_dialog.dart
@@ -1,3 +1,6 @@
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/utils/search/search_engine.dart';
+import 'package:fluffychat/utils/search/search_options.dart';
 import 'package:fluffychat/widgets/avatar/avatar.dart';
 import 'package:flutter/material.dart';
 
@@ -22,6 +25,8 @@ class StickerPickerDialogState extends State<StickerPickerDialog> {
   Widget build(BuildContext context) {
     final stickerPacks = widget.room.getImagePacks(ImagePackUsage.sticker);
     final packSlugs = stickerPacks.keys.toList();
+    final engine = getIt.get<SearchEngine>();
+    const opts = SearchOptions(diacriticSensitive: false);
 
     // ignore: prefer_function_declarations_over_variables
     final packBuilder = (BuildContext context, int packIndex) {
@@ -30,11 +35,12 @@ class StickerPickerDialogState extends State<StickerPickerDialog> {
       if (searchFilter?.isNotEmpty ?? false) {
         filteredImagePackImageEntried.removeWhere(
           (e) =>
-              !(e.key.toLowerCase().contains(searchFilter!.toLowerCase()) ||
-                  (e.value.body?.toLowerCase().contains(
-                        searchFilter!.toLowerCase(),
-                      ) ??
-                      false)),
+              !engine.matchesText(searchFilter!, e.key, options: opts) &&
+              !engine.matchesText(
+                searchFilter!,
+                e.value.body ?? '',
+                options: opts,
+              ),
         );
       }
       final imageKeys = filteredImagePackImageEntried

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2964,7 +2964,7 @@ packages:
     source: hosted
     version: "0.2.12"
   slugify:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: slugify
       sha256: b272501565cb28050cac2d96b7bf28a2d24c8dae359280361d124f3093d337c3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -154,7 +154,6 @@ dependencies:
   scroll_to_index: ^3.0.1
   share_plus: 10.0.2
   shared_preferences: ^2.5.3
-  slugify: ^2.0.0
   skeletons:
     # TODO: Remove when https://github.com/badjio/skeletons/pull/9 is merged
     git:


### PR DESCRIPTION
## Ticket
- #3137


## Impact description
Last rewiring of the series, impacting the input bar. The sticker picker is also affected, but no way to see it since it seems like it is not used yet. In `input_bar.dart`, I changed most `.contains()` with a call to the searchEngine, with the exception of the emoji search as it most of the time the user will not mistakenly input a diacritic to search for an emoji. Also, the search becomes slow when trying to wire the emoji search to the search engine as the haystack has thousands of entries, which demonstrates the potential need for enhancement of `searchEngine` in the future. 


## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:

https://github.com/user-attachments/assets/0d591292-ad8b-49fb-ac24-e60406285575



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced chat suggestion matching for commands, emojis/emotes, mentions, and rooms with more accurate detection and improved Unicode support.
  - Upgraded sticker picker search to use smarter filtering across sticker keys and descriptions.
- **Bug Fixes**
  - Improved matching robustness by reducing accent/diacritic sensitivity.
  - Added Unicode-aware behavior for more consistent emoji/emote and mention recognition across diverse character sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->