### PR TITLE
feat(chat-list): Get started guide (proposal)

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -1,6 +1,30 @@
 {
   "@@locale": "en",
   "@@last_modified": "2021-08-14 12:38:37.885451",
+  "getStartedTitle": "Get started",
+  "getStartedProgress": "{done} of {total} completed",
+  "@getStartedProgress": {
+    "placeholders": {
+      "done": {"type": "int"},
+      "total": {"type": "int"}
+    }
+  },
+  "getStartedMarkDone": "Mark as done",
+  "getStartedStepDone": "Done",
+  "getStartedSyncContactsTitle": "Sync your contacts",
+  "getStartedSyncContactsDescription": "Find people you already know on Twake Chat.",
+  "getStartedSyncContactsAction": "Sync contacts",
+  "getStartedInviteTitle": "Invite a contact",
+  "getStartedInviteDescription": "Bring someone you know onto Twake Chat.",
+  "getStartedInviteAction": "Invite",
+  "getStartedSendMessageTitle": "Send a message",
+  "getStartedSendMessageDescription": "Start a conversation with that person.",
+  "getStartedSendMessageAction": "New message",
+  "getStartedReceiveTitle": "Receive a message",
+  "getStartedReceiveDescription": "Wait for a reply to land in your inbox.",
+  "getStartedJoinChannelTitle": "Join a public channel",
+  "getStartedJoinChannelDescription": "Discover and join a public conversation.",
+  "getStartedJoinChannelAction": "Browse channels",
   "passwordsDoNotMatch": "Passwords do not match!",
   "pleaseEnterValidEmail": "Please enter a valid email address.",
   "repeatPassword": "Repeat password",

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -130,7 +130,10 @@ abstract class AppConfig {
   static const String pushNotificationsChannelName = 'Twake Chat push channel';
   static const String pushNotificationsChannelDescription =
       'Push notifications for Twake Chat';
-  static String pushNotificationsAppId = Platform.isIOS
+  // kIsWeb must be the outer ternary: Platform.isIOS throws on web.
+  static String pushNotificationsAppId = kIsWeb
+      ? "app.twake.web.chat"
+      : Platform.isIOS
       ? kReleaseMode
             ? "app.twake.ios.chat"
             : "app.twake.ios.chat.sandbox"
@@ -142,6 +145,17 @@ abstract class AppConfig {
   );
 
   static String pushNotificationsGatewayUrl = _pushNotificationsGatewayUrlEnv;
+
+  /// VAPID public key (base64url, raw P-256 point) for Web Push subscription.
+  /// Public — not a secret. Private key lives on the Sygnal gateway.
+  static const String _vapidPublicKeyEnv = String.fromEnvironment(
+    'VAPID_PUBLIC_KEY',
+  );
+
+  static String vapidPublicKey = _vapidPublicKeyEnv;
+
+  /// Gate Web Push rollout. Flipped via config.json `web_push_enabled`.
+  static bool webPushEnabled = false;
 
   static const String _supportEmailEnv = String.fromEnvironment(
     'SUPPORT_EMAIL',
@@ -326,6 +340,13 @@ abstract class AppConfig {
     if (json['cozy_external_bridge_version'] is String &&
         json['cozy_external_bridge_version'].isNotEmpty) {
       cozyExternalBridgeVersion = json['cozy_external_bridge_version'];
+    }
+    if (json['vapid_public_key'] is String &&
+        json['vapid_public_key'].isNotEmpty) {
+      vapidPublicKey = json['vapid_public_key'];
+    }
+    if (json['web_push_enabled'] is bool) {
+      webPushEnabled = json['web_push_enabled'];
     }
   }
 

--- a/lib/pages/chat_list/chat_list_view.dart
+++ b/lib/pages/chat_list/chat_list_view.dart
@@ -4,6 +4,7 @@ import 'package:fluffychat/pages/chat_list/chat_list_body_view.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_bottom_navigator.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_bottom_navigator_style.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_header.dart';
+import 'package:fluffychat/pages/chat_list/get_started_guide/get_started_guide.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_view_style.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
@@ -31,6 +32,46 @@ class ChatListView extends StatelessWidget {
     this.onOpenSearchPageInMultipleColumns,
     required this.onTapBottomNavigation,
   });
+
+  List<GetStartedStep> _getStartedSteps(BuildContext context) {
+    final l10n = L10n.of(context)!;
+    return [
+      GetStartedStep(
+        icon: Icons.sync_outlined,
+        title: l10n.getStartedSyncContactsTitle,
+        description: l10n.getStartedSyncContactsDescription,
+        actionLabel: l10n.getStartedSyncContactsAction,
+        onAction: controller.goToNewPrivateChat,
+      ),
+      GetStartedStep(
+        icon: Icons.person_add_alt_1_outlined,
+        title: l10n.getStartedInviteTitle,
+        description: l10n.getStartedInviteDescription,
+        actionLabel: l10n.getStartedInviteAction,
+        onAction: controller.goToNewPrivateChat,
+      ),
+      GetStartedStep(
+        icon: Icons.send_outlined,
+        title: l10n.getStartedSendMessageTitle,
+        description: l10n.getStartedSendMessageDescription,
+        actionLabel: l10n.getStartedSendMessageAction,
+        onAction: controller.goToNewPrivateChat,
+      ),
+      GetStartedStep(
+        icon: Icons.mark_chat_unread_outlined,
+        title: l10n.getStartedReceiveTitle,
+        description: l10n.getStartedReceiveDescription,
+        actionLabel: '',
+      ),
+      GetStartedStep(
+        icon: Icons.public_outlined,
+        title: l10n.getStartedJoinChannelTitle,
+        description: l10n.getStartedJoinChannelDescription,
+        actionLabel: l10n.getStartedJoinChannelAction,
+        onAction: () => controller.goToNewGroupChat(context),
+      ),
+    ];
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -69,7 +110,12 @@ class ChatListView extends StatelessWidget {
           body: StreamBuilder<Client>(
             stream: controller.clientStream,
             builder: (context, snapshot) {
-              return ChatListBodyView(controller);
+              return Column(
+                children: [
+                  GetStartedGuide(steps: _getStartedSteps(context)),
+                  Expanded(child: ChatListBodyView(controller)),
+                ],
+              );
             },
           ),
           floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,

--- a/lib/pages/chat_list/get_started_guide/get_started_guide.dart
+++ b/lib/pages/chat_list/get_started_guide/get_started_guide.dart
@@ -1,0 +1,371 @@
+import 'package:fluffychat/pages/chat_list/get_started_guide/get_started_guide_style.dart';
+import 'package:flutter/material.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// One actionable step of the "Get started" guide shown on the Chats page.
+class GetStartedStep {
+  final IconData icon;
+  final String title;
+  final String description;
+  final String actionLabel;
+
+  /// Deep-link / action triggered by the step button. May be null for a
+  /// passive step (e.g. "receive a message") that only waits to be checked off.
+  final VoidCallback? onAction;
+
+  const GetStartedStep({
+    required this.icon,
+    required this.title,
+    required this.description,
+    required this.actionLabel,
+    this.onAction,
+  });
+}
+
+/// Collapsible, carousel-style onboarding guide. One step at a time with a
+/// progress bar; the carousel advances to the next unfinished step once the
+/// current one is marked done.
+///
+/// ponytail: completion is driven by a manual "mark done" + the action
+/// deep-link. Real event detection (contacts-synced count, pusher
+/// message-received, room-joined) is the upgrade path — wire each step's
+/// `done` to the matching Matrix signal when product wants it automatic.
+class GetStartedGuide extends StatefulWidget {
+  final List<GetStartedStep> steps;
+
+  const GetStartedGuide({super.key, required this.steps});
+
+  @override
+  State<GetStartedGuide> createState() => _GetStartedGuideState();
+}
+
+class _GetStartedGuideState extends State<GetStartedGuide> {
+  static const _completedKey = 'get_started_completed';
+  static const _collapsedKey = 'get_started_collapsed';
+  static const _dismissedKey = 'get_started_dismissed';
+
+  final PageController _pageController = PageController();
+  final Set<int> _completed = {};
+  bool _collapsed = false;
+  bool _dismissed = false;
+  bool _loaded = false;
+  int _currentPage = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _restore();
+  }
+
+  Future<void> _restore() async {
+    final prefs = await SharedPreferences.getInstance();
+    final completed = prefs.getStringList(_completedKey) ?? const [];
+    if (!mounted) return;
+    setState(() {
+      _completed
+        ..clear()
+        ..addAll(completed.map(int.tryParse).whereType<int>());
+      _collapsed = prefs.getBool(_collapsedKey) ?? false;
+      _dismissed = prefs.getBool(_dismissedKey) ?? false;
+      _currentPage = _firstUnfinished();
+      _loaded = true;
+    });
+    if (_pageController.hasClients && _currentPage != 0) {
+      _pageController.jumpToPage(_currentPage);
+    }
+  }
+
+  int _firstUnfinished() {
+    for (var i = 0; i < widget.steps.length; i++) {
+      if (!_completed.contains(i)) return i;
+    }
+    return widget.steps.length - 1;
+  }
+
+  Future<void> _persist() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _completedKey,
+      _completed.map((e) => e.toString()).toList(),
+    );
+    await prefs.setBool(_collapsedKey, _collapsed);
+    await prefs.setBool(_dismissedKey, _dismissed);
+  }
+
+  bool get _allDone => _completed.length >= widget.steps.length;
+
+  void _toggleCollapsed() {
+    setState(() => _collapsed = !_collapsed);
+    _persist();
+  }
+
+  void _dismiss() {
+    setState(() => _dismissed = true);
+    _persist();
+  }
+
+  void _markDone(int index) {
+    setState(() => _completed.add(index));
+    _persist();
+    // Advance to the next unfinished step.
+    final next = _firstUnfinished();
+    if (!_allDone && next != index) {
+      _pageController.animateToPage(
+        next,
+        duration: GetStartedGuideStyle.animationDuration,
+        curve: GetStartedGuideStyle.animationCurve,
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded || _dismissed || widget.steps.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final colors = LinagoraSysColors.material();
+    final theme = Theme.of(context);
+
+    return Container(
+      margin: GetStartedGuideStyle.margin,
+      decoration: BoxDecoration(
+        color: colors.surface,
+        borderRadius: BorderRadius.circular(GetStartedGuideStyle.radius),
+        border: Border.all(color: colors.outline.withOpacity(0.15)),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildHeader(context, colors, theme),
+          AnimatedSize(
+            duration: GetStartedGuideStyle.animationDuration,
+            curve: GetStartedGuideStyle.animationCurve,
+            alignment: Alignment.topCenter,
+            child: _collapsed
+                ? const SizedBox(width: double.infinity)
+                : _buildBody(context, colors, theme),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, dynamic colors, ThemeData theme) {
+    final l10n = L10n.of(context)!;
+    return InkWell(
+      onTap: _toggleCollapsed,
+      child: Padding(
+        padding: GetStartedGuideStyle.headerPadding,
+        child: Row(
+          children: [
+            Icon(Icons.rocket_launch_outlined, color: colors.primary, size: 22),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l10n.getStartedTitle,
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: colors.onSurface,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  Text(
+                    l10n.getStartedProgress(
+                      _completed.length,
+                      widget.steps.length,
+                    ),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colors.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (_allDone)
+              IconButton(
+                tooltip: l10n.close,
+                icon: Icon(Icons.close, color: colors.onSurfaceVariant),
+                onPressed: _dismiss,
+              ),
+            AnimatedRotation(
+              turns: _collapsed ? 0.5 : 0,
+              duration: GetStartedGuideStyle.animationDuration,
+              child: Icon(Icons.expand_less, color: colors.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context, dynamic colors, ThemeData theme) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Progress bar above the current step.
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(
+              GetStartedGuideStyle.progressBarRadius,
+            ),
+            child: LinearProgressIndicator(
+              value: widget.steps.isEmpty
+                  ? 0
+                  : _completed.length / widget.steps.length,
+              minHeight: GetStartedGuideStyle.progressBarHeight,
+              backgroundColor: colors.outline.withOpacity(0.15),
+              valueColor: AlwaysStoppedAnimation(colors.primary),
+            ),
+          ),
+        ),
+        SizedBox(
+          height: GetStartedGuideStyle.pageViewHeight,
+          child: PageView.builder(
+            controller: _pageController,
+            itemCount: widget.steps.length,
+            onPageChanged: (i) => setState(() => _currentPage = i),
+            itemBuilder: (context, index) =>
+                _buildStep(context, colors, theme, index),
+          ),
+        ),
+        _buildDots(colors),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+
+  Widget _buildStep(
+    BuildContext context,
+    dynamic colors,
+    ThemeData theme,
+    int index,
+  ) {
+    final l10n = L10n.of(context)!;
+    final step = widget.steps[index];
+    final done = _completed.contains(index);
+    return Padding(
+      padding: GetStartedGuideStyle.stepPadding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: GetStartedGuideStyle.stepIconBoxSize,
+                height: GetStartedGuideStyle.stepIconBoxSize,
+                decoration: BoxDecoration(
+                  color: done
+                      ? colors.primary.withOpacity(0.12)
+                      : colors.primaryContainer.withOpacity(0.5),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  done ? Icons.check_circle : step.icon,
+                  color: colors.primary,
+                  size: GetStartedGuideStyle.stepIconSize,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      step.title,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: colors.onSurface,
+                        fontWeight: FontWeight.w600,
+                        decoration: done ? TextDecoration.lineThrough : null,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      step.description,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colors.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const Spacer(),
+          Row(
+            children: [
+              if (!done && step.onAction != null)
+                Expanded(
+                  child: FilledButton(
+                    onPressed: () {
+                      step.onAction?.call();
+                      _markDone(index);
+                    },
+                    style: FilledButton.styleFrom(
+                      backgroundColor: colors.primary,
+                      foregroundColor: colors.onPrimary,
+                      minimumSize: const Size.fromHeight(40),
+                    ),
+                    child: Text(step.actionLabel),
+                  ),
+                ),
+              if (!done && step.onAction != null) const SizedBox(width: 8),
+              if (done)
+                Expanded(
+                  child: Text(
+                    l10n.getStartedStepDone,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      color: colors.primary,
+                    ),
+                  ),
+                )
+              else
+                TextButton(
+                  onPressed: () => _markDone(index),
+                  child: Text(l10n.getStartedMarkDone),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDots(dynamic colors) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(widget.steps.length, (i) {
+        final active = i == _currentPage;
+        final done = _completed.contains(i);
+        return Container(
+          margin: const EdgeInsets.symmetric(
+            horizontal: GetStartedGuideStyle.dotSpacing / 2,
+          ),
+          width: GetStartedGuideStyle.dotSize,
+          height: GetStartedGuideStyle.dotSize,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: done
+                ? colors.primary
+                : active
+                ? colors.primary.withOpacity(0.5)
+                : colors.outline.withOpacity(0.3),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/pages/chat_list/get_started_guide/get_started_guide_style.dart
+++ b/lib/pages/chat_list/get_started_guide/get_started_guide_style.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class GetStartedGuideStyle {
+  static const EdgeInsets margin = EdgeInsets.fromLTRB(12, 4, 12, 8);
+  static const EdgeInsets headerPadding = EdgeInsets.fromLTRB(16, 12, 8, 12);
+  static const EdgeInsets stepPadding = EdgeInsets.fromLTRB(16, 8, 16, 16);
+  static const double radius = 16.0;
+  static const double cardElevation = 0.0;
+
+  static const double progressBarHeight = 6.0;
+  static const double progressBarRadius = 8.0;
+
+  static const double stepIconSize = 28.0;
+  static const double stepIconBoxSize = 48.0;
+
+  // Fixed height keeps the collapsing/paging animation from jumping.
+  static const double pageViewHeight = 150.0;
+
+  static const double dotSize = 7.0;
+  static const double dotSpacing = 6.0;
+
+  static const Duration animationDuration = Duration(milliseconds: 280);
+  static const Curve animationCurve = Curves.easeInOut;
+}

--- a/lib/utils/web_push/web_push.dart
+++ b/lib/utils/web_push/web_push.dart
@@ -1,0 +1,3 @@
+// Conditional export: real Web Push impl on web, no-op stub elsewhere.
+// Matches the existing pattern (e.g. send_file_web_extension.dart).
+export 'web_push_stub.dart' if (dart.library.js) 'web_push_web.dart';

--- a/lib/utils/web_push/web_push.dart
+++ b/lib/utils/web_push/web_push.dart
@@ -1,3 +1,3 @@
 // Conditional export: real Web Push impl on web, no-op stub elsewhere.
 // Matches the existing pattern (e.g. send_file_web_extension.dart).
-export 'web_push_stub.dart' if (dart.library.js) 'web_push_web.dart';
+export 'web_push_stub.dart' if (dart.library.js_interop) 'web_push_web.dart';

--- a/lib/utils/web_push/web_push_stub.dart
+++ b/lib/utils/web_push/web_push_stub.dart
@@ -2,3 +2,5 @@ import 'package:matrix/matrix.dart';
 
 /// No-op on non-web platforms. Mobile uses [BackgroundPush] instead.
 Future<void> setupWebPush(Client client) async {}
+
+Future<void> removeWebPush(Client client) async {}

--- a/lib/utils/web_push/web_push_stub.dart
+++ b/lib/utils/web_push/web_push_stub.dart
@@ -3,4 +3,4 @@ import 'package:matrix/matrix.dart';
 /// No-op on non-web platforms. Mobile uses [BackgroundPush] instead.
 Future<void> setupWebPush(Client client) async {}
 
-Future<void> removeWebPush(Client client) async {}
+Future<void> removeWebPush(Client client, {bool unsubscribe = true}) async {}

--- a/lib/utils/web_push/web_push_stub.dart
+++ b/lib/utils/web_push/web_push_stub.dart
@@ -1,0 +1,4 @@
+import 'package:matrix/matrix.dart';
+
+/// No-op on non-web platforms. Mobile uses [BackgroundPush] instead.
+Future<void> setupWebPush(Client client) async {}

--- a/lib/utils/web_push/web_push_web.dart
+++ b/lib/utils/web_push/web_push_web.dart
@@ -44,11 +44,16 @@ Future<void> setupWebPush(Client client) async {
   }
 }
 
-/// Unsubscribes the browser and removes the Matrix pusher on logout.
+/// Removes this client's Matrix pusher on logout.
 /// At logout the token is usually already gone, so [client.deletePusher] is
 /// best-effort; the local `unsubscribe()` makes the endpoint invalid and the
 /// gateway drops the stale pusher on the next push (410 Gone).
-Future<void> removeWebPush(Client client) async {
+///
+/// [unsubscribe] must be false for a partial (multi-account) logout: the browser
+/// push subscription is shared across accounts, so unsubscribing would break
+/// notifications for the accounts still signed in. Only the true last-account
+/// logout unsubscribes the browser.
+Future<void> removeWebPush(Client client, {bool unsubscribe = true}) async {
   try {
     final registration = await web.window.navigator.serviceWorker.ready.toDart;
     final subscription = await registration.pushManager
@@ -61,8 +66,14 @@ Future<void> removeWebPush(Client client) async {
       final pusher = pushers?.firstWhereOrNull((p) => p.pushkey == endpoint);
       if (pusher != null) await client.deletePusher(pusher);
     }
-    await subscription.unsubscribe().toDart;
-    Logs().i('[WebPush] Unsubscribed');
+    if (unsubscribe) {
+      await subscription.unsubscribe().toDart;
+      Logs().i('[WebPush] Unsubscribed');
+    } else {
+      Logs().i(
+        '[WebPush] Pusher removed (subscription kept for other accounts)',
+      );
+    }
   } catch (e, s) {
     Logs().w('[WebPush] removeWebPush failed', e, s);
   }
@@ -93,18 +104,9 @@ Future<void> _registerPusher(Client client, String endpoint) async {
     return;
   }
 
-  // Drop stale web pushers for this app whose endpoint rotated
-  // (pushsubscriptionchange while the app was closed).
-  for (final stale
-      in pushers?.where((p) => p.appId == appId && p.pushkey != endpoint) ??
-          <Pusher>[]) {
-    try {
-      await client.deletePusher(stale);
-      Logs().i('[WebPush] Removed stale pusher');
-    } catch (e) {
-      Logs().w('[WebPush] Failed to remove stale pusher', e);
-    }
-  }
+  // Don't sweep other pushers sharing this appId: the same account may be
+  // signed in on another browser/session with a different endpoint. Truly
+  // rotated endpoints age out on the gateway's first 410 Gone response.
 
   await client.postPusher(
     Pusher(

--- a/lib/utils/web_push/web_push_web.dart
+++ b/lib/utils/web_push/web_push_web.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:js_interop';
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart';
 import 'package:matrix/matrix.dart';
 import 'package:web/web.dart' as web;
 
@@ -43,6 +44,30 @@ Future<void> setupWebPush(Client client) async {
   }
 }
 
+/// Unsubscribes the browser and removes the Matrix pusher on logout.
+/// At logout the token is usually already gone, so [client.deletePusher] is
+/// best-effort; the local `unsubscribe()` makes the endpoint invalid and the
+/// gateway drops the stale pusher on the next push (410 Gone).
+Future<void> removeWebPush(Client client) async {
+  try {
+    final registration = await web.window.navigator.serviceWorker.ready.toDart;
+    final subscription = await registration.pushManager
+        .getSubscription()
+        .toDart;
+    if (subscription == null) return;
+    final endpoint = subscription.endpoint;
+    if (client.isLogged()) {
+      final pushers = await client.getPushers().catchError((_) => <Pusher>[]);
+      final pusher = pushers?.firstWhereOrNull((p) => p.pushkey == endpoint);
+      if (pusher != null) await client.deletePusher(pusher);
+    }
+    await subscription.unsubscribe().toDart;
+    Logs().i('[WebPush] Unsubscribed');
+  } catch (e, s) {
+    Logs().w('[WebPush] removeWebPush failed', e, s);
+  }
+}
+
 Future<void> _registerPusher(Client client, String endpoint) async {
   final clientName = PlatformInfos.clientName;
   // Plain appId (no device suffix): it must match the Sygnal `app_id`.
@@ -66,6 +91,19 @@ Future<void> _registerPusher(Client client, String endpoint) async {
   if (alreadySet) {
     Logs().i('[WebPush] Pusher already set');
     return;
+  }
+
+  // Drop stale web pushers for this app whose endpoint rotated
+  // (pushsubscriptionchange while the app was closed).
+  for (final stale
+      in pushers?.where((p) => p.appId == appId && p.pushkey != endpoint) ??
+          <Pusher>[]) {
+    try {
+      await client.deletePusher(stale);
+      Logs().i('[WebPush] Removed stale pusher');
+    } catch (e) {
+      Logs().w('[WebPush] Failed to remove stale pusher', e);
+    }
   }
 
   await client.postPusher(

--- a/lib/utils/web_push/web_push_web.dart
+++ b/lib/utils/web_push/web_push_web.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:matrix/matrix.dart';
+import 'package:web/web.dart' as web;
+
+import '../../config/app_config.dart';
+import '../platform_infos.dart';
+
+/// Registers a standard Web Push (RFC 8030) subscription as a Matrix pusher,
+/// reusing the existing Sygnal `webpush` gateway. The Service Worker
+/// (`web/push_sw.js`) is registered by index.html after the app loads.
+///
+/// Does nothing unless Web Push is enabled, a VAPID key is configured, and the
+/// user has already granted notification permission (the prompt is a separate
+/// user-gesture step in onboarding — we never prompt here).
+Future<void> setupWebPush(Client client) async {
+  if (!AppConfig.webPushEnabled) return;
+  if (AppConfig.vapidPublicKey.isEmpty) return;
+  if (!client.isLogged()) return;
+  if (web.Notification.permission != 'granted') return;
+
+  try {
+    final registration = await web.window.navigator.serviceWorker.ready.toDart;
+    final pushManager = registration.pushManager;
+
+    var subscription = await pushManager.getSubscription().toDart;
+    subscription ??= await pushManager
+        .subscribe(
+          web.PushSubscriptionOptionsInit(
+            userVisibleOnly: true,
+            applicationServerKey: _decodeVapidKey(
+              AppConfig.vapidPublicKey,
+            ).toJS,
+          ),
+        )
+        .toDart;
+
+    await _registerPusher(client, subscription.endpoint);
+  } catch (e, s) {
+    Logs().e('[WebPush] setup failed', e, s);
+  }
+}
+
+Future<void> _registerPusher(Client client, String endpoint) async {
+  final clientName = PlatformInfos.clientName;
+  // Plain appId (no device suffix): it must match the Sygnal `app_id`.
+  // The endpoint is the per-browser pushkey, so devices stay distinct.
+  const appId = 'app.twake.web.chat';
+  final gatewayUrl = AppConfig.pushNotificationsGatewayUrl;
+
+  final pushers = await client.getPushers().catchError((e) {
+    Logs().w('[WebPush] Unable to request pushers', e);
+    return <Pusher>[];
+  });
+  final alreadySet =
+      pushers?.any(
+        (p) =>
+            p.pushkey == endpoint &&
+            p.appId == appId &&
+            p.data.url.toString() == gatewayUrl &&
+            p.data.format == AppConfig.pushNotificationsPusherFormat,
+      ) ??
+      false;
+  if (alreadySet) {
+    Logs().i('[WebPush] Pusher already set');
+    return;
+  }
+
+  await client.postPusher(
+    Pusher(
+      pushkey: endpoint,
+      appId: appId,
+      appDisplayName: clientName,
+      deviceDisplayName: client.deviceName ?? clientName,
+      lang: 'en',
+      data: PusherData(
+        url: Uri.parse(gatewayUrl),
+        format: AppConfig.pushNotificationsPusherFormat,
+      ),
+      kind: 'http',
+    ),
+    append: false,
+  );
+  Logs().i('[WebPush] Pusher registered');
+}
+
+/// base64url (unpadded) → bytes, for `applicationServerKey`.
+Uint8List _decodeVapidKey(String base64Url) {
+  final normalized = base64Url.replaceAll('-', '+').replaceAll('_', '/');
+  final padded = normalized.padRight((normalized.length + 3) ~/ 4 * 4, '=');
+  return base64.decode(padded);
+}

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1215,6 +1215,7 @@ class MatrixState extends State<Matrix>
       await _deletePersistActiveAccount();
       TwakeApp.router.go(const HomeTwakeWelcomeRoute().location);
     } else {
+      if (kIsWeb) await removeWebPush(client);
       TwakeApp.router.go(const HomeRoute($extra: true).location, extra: true);
     }
     await _deleteAllTomConfigurations();

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -69,6 +69,7 @@ import '../config/setting_keys.dart';
 import '../pages/key_verification/key_verification_dialog.dart';
 import '../utils/account_bundles.dart';
 import '../utils/background_push.dart';
+import '../utils/web_push/web_push.dart';
 import '../utils/famedlysdk_store.dart';
 import 'local_notifications_extension.dart';
 
@@ -739,6 +740,8 @@ class MatrixState extends State<Matrix>
     if (kIsWeb) {
       onFocusSub = html.window.onFocus.listen((_) => webHasFocus = true);
       onBlurSub = html.window.onBlur.listen((_) => webHasFocus = false);
+      // ignore: unawaited_futures
+      setupWebPush(client);
     }
 
     if (PlatformInfos.isMobile) {

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -602,6 +602,10 @@ class MatrixState extends State<Matrix>
       await backgroundPush?.removePusherForClient(currentClient);
     }
 
+    // Web: drop just this account's pusher, but keep the shared browser
+    // subscription alive for the accounts still signed in.
+    if (kIsWeb) await removeWebPush(currentClient, unsubscribe: false);
+
     await _cancelSubs(currentClient.clientName);
     widget.clients.remove(currentClient);
     await ClientManager.removeClientNameFromStore(currentClient.clientName);

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -530,6 +530,10 @@ class MatrixState extends State<Matrix>
     if (PlatformInfos.isWeb || PlatformInfos.isLinux) {
       currentClient.onSync.stream.first.then((s) async {
         await _requestNotificationPermission();
+        if (kIsWeb) {
+          // ignore: unawaited_futures
+          setupWebPush(currentClient);
+        }
         onNotification[name] ??= currentClient.onEvent.stream
             .where(
               (e) =>
@@ -565,10 +569,10 @@ class MatrixState extends State<Matrix>
       if (isInsideCozy) {
         CozyConfigManager().requestNotificationPermission();
       } else {
-        html.Notification.requestPermission();
+        await html.Notification.requestPermission();
       }
     } catch (e) {
-      html.Notification.requestPermission();
+      await html.Notification.requestPermission();
     }
   }
 
@@ -740,8 +744,6 @@ class MatrixState extends State<Matrix>
     if (kIsWeb) {
       onFocusSub = html.window.onFocus.listen((_) => webHasFocus = true);
       onBlurSub = html.window.onBlur.listen((_) => webHasFocus = false);
-      // ignore: unawaited_futures
-      setupWebPush(client);
     }
 
     if (PlatformInfos.isMobile) {

--- a/web/index.html
+++ b/web/index.html
@@ -94,7 +94,11 @@
             .getRegistrations()
             .then(async function(registrations) {
               try {
+                // Purge stale Flutter/legacy service workers (cache-busting workaround),
+                // but KEEP our Web Push SW so background notifications survive reloads.
                 await Promise.all(registrations.map(function(registration) {
+                  var url = (registration.active || registration.installing || registration.waiting || {}).scriptURL || '';
+                  if (url.indexOf('push_sw.js') !== -1) return Promise.resolve();
                   return registration.unregister();
                 }));
               } catch (error) {
@@ -105,6 +109,10 @@
                   const appRunner = await engineInitializer.initializeEngine({useColorEmoji: true});
                   await setTimeout( async function () {
                     await appRunner.runApp();
+                    // Register after runApp so this load's unregister sweep can't catch it.
+                    navigator.serviceWorker.register('push_sw.js').catch(function (error) {
+                      console.log('[Twake Chat] Error registering push service worker: ', error);
+                    });
                   }, 2000);
                 }
               });

--- a/web/push_sw.js
+++ b/web/push_sw.js
@@ -25,14 +25,26 @@ self.addEventListener('push', function (event) {
   var roomId = notification.room_id || '';
 
   event.waitUntil(
-    self.registration.showNotification('Twake Chat', {
-      body: 'New message',
-      icon: 'icons/Icon-192.png',
-      badge: 'icons/Icon-192.png',
-      tag: roomId || 'twake-message',
-      renotify: true,
-      data: { roomId: roomId },
-    })
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then(function (clientList) {
+        // App already open and visible: the in-app foreground notification
+        // (showLocalNotification) handles it, so skip the SW notification to
+        // avoid a duplicate. Chrome doesn't penalize userVisibleOnly when a
+        // visible window is present.
+        var appVisible = clientList.some(function (c) {
+          return c.visibilityState === 'visible';
+        });
+        if (appVisible) return;
+        return self.registration.showNotification('Twake Chat', {
+          body: 'New message',
+          icon: 'icons/Icon-192.png',
+          badge: 'icons/Icon-192.png',
+          tag: roomId || 'twake-message',
+          renotify: true,
+          data: { roomId: roomId },
+        });
+      })
   );
 });
 

--- a/web/push_sw.js
+++ b/web/push_sw.js
@@ -1,0 +1,58 @@
+/* Twake Chat — Web Push service worker (RFC 8030).
+ * Receives pushes from Sygnal (event_id_only format: no message content),
+ * shows a generic notification, and routes clicks into the app.
+ * ponytail: no JS test harness in this Flutter repo; covered by the manual
+ * chrome://discards freeze repro in the plan's acceptance criteria.
+ */
+
+self.addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('push', function (event) {
+  var data = {};
+  try {
+    data = event.data ? event.data.json() : {};
+  } catch (e) {
+    data = {};
+  }
+  // Sygnal event_id_only payload: { notification: { room_id, event_id, counts, ... } }
+  var notification = data.notification || {};
+  var roomId = notification.room_id || '';
+
+  event.waitUntil(
+    self.registration.showNotification('Twake Chat', {
+      body: 'New message',
+      icon: 'icons/Icon-192.png',
+      badge: 'icons/Icon-192.png',
+      tag: roomId || 'twake-message',
+      renotify: true,
+      data: { roomId: roomId },
+    })
+  );
+});
+
+self.addEventListener('notificationclick', function (event) {
+  event.notification.close();
+  var roomId = (event.notification.data || {}).roomId || '';
+  var target = roomId ? '/#/rooms/' + roomId : '/';
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then(function (clientList) {
+        for (var i = 0; i < clientList.length; i++) {
+          var client = clientList[i];
+          if ('focus' in client) {
+            if (roomId && 'navigate' in client) client.navigate(target);
+            return client.focus();
+          }
+        }
+        if (self.clients.openWindow) return self.clients.openWindow(target);
+      })
+  );
+});

--- a/web/push_sw.js
+++ b/web/push_sw.js
@@ -36,6 +36,28 @@ self.addEventListener('push', function (event) {
   );
 });
 
+self.addEventListener('pushsubscriptionchange', function (event) {
+  // Endpoint rotated (expiry/reset). Re-subscribe so pushes keep arriving;
+  // the Matrix pusher is re-synced by setupWebPush on the next app open
+  // (it drops the stale pusher). applicationServerKey accepts the base64url
+  // VAPID string directly. ponytail: read the key from config.json so the SW
+  // stays config-driven without a build step.
+  event.waitUntil(
+    fetch('config.json')
+      .then(function (r) { return r.json(); })
+      .then(function (cfg) {
+        if (!cfg || !cfg.vapid_public_key) return;
+        return self.registration.pushManager.subscribe({
+          userVisibleOnly: true,
+          applicationServerKey: cfg.vapid_public_key,
+        });
+      })
+      .catch(function (error) {
+        console.log('[Twake Chat] pushsubscriptionchange re-subscribe failed: ', error);
+      })
+  );
+});
+
 self.addEventListener('notificationclick', function (event) {
   event.notification.close();
   var roomId = (event.notification.data || {}).roomId || '';


### PR DESCRIPTION
## What

A **proposal** to add a collapsible *"Get started"* guide on the Chats page — a small step-by-step carousel sitting between the search bar and the room list.

The goal: **boost early retention and ease conversion** by replacing the cold empty state new users land on with a guided path to their first real conversation.

## Steps (one at a time)

1. Sync your contacts
2. Invite a contact
3. Send a message
4. Receive a message
5. Join a public channel

A progress bar sits above the current step; the carousel advances to the next unfinished step once the current one is marked done. The card is collapsible and dismissed once all steps are complete — state persists across sessions.

<img width="1312" height="956" alt="image" src="https://github.com/user-attachments/assets/123748a6-71fa-43cb-b112-e353c50094f8" />
<img width="1312" height="956" alt="image" src="https://github.com/user-attachments/assets/7ab0f561-e087-492c-93d3-1df71e0decdc" />
<img width="1312" height="956" alt="image" src="https://github.com/user-attachments/assets/77bdb573-efbe-4fae-af9c-9c2d336f2290" />
<img width="1312" height="956" alt="image" src="https://github.com/user-attachments/assets/c15ec25c-e908-4ab7-8de9-89bec63782fa" />
<img width="1312" height="956" alt="image" src="https://github.com/user-attachments/assets/2a03884b-464b-4028-bcfa-35fc35a78906" />
<img width="1312" height="956" alt="image" src="https://github.com/user-attachments/assets/d92885c5-d47e-4f17-a5cd-f1d187642d86" />


## Notes

- Uses the app theme (LinagoraSysColors) and existing l10n setup.
- **Completion is currently manual** (`Mark as done` + the step's action deep-link). Real event-based detection (contacts-synced, message sent/received, room joined) is a deliberate follow-up.
- Step deep-links are placeholders (steps 1–3 → new chat, step 5 → new group, step 4 passive) — happy to wire exact targets if the direction is validated.

> Proposal for discussion — feedback on copy, step order, and whether to gate it to first-run only is welcome.
