### PR TITLE
TW-3170(fix): send read marker when a room opens already at bottom

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -693,6 +693,7 @@ class ChatController extends State<Chat>
       // and no timeline update
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
+        if (_isProgrammaticScrolling) return;
         _markLatestReadIfAtBottom();
       });
     } catch (e, s) {

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -669,10 +669,9 @@ class ChatController extends State<Chat>
       });
       await _tryRequestHistory();
       final fullyRead = room?.fullyRead;
-      if (fullyRead == null || fullyRead.isEmpty || fullyRead == '') {
-        return;
-      }
-      if (room?.hasNewMessages == true) {
+      if (fullyRead != null &&
+          fullyRead.isNotEmpty &&
+          room?.hasNewMessages == true) {
         // Log only when lastEvent is absent — scrolling to fullyRead may push it out of view.
         final lastEventId = room?.lastEvent?.eventId;
         final lastEventInTimeline =
@@ -690,7 +689,12 @@ class ChatController extends State<Chat>
         }
         _initUnreadLocation(fullyRead);
       }
-      if (!mounted) return;
+      // Mark read on open: a room already at the live bottom fires no scroll
+      // and no timeline update
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _markLatestReadIfAtBottom();
+      });
     } catch (e, s) {
       Logs().wtf('Failed to load timeline', e, s);
       rethrow;


### PR DESCRIPTION
## Problem
Related to #3170 
The unread badge didn't clear when opening a room already openned at the live bottom (short timelines): with no scroll and no timeline update, neither `_updateScrollController` nor `updateView` invoked the read marker, so no receipt was ever sent.

## Fix
In `_tryLoadTimeline`, schedule `_markLatestReadIfAtBottom()` post-frame on open (once the `scrollController` is attached). The `_isAtLiveBottom` guard leaves rooms opened on a mid-timeline unread marker untouched.

## Validation
`chat_list_test` (Patrol web) 3/4 passing before, now 4/4 (https://github.com/linagora/twake-on-matrix/actions/runs/28576823192)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-status handling when opening chats, so messages are more reliably marked as read.
  * Fixed cases where a chat could fail to update as read when there was no immediate scrolling or timeline refresh.
  * Chat screens now more accurately detect unread/new messages and apply the correct read state on open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->