### PR TITLE
TW-3170(fix): mark last event as read when at room bottom

### DIFF
--- a/integration_test/robots/abstract/abstract_chat_group_detail_robot.dart
+++ b/integration_test/robots/abstract/abstract_chat_group_detail_robot.dart
@@ -23,4 +23,8 @@ abstract class AbstractChatGroupDetailRobot {
 
   Future<void> clickOnBackIcon();
   Future<void> confirmAccessMedia();
+
+  /// Jumps to the live bottom of the timeline (taps the scroll-down button),
+  /// which is what marks the room read. No-op when already at the bottom.
+  Future<void> scrollToLiveBottom();
 }

--- a/integration_test/robots/abstract/abstract_chat_list_robot.dart
+++ b/integration_test/robots/abstract/abstract_chat_list_robot.dart
@@ -8,6 +8,11 @@ import '../twake_list_item_robot.dart';
 /// scenarios call appear here.
 abstract class AbstractChatListRobot {
   Future<void> openChatGroupByIndex(int index);
+
+  /// Opens the chat row whose title matches [title] from the (unfiltered) list.
+  /// Avoids the search screen so callers return to the same list afterwards.
+  Future<void> openChatByTitle(String title);
+
   Future<void> openSearchScreen();
   Future<void> clickOnPenIcon();
   Future<void> clickOnPinIcon();

--- a/integration_test/robots/chat_group_detail_robot.dart
+++ b/integration_test/robots/chat_group_detail_robot.dart
@@ -138,6 +138,20 @@ class ChatGroupDetailRobot extends CoreRobot
     await goBack();
   }
 
+  @override
+  Future<void> scrollToLiveBottom() async {
+    // Drag the timeline to its bottom deterministically rather than relying on
+    // the scroll-down FAB (which only shows while scrolled up, and whose
+    // appearance races the async timeline load on web). The list is not
+    // reversed — the live bottom is at `maxScrollExtent` — so dragging up until
+    // the scroll position stops moving lands exactly there, which is the
+    // transition that fires the read marker. A room that already opens at the
+    // bottom needs no movement and exits on the first no-op drag.
+    await isVisible(); // waits for the ChatEventList timeline to mount
+    await scrollToBottom($, root: $(ChatEventList));
+    await $.pump(const Duration(milliseconds: 500));
+  }
+
   Future<PullDownMenuRobot> openPullDownMenu(String message) async {
     await $(MessageContent).containing(find.text(message)).longPress();
     await $.waitUntilVisible($(PullDownMenu));

--- a/integration_test/robots/chat_list_robot.dart
+++ b/integration_test/robots/chat_list_robot.dart
@@ -73,6 +73,13 @@ class ChatListRobot extends HomeRobot implements AbstractChatListRobot {
   }
 
   @override
+  Future<void> openChatByTitle(String title) async {
+    await $.waitUntilVisible($(TwakeListItem));
+    await getChatGroupByTitle(title).root.tap();
+    await $.pumpAndSettle();
+  }
+
+  @override
   Future<List<TwakeListItemRobot>> getListOfChatGroup() async {
     final List<TwakeListItemRobot> groupList = [];
 

--- a/integration_test/scenarios/chat_list_scenarios.dart
+++ b/integration_test/scenarios/chat_list_scenarios.dart
@@ -154,6 +154,73 @@ class UnreadCountScenario extends BaseTestScenario {
   }
 }
 
+/// Cross-platform scenario: the unread badge clears once the room is viewed at
+/// the live bottom.
+///
+/// Guards the read-marker behaviour introduced by this change: arriving at the
+/// bottom of the timeline fires `setReadMarker(eventId: null)`, which must mark
+/// the room read and drop the chat-list badge back to zero. With the
+/// per-message VisibilityDetector logic removed, the at-bottom transition is
+/// now the sole mechanism that clears the badge, so a regression here surfaces
+/// as the badge staying non-zero.
+class UnreadBadgeClearsScenario extends BaseTestScenario {
+  UnreadBadgeClearsScenario(super.$, super.robots);
+
+  static const _groupTest = String.fromEnvironment('TitleOfGroupTest');
+
+  @override
+  Future<void> runTestLogic() async {
+    final now = DateTime.now();
+    // Non-numeric body so the message preview is never mis-read as the count.
+    final body = 'read probe ${now.hour}:${now.minute}:${now.second}';
+
+    await robots.homeRobot().gotoChatListScreen();
+
+    // Make the room unread first, and confirm the badge actually went up —
+    // otherwise the clear-to-zero assertion below would pass vacuously.
+    await sendMessageAsReceiver(message: body);
+    final unread = await _pollUnread((count) => count >= 1);
+    expect(
+      unread >= 1,
+      isTrue,
+      reason: 'expected the unread badge to increment, got $unread',
+    );
+
+    // Open the room and arrive at the live bottom, which is what marks it read.
+    final chatList = robots.chatListRobot();
+    await chatList.openChatByTitle(_groupTest);
+    final detail = robots.chatGroupDetailRobot();
+    await detail.confirmAccessMedia();
+    await detail.scrollToLiveBottom();
+    await detail.clickOnBackIcon();
+
+    // The receipt is sent on the at-bottom transition and the badge only clears
+    // after the next /sync, so poll until it drops to zero.
+    final cleared = await _pollUnread((count) => count == 0);
+    expect(
+      cleared,
+      0,
+      reason:
+          'expected the unread badge to clear after viewing the room at '
+          'the live bottom, got $cleared',
+    );
+  }
+
+  int _readUnread() => robots.chatListRobot().getUnreadMessage(_groupTest);
+
+  /// Polls the unread badge (which only updates after the next /sync) until
+  /// [done] holds or the deadline passes, then returns the last value read.
+  Future<int> _pollUnread(bool Function(int) done) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 15));
+    var current = _readUnread();
+    while (!done(current) && DateTime.now().isBefore(deadline)) {
+      await $.pump(const Duration(milliseconds: 300));
+      current = _readUnread();
+    }
+    return current;
+  }
+}
+
 /// Cross-platform scenario: pin then unpin a chat.
 class PinChatScenario extends BaseTestScenario {
   PinChatScenario(super.$, super.robots);

--- a/integration_test/tests/chat/chat_list_test.dart
+++ b/integration_test/tests/chat/chat_list_test.dart
@@ -13,6 +13,11 @@ void main() {
   );
 
   TestBase().runPatrolTest(
+    description: 'Unread badge clears after viewing at the live bottom',
+    scenarioBuilder: ($, robots) => UnreadBadgeClearsScenario($, robots),
+  );
+
+  TestBase().runPatrolTest(
     description: 'Pin/unpin a chat',
     scenarioBuilder: ($, robots) => PinChatScenario($, robots),
   );

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -539,6 +539,8 @@ class ChatController extends State<Chat>
   bool get _isAtLiveBottom =>
       timeline?.allowNewEvent == true &&
       scrollController.hasClients &&
+      // 2px tolerance to absorb sub-pixel rounding so we still count as "at
+      // bottom" when pixels never lands exactly on maxScrollExtent.
       (scrollController.position.maxScrollExtent -
               scrollController.position.pixels) <=
           2;

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -10,7 +10,6 @@ import 'package:fluffychat/data/memory/mxc_image_cache_manager.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/domain/matrix_events/event_type_rules.dart';
-import 'package:fluffychat/domain/matrix_events/event_visibility_resolver.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/domain/app_state/room/report_content_state.dart';
@@ -536,23 +535,33 @@ class ChatController extends State<Chat>
     }
   }
 
+  /// Whether the user is physically at the bottom of the live timeline
+  bool get _isAtLiveBottom =>
+      timeline?.allowNewEvent == true &&
+      scrollController.hasClients &&
+      (scrollController.position.maxScrollExtent -
+              scrollController.position.pixels) <=
+          2;
+
+  void _markLatestReadIfAtBottom() {
+    if (!_isAtLiveBottom) return;
+    if (room?.notificationCount == 0 && room?.hasNewMessages != true) return;
+    timeline?.setReadMarker(eventId: null).ignore();
+  }
+
   void _updateScrollController() async {
     if (!mounted) {
       return;
     }
     if (!scrollController.hasClients) return;
-    if (timeline?.allowNewEvent == false) {
-      showScrollDownButtonNotifier.value = true;
-    } else {
-      showScrollDownButtonNotifier.value =
-          scrollController.position.pixels !=
-          scrollController.position.maxScrollExtent;
-    }
+    showScrollDownButtonNotifier.value = !_isAtLiveBottom;
 
     // Skip auto-loading if we're doing programmatic scrolling
     if (_isProgrammaticScrolling) {
       return;
     }
+
+    _markLatestReadIfAtBottom();
 
     if (scrollController.position.pixels ==
             scrollController.position.maxScrollExtent ||
@@ -684,6 +693,8 @@ class ChatController extends State<Chat>
     if (!mounted) return;
     setState(() {});
 
+    _markLatestReadIfAtBottom();
+
     // Complete any pending timeline update waiters
     final completer = _timelineUpdateCompleter;
     if (completer != null && !completer.isCompleted) {
@@ -737,16 +748,8 @@ class ChatController extends State<Chat>
       var currentEventId = _pendingReadMarkerEventId;
       _pendingReadMarkerEventId = null;
 
-      // If the event being marked is the last visible event of the room,
-      // advance the read marker to room.lastEvent so that hidden trailing
-      // events don't leave a stale badge.
-      if (timeline.allowNewEvent) {
-        final lastVisibleEventId = timeline.events
-            .firstWhereOrNull(EventVisibilityResolver.isVisibleInTimeline)
-            ?.eventId;
-        if (currentEventId == lastVisibleEventId) {
-          currentEventId = room!.lastEvent!.eventId;
-        }
+      if (_isAtLiveBottom) {
+        currentEventId = null;
       }
 
       Logs().d('Set read marker...', currentEventId);

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -543,10 +543,16 @@ class ChatController extends State<Chat>
               scrollController.position.pixels) <=
           2;
 
+  bool _markingLatestRead = false;
+
   void _markLatestReadIfAtBottom() {
     if (!_isAtLiveBottom) return;
     if (room?.notificationCount == 0 && room?.hasNewMessages != true) return;
-    timeline?.setReadMarker(eventId: null).ignore();
+    if (_markingLatestRead) return;
+    _markingLatestRead = true;
+    timeline?.setReadMarker(eventId: null).whenComplete(() {
+      _markingLatestRead = false;
+    });
   }
 
   void _updateScrollController() async {


### PR DESCRIPTION
## Ticket
Fixes #3170 

## Root cause
The "Mark as read" behavior was driven entirely by the per-message visibility detector(`AutoMarkAsReadMixin`): a read receipt only goes out when a **visible** message nters the viewport. That leaves a hole: if a room latest events are types we don't render (reactions, redactions, call events, state events or unknown types…), there's no visible message to trigger anything, so no receipt is sent and the notification badge in the chat list just sits there. Same thing when one of those events arrives live while you're already at the bottom.

## Solution
When you're at the live bottom of a room, we now mark the newest event read (visible or not) via `setReadMarker(eventId: null)` (the SDK resolves `null` to the latest synced event). It's wired into two places:

- **reaching the bottom** (scroll listener), which also covers opening a room and landing at the bottom
- **a live event landing** (`updateView`), which covers events that show up while you're already at the bottom

By the way this is essentially how **FluffyChat** does read markers from what I've seen. (The "am I at the bottom?" logic)

## Test recommendations
Please help me test, what we can test is:

- [ ] Receive a text message and it marks as read when you enter the room
- [ ] Receive a unknown event with unknown event visibility ON and it marks as read when you enter the room
- [ ] Receive a unknown event with unknown event visibility OFF and it marks as read when you enter the room
- [ ] Receive a text message that has some reactions and tags in it and it marks as read when you enter the room

## Demos
Before
https://github.com/user-attachments/assets/ad9676e9-e290-49d8-a4aa-90bbe2635e97
After
https://github.com/user-attachments/assets/8175c8eb-51a0-4ced-9462-499f4ba78816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “mark as read” handling when you’re at the bottom of the chat timeline, so the unread badge updates more consistently.
  * Adjusted live-bottom detection and the scroll-down indicator to better match user scrolling, while avoiding unintended read updates during automatic navigation.

* **Tests**
  * Added an integration test scenario and a new patrol test to verify the unread chat-list badge clears to zero after opening a room and scrolling to the live bottom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->