### PR TITLE
Fix web image viewer original asset loading

### DIFF
--- a/lib/pages/image_viewer/image_viewer.dart
+++ b/lib/pages/image_viewer/image_viewer.dart
@@ -57,6 +57,8 @@ class ImageViewerController extends State<ImageViewer> {
   StreamSubscription? streamSubcription;
 
   final _webOverlay = MediaViewerWebOverlay.image();
+  String? _webAttachmentEventId;
+  Future<MatrixFile>? _webAttachmentFuture;
 
   @override
   void initState() {
@@ -75,7 +77,7 @@ class ImageViewerController extends State<ImageViewer> {
   /// the DOM so the browser's native "Save Image As" context menu works.
   Future<void> _injectWebImageOverlay(Event event) async {
     try {
-      final matrixFile = await event.downloadAndDecryptAttachment();
+      final matrixFile = await webAttachmentFuture(event);
       if (!mounted) return;
       final mimeType = event.mimeType ?? 'image/jpeg';
       _webOverlay.attach(
@@ -86,6 +88,14 @@ class ImageViewerController extends State<ImageViewer> {
     } catch (e) {
       Logs().e('ImageViewerController: failed to inject web overlay', e);
     }
+  }
+
+  Future<MatrixFile> webAttachmentFuture(Event event) {
+    if (_webAttachmentEventId != event.eventId) {
+      _webAttachmentEventId = event.eventId;
+      _webAttachmentFuture = event.downloadAndDecryptAttachment();
+    }
+    return _webAttachmentFuture!;
   }
 
   Future<void> handleDownloadFile(Event event) async {

--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -130,8 +130,11 @@ class _ImageWidget extends StatelessWidget {
         );
       }
       return FutureBuilder(
-        future: event.downloadAndDecryptAttachment(),
+        future: controller.webAttachmentFuture(event),
         builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return const Icon(Icons.broken_image_outlined, color: Colors.white);
+          }
           if (snapshot.data == null || snapshot.data!.bytes.isEmpty != false) {
             return const CircularProgressIndicator();
           }

--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -130,16 +130,14 @@ class _ImageWidget extends StatelessWidget {
         );
       }
       return FutureBuilder(
-        // Download full image for GIFs to preserve animation
-        future: event.downloadAndDecryptAttachment(
-          getThumbnail: !event.isGifImage,
-        ),
+        future: event.downloadAndDecryptAttachment(),
         builder: (context, snapshot) {
           if (snapshot.data == null || snapshot.data!.bytes.isEmpty != false) {
             return const CircularProgressIndicator();
           }
           return Image.memory(
             snapshot.data!.bytes,
+            fit: BoxFit.contain,
             cacheWidth: width != null
                 ? (width! * MediaQuery.devicePixelRatioOf(context)).toInt()
                 : null,


### PR DESCRIPTION
## Summary
- Fix web image viewer to load the original image instead of the thumbnail.
- Keep thumbnail usage in chat bubbles unchanged.
- Use contain fit for full-screen image display.

<img width="697" height="564" alt="image" src="https://github.com/user-attachments/assets/582a51ed-6e53-403b-8cd4-5750514e6155" />
<img width="1624" height="1000" alt="image" src="https://github.com/user-attachments/assets/9f73e54c-cfc4-4392-ab2d-2fbf425d9876" />
<img width="820" height="737" alt="image" src="https://github.com/user-attachments/assets/90795b0b-563c-4e3a-95b7-7f92c0255dc0" />


## Root cause
The web image viewer requested thumbnails for non-GIF images, so full-screen preview could display a low-resolution asset while download used the original file.

Fixes #3199

## Validation
- dart format lib/pages/image_viewer/image_viewer_view.dart
- flutter analyze lib/pages/image_viewer/image_viewer_view.dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved web image loading by memoizing the asynchronous download/decryption used for image overlays, reducing repeated fetches.
  * Adjusted the web rendering path to use the controller’s cached future while preserving the existing loading indicator and image display layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->