### PR TITLE
TW-3179(fix): inconsistent edited timestamp in timeline

### DIFF
--- a/lib/pages/chat/events/message_time.dart
+++ b/lib/pages/chat/events/message_time.dart
@@ -71,7 +71,9 @@ class MessageTime extends StatelessWidget {
               ),
             ),
           Text(
-            DateFormat("HH:mm").format(event.originServerTs),
+            DateFormat(
+              "HH:mm",
+            ).format(event.getDisplayEvent(timeline).originServerTs),
             textScaler: const TextScaler.linear(1.0),
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
               color: timelineOverlayMessage

--- a/test/pages/chat/events/event_extension_test.dart
+++ b/test/pages/chat/events/event_extension_test.dart
@@ -1173,4 +1173,152 @@ void main() {
       });
     });
   });
+
+  // Regression guard for TW-3179: the conversation showed the original post
+  // time under an "edited" label while the chat list showed the edit time.
+  // MessageTime now reads `event.getDisplayEvent(timeline).originServerTs`, so
+  // these tests pin the SDK contract that fix relies on.
+  group(
+    'getDisplayEvent timestamp (conversation time for edited messages)',
+    () {
+      late Client client;
+      late Room room;
+
+      setUpAll(() async {
+        client = await getClient();
+        room = Room(
+          client: client,
+          id: '!test:example.com',
+          membership: Membership.join,
+        );
+      });
+
+      Timeline buildTimeline(List<Event> events) {
+        final timeline = Timeline(
+          room: room,
+          chunk: TimelineChunk(events: []),
+        );
+        for (final e in events) {
+          timeline.addAggregatedEvent(e);
+        }
+        return timeline;
+      }
+
+      Event createOriginal({
+        required String eventId,
+        required Map<String, dynamic> content,
+        int timestamp = 1000,
+      }) {
+        return Event(
+          senderId: '@user:example.com',
+          type: EventTypes.Message,
+          room: room,
+          eventId: eventId,
+          content: content,
+          originServerTs: DateTime.fromMillisecondsSinceEpoch(timestamp),
+        );
+      }
+
+      Event createEdit({
+        required String originalEventId,
+        required String eventId,
+        required Map<String, dynamic> newContent,
+        int timestamp = 2000,
+      }) {
+        return Event(
+          senderId: '@user:example.com',
+          type: EventTypes.Message,
+          room: room,
+          eventId: eventId,
+          content: {
+            ...newContent,
+            'body': '* ${newContent['body']}',
+            'm.new_content': newContent,
+            'm.relates_to': {
+              'rel_type': RelationshipTypes.edit,
+              'event_id': originalEventId,
+            },
+          },
+          originServerTs: DateTime.fromMillisecondsSinceEpoch(timestamp),
+        );
+      }
+
+      test('GIVEN a never-edited message\n'
+          'THEN the displayed time is the original post time', () {
+        final original = createOriginal(
+          eventId: '\$plain',
+          content: {'body': 'hello', 'msgtype': 'm.text'},
+          timestamp: 1000,
+        );
+        final timeline = buildTimeline([original]);
+
+        expect(
+          original.getDisplayEvent(timeline).originServerTs,
+          DateTime.fromMillisecondsSinceEpoch(1000),
+        );
+      });
+
+      test('GIVEN an edited text message\n'
+          'THEN the displayed time is the edit time, not the original', () {
+        final original = createOriginal(
+          eventId: '\$text',
+          content: {'body': 'hello', 'msgtype': 'm.text'},
+          timestamp: 1000,
+        );
+        final edit = createEdit(
+          originalEventId: '\$text',
+          eventId: '\$text_edit',
+          newContent: {'body': 'hello edited', 'msgtype': 'm.text'},
+          timestamp: 2000,
+        );
+        final timeline = buildTimeline([original, edit]);
+
+        expect(
+          original.getDisplayEvent(timeline).originServerTs,
+          DateTime.fromMillisecondsSinceEpoch(2000),
+        );
+      });
+
+      test(
+        'GIVEN an edited media caption\n'
+        'THEN getDisplayEvent gives the edit time\n'
+        'WHEREAS getDisplayEventWithoutEditEvent keeps the original time\n'
+        '(documents why MessageTime uses getDisplayEvent, not the body event)',
+        () {
+          final original = createOriginal(
+            eventId: '\$img',
+            content: {
+              'body': 'My holiday photo',
+              'filename': 'IMG.jpg',
+              'msgtype': 'm.image',
+              'url': 'mxc://example.org/img',
+            },
+            timestamp: 1000,
+          );
+          final edit = createEdit(
+            originalEventId: '\$img',
+            eventId: '\$img_edit',
+            newContent: {
+              'body': 'My holiday photo (edited)',
+              'filename': 'IMG.jpg',
+              'msgtype': 'm.image',
+              'url': 'mxc://example.org/img',
+            },
+            timestamp: 2000,
+          );
+          final timeline = buildTimeline([original, edit]);
+
+          // What MessageTime now reads: the edit time.
+          expect(
+            original.getDisplayEvent(timeline).originServerTs,
+            DateTime.fromMillisecondsSinceEpoch(2000),
+          );
+          expect(
+            original.getDisplayEventWithoutEditEvent(timeline).originServerTs,
+            DateTime.fromMillisecondsSinceEpoch(1000),
+          );
+        },
+      );
+    },
+  );
 }


### PR DESCRIPTION
## Ticket
Fixes #3179 

## Root cause
The chat list reads `room.lastEvent`, which is the edit event itself, so it shows the **edit** time. The timeline rendered
the **original** event `originServerTs` under the "edited" label which is different from what we see in the chat list.

## Solution
`MessageTime` now reads `event.getDisplayEvent(timeline).originServerTs`, which resolves to the latest edit event. Both views show the edit time consistently.

## Test recommendations
I added some regression tests

## Demos
| Before | After |
|:-------- |:--------:|
|  <img width="1725" height="954" alt="Capture d’écran 2026-06-26 à 09 22 02" src="https://github.com/user-attachments/assets/27bce878-acee-43b5-af92-b95bed545ebd" /> |  <img width="1725" height="954" alt="Capture d’écran 2026-06-26 à 09 21 31" src="https://github.com/user-attachments/assets/e037971f-3e93-47e2-bd7b-3163fa8a3f97" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message timestamps now reflect the correct display time when a message has been edited.
  * Edited messages and captions will show the updated time, while unedited messages keep their original timestamp.
* **Tests**
  * Added coverage for message timestamp behavior with original and edited events to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->