### PR TITLE
TW-3065: Warn user when not able to retry sending

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3261,5 +3261,10 @@
   "resetCompleteDescription": "Your new encryption identity is ready. Previously encrypted messages are no longer available.",
   "verificationFailedTitle": "Verification failed",
   "verificationFailedDescription": "The request was cancelled or rejected. Please try again.",
-  "retryFailedDescription": "Automatic retry didn't work. Try another way to verify this device."
+  "retryFailedDescription": "Automatic retry didn't work. Try another way to verify this device.",
+  "messageCannotBeResent": "This message can't be resent because its data is unavailable",
+  "@messageCannotBeResent": {
+    "type": "text",
+    "placeholders": {}
+  }
 }

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1269,76 +1269,6 @@ class ChatController extends State<Chat>
     }
   }
 
-  /// After timeline loads, remove stuck sending file events that can never
-  /// complete because their file data is gone (web page refresh wipes RAM).
-  ///
-  /// Root cause: on web, `matrixFile` bytes live in RAM only
-  /// (`@JsonKey(includeToJson: false)`). After a page refresh the bytes are
-  /// gone but the event stays in the local DB as `sending/error` forever.
-  /// On mobile, `fileInfo` (a file path) IS serialized and can be restored,
-  /// so mobile events are never affected.
-  Future<void> _removeSendingFileEventsWithLostData() async {
-    final room = this.room;
-    final events = timeline?.events;
-    if (events == null || room == null) return;
-
-    final uploadManager = getIt.get<UploadManager>();
-
-    // Collect first, then remove — cancelSend() triggers handleSync/onUpdate
-    // which would mutate the list mid-iteration.
-    final stuckEvents = <Event>[];
-    for (final event in events) {
-      if (!event.status.isSending && event.status != EventStatus.error) {
-        continue;
-      }
-      if (event.messageType != MessageTypes.Video &&
-          event.messageType != MessageTypes.Image &&
-          event.messageType != MessageTypes.File) {
-        continue;
-      }
-
-      // Only remove events tracked by our upload system (have upload_info in
-      // unsigned). Events without upload_info are from before this feature or
-      // from other clients — leave them alone.
-      final hasUploadInfo =
-          event.unsigned?['upload_info'] is Map<String, dynamic>;
-      if (!hasUploadInfo) continue;
-
-      // getUploadFileInfo checks in-memory map first, then falls back to
-      // restoring from unsigned JSON (works for mobile FileInfo paths).
-      // If either fileInfo or matrixFile is available the upload can proceed.
-      final uploadInfo = await uploadManager.getUploadFileInfo(
-        event.eventId,
-        room: room,
-      );
-      if (uploadInfo != null &&
-          (uploadInfo.fileInfo != null || uploadInfo.matrixFile != null)) {
-        continue;
-      }
-
-      // upload_info exists but no usable bytes → stuck web event, safe to remove.
-      stuckEvents.add(event);
-    }
-
-    for (final event in stuckEvents) {
-      try {
-        Logs().w(
-          'Chat::_removeSendingFileEventsWithLostData(): '
-          'removing stuck event ${event.eventId} (${event.messageType}) — '
-          'file data lost after page refresh',
-        );
-        await event.cancelSend();
-      } catch (e, s) {
-        Logs().e(
-          'Chat::_removeSendingFileEventsWithLostData(): '
-          'failed to remove event ${event.eventId} (${event.messageType})',
-          e,
-          s,
-        );
-      }
-    }
-  }
-
   Future<void> _getTimeline({String? eventContextId}) async {
     await Matrix.of(context).client.roomsLoading;
     await Matrix.of(context).client.accountDataLoading;
@@ -1362,7 +1292,6 @@ class ChatController extends State<Chat>
     }
     timeline?.requestKeys(onlineKeyBackupOnly: false);
     if (room!.markedUnread) room?.markUnread(false);
-    await _removeSendingFileEventsWithLostData();
 
     // Debug: log if room's lastEvent is absent from the freshly loaded timeline
     final lastEvent = room?.lastEvent;

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1321,12 +1321,21 @@ class ChatController extends State<Chat>
     }
 
     for (final event in stuckEvents) {
-      Logs().w(
-        'Chat::_removeSendingFileEventsWithLostData(): '
-        'removing stuck event ${event.eventId} (${event.messageType}) — '
-        'file data lost after page refresh',
-      );
-      await event.cancelSend();
+      try {
+        Logs().w(
+          'Chat::_removeSendingFileEventsWithLostData(): '
+          'removing stuck event ${event.eventId} (${event.messageType}) — '
+          'file data lost after page refresh',
+        );
+        await event.cancelSend();
+      } catch (e, s) {
+        Logs().e(
+          'Chat::_removeSendingFileEventsWithLostData(): '
+          'failed to remove event ${event.eventId} (${event.messageType})',
+          e,
+          s,
+        );
+      }
     }
   }
 

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1269,6 +1269,67 @@ class ChatController extends State<Chat>
     }
   }
 
+  /// After timeline loads, remove stuck sending file events that can never
+  /// complete because their file data is gone (web page refresh wipes RAM).
+  ///
+  /// Root cause: on web, `matrixFile` bytes live in RAM only
+  /// (`@JsonKey(includeToJson: false)`). After a page refresh the bytes are
+  /// gone but the event stays in the local DB as `sending/error` forever.
+  /// On mobile, `fileInfo` (a file path) IS serialized and can be restored,
+  /// so mobile events are never affected.
+  Future<void> _removeSendingFileEventsWithLostData() async {
+    final room = this.room;
+    final events = timeline?.events;
+    if (events == null || room == null) return;
+
+    final uploadManager = getIt.get<UploadManager>();
+
+    // Collect first, then remove — cancelSend() triggers handleSync/onUpdate
+    // which would mutate the list mid-iteration.
+    final stuckEvents = <Event>[];
+    for (final event in events) {
+      if (!event.status.isSending && event.status != EventStatus.error) {
+        continue;
+      }
+      if (event.messageType != MessageTypes.Video &&
+          event.messageType != MessageTypes.Image &&
+          event.messageType != MessageTypes.File) {
+        continue;
+      }
+
+      // Only remove events tracked by our upload system (have upload_info in
+      // unsigned). Events without upload_info are from before this feature or
+      // from other clients — leave them alone.
+      final hasUploadInfo =
+          event.unsigned?['upload_info'] is Map<String, dynamic>;
+      if (!hasUploadInfo) continue;
+
+      // getUploadFileInfo checks in-memory map first, then falls back to
+      // restoring from unsigned JSON (works for mobile FileInfo paths).
+      // If either fileInfo or matrixFile is available the upload can proceed.
+      final uploadInfo = await uploadManager.getUploadFileInfo(
+        event.eventId,
+        room: room,
+      );
+      if (uploadInfo != null &&
+          (uploadInfo.fileInfo != null || uploadInfo.matrixFile != null)) {
+        continue;
+      }
+
+      // upload_info exists but no usable bytes → stuck web event, safe to remove.
+      stuckEvents.add(event);
+    }
+
+    for (final event in stuckEvents) {
+      Logs().w(
+        'Chat::_removeSendingFileEventsWithLostData(): '
+        'removing stuck event ${event.eventId} (${event.messageType}) — '
+        'file data lost after page refresh',
+      );
+      await event.cancelSend();
+    }
+  }
+
   Future<void> _getTimeline({String? eventContextId}) async {
     await Matrix.of(context).client.roomsLoading;
     await Matrix.of(context).client.accountDataLoading;
@@ -1292,6 +1353,7 @@ class ChatController extends State<Chat>
     }
     timeline?.requestKeys(onlineKeyBackupOnly: false);
     if (room!.markedUnread) room?.markUnread(false);
+    await _removeSendingFileEventsWithLostData();
 
     // Debug: log if room's lastEvent is absent from the freshly loaded timeline
     final lastEvent = room?.lastEvent;

--- a/lib/pages/chat/events/images_builder/message_content_image_builder.dart
+++ b/lib/pages/chat/events/images_builder/message_content_image_builder.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:twake_chat/config/app_config.dart';
 import 'package:twake_chat/di/global/get_it_initializer.dart';
 import 'package:twake_chat/pages/chat/events/images_builder/image_bubble.dart';
@@ -95,6 +97,20 @@ class _MessageImageBuilderState extends State<MessageImageBuilder> {
           return SendingImageInfoWidget(
             key: ValueKey(widget.event.eventId),
             matrixFile: file,
+            event: widget.event,
+            onTapPreview: widget.onTapPreview,
+            displayImageInfo: displayImageInfo,
+            bubbleWidth: widget.maxWidth,
+          );
+        }
+        // Keep the placeholder bubble
+        if (!widget.event.status.isSent) {
+          return SendingImageInfoWidget(
+            key: ValueKey(widget.event.eventId),
+            matrixFile: MatrixImageFile(
+              bytes: Uint8List(0),
+              name: widget.event.filename,
+            ),
             event: widget.event,
             onTapPreview: widget.onTapPreview,
             displayImageInfo: displayImageInfo,

--- a/lib/pages/chat/events/images_builder/message_content_image_builder.dart
+++ b/lib/pages/chat/events/images_builder/message_content_image_builder.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/events/images_builder/image_bubble.dart';
@@ -95,6 +97,20 @@ class _MessageImageBuilderState extends State<MessageImageBuilder> {
           return SendingImageInfoWidget(
             key: ValueKey(widget.event.eventId),
             matrixFile: file,
+            event: widget.event,
+            onTapPreview: widget.onTapPreview,
+            displayImageInfo: displayImageInfo,
+            bubbleWidth: widget.maxWidth,
+          );
+        }
+        // Keep the placeholder bubble
+        if (!widget.event.status.isSent) {
+          return SendingImageInfoWidget(
+            key: ValueKey(widget.event.eventId),
+            matrixFile: MatrixImageFile(
+              bytes: Uint8List(0),
+              name: widget.event.filename,
+            ),
             event: widget.event,
             onTapPreview: widget.onTapPreview,
             displayImageInfo: displayImageInfo,

--- a/lib/pages/chat/events/images_builder/sending_image_info_widget.dart
+++ b/lib/pages/chat/events/images_builder/sending_image_info_widget.dart
@@ -53,6 +53,12 @@ class _SendingImageInfoWidgetState extends State<SendingImageInfoWidget>
   final ValueNotifier<double> sendingFileProgressNotifier = ValueNotifier(0);
 
   Future<void> _onTap(BuildContext context) async {
+    if (!widget.event.status.isSent) {
+      if (uploadFileStateNotifier.value is UploadFileFailedUIState) {
+        await onRetryUpload();
+      }
+      return;
+    }
     if (widget.onTapPreview != null) {
       await Navigator.of(context, rootNavigator: PlatformInfos.isWeb).push(
         HeroPageRoute(
@@ -104,9 +110,7 @@ class _SendingImageInfoWidgetState extends State<SendingImageInfoWidget>
                   ),
                 if (hasError)
                   IconButton(
-                    onPressed: () {
-                      uploadManager.retryUpload(widget.event);
-                    },
+                    onPressed: onRetryUpload,
                     icon: Icon(
                       Icons.refresh,
                       color: sysColor.primary,

--- a/lib/pages/chat/events/message_upload_content.dart
+++ b/lib/pages/chat/events/message_upload_content.dart
@@ -81,9 +81,7 @@ class _MessageUploadingContentState extends State<MessageUploadingContent>
                     children: [
                       if (hasError)
                         IconButton(
-                          onPressed: () {
-                            uploadManager.retryUpload(widget.event);
-                          },
+                          onPressed: onRetryUpload,
                           icon: Icon(
                             Icons.refresh,
                             color: sysColor.primary,
@@ -142,7 +140,7 @@ class _MessageUploadingContentState extends State<MessageUploadingContent>
                             return;
                           }
                           if (hasError) {
-                            uploadManager.retryUpload(event);
+                            onRetryUpload();
                           } else {
                             uploadManager.cancelUpload(event);
                           }

--- a/lib/pages/chat/events/message_video_upload_content.dart
+++ b/lib/pages/chat/events/message_video_upload_content.dart
@@ -112,7 +112,7 @@ class _MessageVideoUploadContentState extends State<MessageVideoUploadContent>
                   return;
                 }
                 if (hasError) {
-                  uploadManager.retryUpload(event);
+                  onRetryUpload();
                 } else {
                   uploadManager.cancelUpload(event);
                 }

--- a/lib/pages/chat/events/sending_video_widget.dart
+++ b/lib/pages/chat/events/sending_video_widget.dart
@@ -121,9 +121,7 @@ class _SendingVideoWidgetState extends State<SendingVideoWidget>
           ...switch (event.status) {
             EventStatus.error => [
               IconButton(
-                onPressed: () {
-                  uploadManager.retryUpload(event);
-                },
+                onPressed: onRetryUpload,
                 icon: Icon(Icons.refresh, color: sysColor.primary, size: 24),
                 padding: const EdgeInsets.all(4),
                 style: IconButton.styleFrom(

--- a/lib/utils/manager/upload_manager/models/retry_upload_result.dart
+++ b/lib/utils/manager/upload_manager/models/retry_upload_result.dart
@@ -1,0 +1,13 @@
+enum RetryUploadResult {
+  /// The upload has been queued again
+  started,
+
+  /// A retry is already running
+  alreadyInProgress,
+
+  /// The upload is not in a failed state, there is nothing to retry
+  notFailed,
+
+  /// The file data is gone
+  fileDataUnavailable,
+}

--- a/lib/utils/manager/upload_manager/upload_manager.dart
+++ b/lib/utils/manager/upload_manager/upload_manager.dart
@@ -51,11 +51,18 @@ class UploadManager {
     if (event != null) {
       final uploadInfoMap = event.unsigned?['upload_info'];
       if (uploadInfoMap is Map<String, dynamic>) {
-        final info = UploadFileInfo.fromJson(uploadInfoMap);
-        if (info.fileInfo != null || info.matrixFile != null) {
-          _eventIdMapUploadFileInfo[eventId] = info;
+        try {
+          final info = UploadFileInfo.fromJson(uploadInfoMap);
+          if (info.fileInfo != null || info.matrixFile != null) {
+            _eventIdMapUploadFileInfo[eventId] = info;
+          }
+          return info;
+        } catch (e) {
+          Logs().w(
+            'UploadManager::getUploadFileInfo(): '
+            'failed to parse upload_info for $eventId, ignoring: $e',
+          );
         }
-        return info;
       }
     }
 

--- a/lib/utils/manager/upload_manager/upload_manager.dart
+++ b/lib/utils/manager/upload_manager/upload_manager.dart
@@ -38,17 +38,23 @@ class UploadManager {
     String eventId, {
     required Room room,
   }) async {
-    if (_eventIdMapUploadFileInfo.containsKey(eventId)) {
-      return _eventIdMapUploadFileInfo[eventId];
+    final cached = _eventIdMapUploadFileInfo[eventId];
+    if (cached != null &&
+        (cached.fileInfo != null || cached.matrixFile != null)) {
+      return cached;
     }
 
-    // Attempt to restore on-demand from the event's unsigned data
+    // Attempt to restore on-demand from the event's unsigned data.
+    // Only cache the restored entry when it has usable file data — otherwise
+    // a null-byte entry would poison the map and mask the data-lost condition.
     final event = await room.getEventById(eventId);
     if (event != null) {
       final uploadInfoMap = event.unsigned?['upload_info'];
       if (uploadInfoMap is Map<String, dynamic>) {
         final info = UploadFileInfo.fromJson(uploadInfoMap);
-        _eventIdMapUploadFileInfo[eventId] = info;
+        if (info.fileInfo != null || info.matrixFile != null) {
+          _eventIdMapUploadFileInfo[eventId] = info;
+        }
         return info;
       }
     }
@@ -106,6 +112,18 @@ class UploadManager {
       final room = event.room;
       final fileInfo = uploadInfo.fileInfo;
       final matrixFile = uploadInfo.matrixFile;
+
+      // File bytes lost (e.g. web page refresh) — remove the stuck event
+      // instead of throwing, so the user never sees a broken retry button.
+      if (fileInfo == null && matrixFile == null) {
+        Logs().w(
+          'UploadManager::retryUpload(): no file data for $txid, removing event',
+        );
+        await _clearFileTask(txid);
+        await event.cancelSend();
+        return;
+      }
+
       final caption = uploadInfo.captionInfo?.caption;
       final inReplyTo = uploadInfo.inReplyToEventId == null
           ? null
@@ -122,18 +140,14 @@ class UploadManager {
             uploadInfo: uploadInfo.toJson(),
             inReplyTo: inReplyTo,
           );
-        } else if (matrixFile != null) {
+        } else {
           fakeImageEvent = await room.sendFakeFileEvent(
-            matrixFile,
+            matrixFile!,
             txid: txid,
             captionInfo: caption,
             uploadInfo: uploadInfo.toJson(),
             inReplyTo: inReplyTo,
           );
-        }
-
-        if (fakeImageEvent == null) {
-          throw Exception('Missing required retry data for txid $txid');
         }
       } catch (e) {
         uploadInfo.isFailed = true;
@@ -160,12 +174,12 @@ class UploadManager {
             uploadInfo: uploadInfo.toJson(),
             inReplyTo: inReplyTo,
           );
-        } else if (matrixFile != null) {
+        } else {
           await _addFileTaskToWorkerQueueWeb(
             txid: txid,
             fakeImageEvent: fakeImageEvent,
             room: room,
-            matrixFile: matrixFile,
+            matrixFile: matrixFile!,
             streamController: streamController,
             cancelToken: cancelToken,
             thumbnail: uploadInfo.thumbnail,
@@ -174,8 +188,6 @@ class UploadManager {
             uploadInfo: uploadInfo.toJson(),
             inReplyTo: inReplyTo,
           );
-        } else {
-          throw Exception('No file data found for retry with txid $txid');
         }
       } catch (e) {
         uploadInfo.isFailed = true;

--- a/lib/utils/manager/upload_manager/upload_manager.dart
+++ b/lib/utils/manager/upload_manager/upload_manager.dart
@@ -11,6 +11,7 @@ import 'package:twake_chat/presentation/extensions/send_file_extension.dart';
 import 'package:twake_chat/presentation/extensions/send_file_fake_event_extension.dart';
 import 'package:twake_chat/presentation/extensions/send_file_web_extension.dart';
 import 'package:twake_chat/presentation/model/file/file_asset_entity.dart';
+import 'package:twake_chat/utils/manager/upload_manager/models/retry_upload_result.dart';
 import 'package:twake_chat/utils/manager/upload_manager/models/upload_caption_info.dart';
 import 'package:twake_chat/utils/manager/upload_manager/models/upload_file_info.dart';
 import 'package:twake_chat/utils/manager/upload_manager/upload_state.dart';
@@ -97,38 +98,42 @@ class UploadManager {
   }
 
   /// Retries a failed upload
-  Future<void> retryUpload(Event event) async {
+  Future<RetryUploadResult> retryUpload(Event event) async {
     final txid = event.eventId;
     if (_retriesInProgress.contains(txid)) {
       Logs().w('Retry already in progress for txid $txid');
-      return;
+      return RetryUploadResult.alreadyInProgress;
     }
     _retriesInProgress.add(txid);
     try {
       final uploadInfo = await getUploadFileInfo(txid, room: event.room);
 
       if (uploadInfo == null) {
-        throw Exception('Upload with txid $txid not found');
-      }
-
-      if (!uploadInfo.isFailed) {
-        await event.cancelSend();
-        throw Exception('Upload with txid $txid is not in failed state');
+        Logs().w(
+          'UploadManager::retryUpload(): no upload info for $txid, '
+          'the message cannot be resent',
+        );
+        return RetryUploadResult.fileDataUnavailable;
       }
 
       final room = event.room;
       final fileInfo = uploadInfo.fileInfo;
       final matrixFile = uploadInfo.matrixFile;
 
-      // File bytes lost (e.g. web page refresh) — remove the stuck event
-      // instead of throwing, so the user never sees a broken retry button.
+      // File bytes lost (e.g. web page refresh): keep the event in the timeline
+      // and let the caller tell the user, rather than silently dropping it.
       if (fileInfo == null && matrixFile == null) {
         Logs().w(
-          'UploadManager::retryUpload(): no file data for $txid, removing event',
+          'UploadManager::retryUpload(): no file data for $txid, '
+          'the message cannot be resent',
         );
-        await _clearFileTask(txid);
+        return RetryUploadResult.fileDataUnavailable;
+      }
+
+      if (!uploadInfo.isFailed) {
+        Logs().w('UploadManager::retryUpload(): $txid is not in failed state');
         await event.cancelSend();
-        return;
+        return RetryUploadResult.notFailed;
       }
 
       final caption = uploadInfo.captionInfo?.caption;
@@ -208,6 +213,8 @@ class UploadManager {
         );
         rethrow;
       }
+
+      return RetryUploadResult.started;
     } finally {
       _retriesInProgress.remove(txid);
     }

--- a/lib/utils/manager/upload_manager/upload_manager.dart
+++ b/lib/utils/manager/upload_manager/upload_manager.dart
@@ -11,6 +11,7 @@ import 'package:fluffychat/presentation/extensions/send_file_extension.dart';
 import 'package:fluffychat/presentation/extensions/send_file_fake_event_extension.dart';
 import 'package:fluffychat/presentation/extensions/send_file_web_extension.dart';
 import 'package:fluffychat/presentation/model/file/file_asset_entity.dart';
+import 'package:fluffychat/utils/manager/upload_manager/models/retry_upload_result.dart';
 import 'package:fluffychat/utils/manager/upload_manager/models/upload_caption_info.dart';
 import 'package:fluffychat/utils/manager/upload_manager/models/upload_file_info.dart';
 import 'package:fluffychat/utils/manager/upload_manager/upload_state.dart';
@@ -97,38 +98,42 @@ class UploadManager {
   }
 
   /// Retries a failed upload
-  Future<void> retryUpload(Event event) async {
+  Future<RetryUploadResult> retryUpload(Event event) async {
     final txid = event.eventId;
     if (_retriesInProgress.contains(txid)) {
       Logs().w('Retry already in progress for txid $txid');
-      return;
+      return RetryUploadResult.alreadyInProgress;
     }
     _retriesInProgress.add(txid);
     try {
       final uploadInfo = await getUploadFileInfo(txid, room: event.room);
 
       if (uploadInfo == null) {
-        throw Exception('Upload with txid $txid not found');
-      }
-
-      if (!uploadInfo.isFailed) {
-        await event.cancelSend();
-        throw Exception('Upload with txid $txid is not in failed state');
+        Logs().w(
+          'UploadManager::retryUpload(): no upload info for $txid, '
+          'the message cannot be resent',
+        );
+        return RetryUploadResult.fileDataUnavailable;
       }
 
       final room = event.room;
       final fileInfo = uploadInfo.fileInfo;
       final matrixFile = uploadInfo.matrixFile;
 
-      // File bytes lost (e.g. web page refresh) — remove the stuck event
-      // instead of throwing, so the user never sees a broken retry button.
+      // File bytes lost (e.g. web page refresh): keep the event in the timeline
+      // and let the caller tell the user, rather than silently dropping it.
       if (fileInfo == null && matrixFile == null) {
         Logs().w(
-          'UploadManager::retryUpload(): no file data for $txid, removing event',
+          'UploadManager::retryUpload(): no file data for $txid, '
+          'the message cannot be resent',
         );
-        await _clearFileTask(txid);
+        return RetryUploadResult.fileDataUnavailable;
+      }
+
+      if (!uploadInfo.isFailed) {
+        Logs().w('UploadManager::retryUpload(): $txid is not in failed state');
         await event.cancelSend();
-        return;
+        return RetryUploadResult.notFailed;
       }
 
       final caption = uploadInfo.captionInfo?.caption;
@@ -208,6 +213,8 @@ class UploadManager {
         );
         rethrow;
       }
+
+      return RetryUploadResult.started;
     } finally {
       _retriesInProgress.remove(txid);
     }

--- a/lib/widgets/mixins/upload_file_mixin.dart
+++ b/lib/widgets/mixins/upload_file_mixin.dart
@@ -7,6 +7,7 @@ import 'package:twake_chat/di/global/get_it_initializer.dart';
 import 'package:twake_chat/generated/l10n/app_localizations.dart';
 import 'package:twake_chat/presentation/model/chat/upload_file_ui_state.dart';
 import 'package:twake_chat/utils/exception/upload_exception.dart';
+import 'package:twake_chat/utils/manager/upload_manager/models/retry_upload_result.dart';
 import 'package:twake_chat/utils/manager/upload_manager/upload_manager.dart';
 import 'package:twake_chat/utils/manager/upload_manager/upload_state.dart';
 import 'package:twake_chat/utils/twake_snackbar.dart';
@@ -26,6 +27,14 @@ mixin UploadFileMixin<T extends StatefulWidget> on State<T> {
   _trySetupUploadStreamSubcription() => streamSubscription = uploadManager
       .getUploadStateStream(event.eventId)
       ?.listen(setupUploadProcess);
+
+  Future<void> onRetryUpload() async {
+    final result = await uploadManager.retryUpload(event);
+    if (!mounted) return;
+    if (result == RetryUploadResult.fileDataUnavailable) {
+      TwakeSnackBar.show(context, L10n.of(context)!.messageCannotBeResent);
+    }
+  }
 
   void setupUploadProcess(Either<Failure, Success> state) {
     state.fold(

--- a/lib/widgets/mixins/upload_file_mixin.dart
+++ b/lib/widgets/mixins/upload_file_mixin.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:fluffychat/presentation/model/chat/upload_file_ui_state.dart';
 import 'package:fluffychat/utils/exception/upload_exception.dart';
+import 'package:fluffychat/utils/manager/upload_manager/models/retry_upload_result.dart';
 import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
 import 'package:fluffychat/utils/manager/upload_manager/upload_state.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
@@ -26,6 +27,14 @@ mixin UploadFileMixin<T extends StatefulWidget> on State<T> {
   _trySetupUploadStreamSubcription() => streamSubscription = uploadManager
       .getUploadStateStream(event.eventId)
       ?.listen(setupUploadProcess);
+
+  Future<void> onRetryUpload() async {
+    final result = await uploadManager.retryUpload(event);
+    if (!mounted) return;
+    if (result == RetryUploadResult.fileDataUnavailable) {
+      TwakeSnackBar.show(context, L10n.of(context)!.messageCannotBeResent);
+    }
+  }
 
   void setupUploadProcess(Either<Failure, Success> state) {
     state.fold(

--- a/test/widget/upload_file_mixin_test.dart
+++ b/test/widget/upload_file_mixin_test.dart
@@ -1,0 +1,126 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:fluffychat/config/localizations/localization_service.dart';
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:fluffychat/utils/manager/upload_manager/models/retry_upload_result.dart';
+import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/widgets/mixins/upload_file_mixin.dart';
+import 'package:fluffychat/widgets/theme_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localized_locales/flutter_localized_locales.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'upload_file_mixin_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<Room>(), MockSpec<UploadManager>()])
+class _RetryUploadHost extends StatefulWidget {
+  const _RetryUploadHost({required this.event});
+
+  final Event event;
+
+  @override
+  State<_RetryUploadHost> createState() => _RetryUploadHostState();
+}
+
+class _RetryUploadHostState extends State<_RetryUploadHost>
+    with UploadFileMixin<_RetryUploadHost> {
+  @override
+  Event get event => widget.event;
+
+  @override
+  Widget build(BuildContext context) =>
+      TextButton(onPressed: onRetryUpload, child: const Text('retry'));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockUploadManager uploadManager;
+  late Event event;
+
+  setUpAll(() {
+    getIt.registerSingleton(ResponsiveUtils());
+  });
+
+  setUp(() {
+    uploadManager = MockUploadManager();
+    if (getIt.isRegistered<UploadManager>()) {
+      getIt.unregister<UploadManager>();
+    }
+    getIt.registerSingleton<UploadManager>(uploadManager);
+    event = Event(
+      content: {'body': 'document.pdf', 'msgtype': 'm.file'},
+      type: 'm.room.message',
+      eventId: 'txid',
+      senderId: '@bob:example.com',
+      originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
+      room: MockRoom(),
+      status: EventStatus.error,
+    );
+  });
+
+  Future<void> pumpAndTapRetry(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ThemeBuilder(
+        builder: (context, themeMode, primaryColor) => MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: const [
+            LocaleNamesLocalizationsDelegate(),
+            L10n.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          supportedLocales: LocalizationService.supportedLocales,
+          theme: TwakeThemes.buildTheme(
+            context,
+            Brightness.light,
+            primaryColor,
+          ),
+          home: Scaffold(body: _RetryUploadHost(event: event)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('retry'));
+    await tester.pumpAndSettle();
+  }
+
+  group('UploadFileMixin::onRetryUpload()', () {
+    testWidgets('\nWHEN the file data of a failed upload is gone.\n'
+        'THEN a snackbar tells the user the message cannot be resent.\n', (
+      tester,
+    ) async {
+      when(
+        uploadManager.retryUpload(event),
+      ).thenAnswer((_) async => RetryUploadResult.fileDataUnavailable);
+
+      await pumpAndTapRetry(tester);
+
+      expect(
+        find.text(
+          "This message can't be resent because its data is unavailable",
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('\nWHEN the upload is retried successfully.\n'
+        'THEN no snackbar is displayed.\n', (tester) async {
+      when(
+        uploadManager.retryUpload(event),
+      ).thenAnswer((_) async => RetryUploadResult.started);
+
+      await pumpAndTapRetry(tester);
+
+      expect(find.byType(SnackBar), findsNothing);
+    });
+  });
+}

--- a/test/widget/upload_file_mixin_test.dart
+++ b/test/widget/upload_file_mixin_test.dart
@@ -1,0 +1,126 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'package:twake_chat/config/localizations/localization_service.dart';
+import 'package:twake_chat/config/themes.dart';
+import 'package:twake_chat/di/global/get_it_initializer.dart';
+import 'package:twake_chat/generated/l10n/app_localizations.dart';
+import 'package:twake_chat/utils/manager/upload_manager/models/retry_upload_result.dart';
+import 'package:twake_chat/utils/manager/upload_manager/upload_manager.dart';
+import 'package:twake_chat/utils/responsive/responsive_utils.dart';
+import 'package:twake_chat/widgets/mixins/upload_file_mixin.dart';
+import 'package:twake_chat/widgets/theme_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_localized_locales/flutter_localized_locales.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'upload_file_mixin_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<Room>(), MockSpec<UploadManager>()])
+class _RetryUploadHost extends StatefulWidget {
+  const _RetryUploadHost({required this.event});
+
+  final Event event;
+
+  @override
+  State<_RetryUploadHost> createState() => _RetryUploadHostState();
+}
+
+class _RetryUploadHostState extends State<_RetryUploadHost>
+    with UploadFileMixin<_RetryUploadHost> {
+  @override
+  Event get event => widget.event;
+
+  @override
+  Widget build(BuildContext context) =>
+      TextButton(onPressed: onRetryUpload, child: const Text('retry'));
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockUploadManager uploadManager;
+  late Event event;
+
+  setUpAll(() {
+    getIt.registerSingleton(ResponsiveUtils());
+  });
+
+  setUp(() {
+    uploadManager = MockUploadManager();
+    if (getIt.isRegistered<UploadManager>()) {
+      getIt.unregister<UploadManager>();
+    }
+    getIt.registerSingleton<UploadManager>(uploadManager);
+    event = Event(
+      content: {'body': 'document.pdf', 'msgtype': 'm.file'},
+      type: 'm.room.message',
+      eventId: 'txid',
+      senderId: '@bob:example.com',
+      originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
+      room: MockRoom(),
+      status: EventStatus.error,
+    );
+  });
+
+  Future<void> pumpAndTapRetry(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ThemeBuilder(
+        builder: (context, themeMode, primaryColor) => MaterialApp(
+          locale: const Locale('en'),
+          localizationsDelegates: const [
+            LocaleNamesLocalizationsDelegate(),
+            L10n.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          supportedLocales: LocalizationService.supportedLocales,
+          theme: TwakeThemes.buildTheme(
+            context,
+            Brightness.light,
+            primaryColor,
+          ),
+          home: Scaffold(body: _RetryUploadHost(event: event)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('retry'));
+    await tester.pumpAndSettle();
+  }
+
+  group('UploadFileMixin::onRetryUpload()', () {
+    testWidgets('\nWHEN the file data of a failed upload is gone.\n'
+        'THEN a snackbar tells the user the message cannot be resent.\n', (
+      tester,
+    ) async {
+      when(
+        uploadManager.retryUpload(event),
+      ).thenAnswer((_) async => RetryUploadResult.fileDataUnavailable);
+
+      await pumpAndTapRetry(tester);
+
+      expect(
+        find.text(
+          "This message can't be resent because its data is unavailable",
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('\nWHEN the upload is retried successfully.\n'
+        'THEN no snackbar is displayed.\n', (tester) async {
+      when(
+        uploadManager.retryUpload(event),
+      ).thenAnswer((_) async => RetryUploadResult.started);
+
+      await pumpAndTapRetry(tester);
+
+      expect(find.byType(SnackBar), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Ticket
**Related issue**

- Fixes #3065

### Root Cause:

- `UploadFileInfo` stores file bytes (matrixFile) and bytes live in RAM only, never serialized. On web, F5 wipes RAM. The sending event persists in local Matrix DB with status = sending/error but bytes are gone — upload can never complete or retry. 
- Note: Mobile is unaffected — fileInfo (file path on disk) IS serialized and restored correctly.  

### Steps to Reproduce :
1. Go offline (or have poor connection)
2. Send a video/image/file → upload fails
3. F5 (page refresh)
4. Come back online → open chat
5. Result: Stuck event visible in timeline, retry button does nothing  

### Solution:

On retry, if data is lost, show a snackbar

## Demo


https://github.com/user-attachments/assets/e660297e-f68e-40e3-a808-13b6db05f8f4

