### PR TITLE
TW-3203: reuse timeline status icon for chat list last message

### DIFF
--- a/lib/pages/chat/events/message/message_content_builder_mixin.dart
+++ b/lib/pages/chat/events/message/message_content_builder_mixin.dart
@@ -151,7 +151,7 @@ mixin MessageContentBuilderMixin {
     const pushpinIconSize = MessageStyle.pushpinIconSize;
     const paddingAllPushpin = MessageStyle.paddingAllPushpin;
     const paddingToTimeSpacing = 4.0;
-    final seenByRowIconSize = MessageTimeStyle.seenByRowIconSize;
+    const seenByRowIconSize = MessageTimeStyle.seenByRowIconSize;
     final paddingTimeAndIcon = MessageTimeStyle.paddingTimeAndIcon;
 
     double totalWidth = painTimeText.width;

--- a/lib/pages/chat/events/message_time_style.dart
+++ b/lib/pages/chat/events/message_time_style.dart
@@ -9,7 +9,7 @@ final class MessageTimeStyle {
 
   static double get timelineLetterSpacing => 0.4;
   static double get paddingTimeAndIcon => 8;
-  static double get seenByRowIconSize => 16;
+  static const double seenByRowIconSize = 16;
 
   static Color readReceiptColor(bool seenByOthers) => seenByOthers
       ? LinagoraSysColors.material().secondary

--- a/lib/pages/chat/seen_by_row.dart
+++ b/lib/pages/chat/seen_by_row.dart
@@ -9,11 +9,14 @@ class SeenByRow extends StatelessWidget {
   final EventStatus? eventStatus;
   final bool timelineOverlayMessage;
 
+  final double size;
+
   const SeenByRow({
     this.eventStatus,
     super.key,
     required this.getSeenByUsers,
     required this.timelineOverlayMessage,
+    this.size = MessageTimeStyle.seenByRowIconSize,
   });
 
   @override
@@ -46,43 +49,22 @@ class SeenByRow extends StatelessWidget {
     List<User> seenByUsers, {
     EventStatus? eventStatus,
   }) {
-    final messageStatus = getMessageStatus(
+    final Color secondaryColor = MessageTimeStyle.seenByRowIconSecondaryColor(
+      timelineOverlayMessage,
+      colorScheme,
+    );
+    final (IconData icon, Color color) = switch (getMessageStatus(
       seenByUsers,
       eventStatus: eventStatus,
-    );
-    switch (messageStatus) {
-      case MessageStatus.sending:
-        return Icon(
-          Icons.schedule,
-          color: MessageTimeStyle.seenByRowIconSecondaryColor(
-            timelineOverlayMessage,
-            colorScheme,
-          ),
-          size: MessageTimeStyle.seenByRowIconSize,
-        );
-      case MessageStatus.sent:
-        return Icon(
-          Icons.done_all,
-          color: MessageTimeStyle.seenByRowIconSecondaryColor(
-            timelineOverlayMessage,
-            colorScheme,
-          ),
-          size: MessageTimeStyle.seenByRowIconSize,
-        );
-      case MessageStatus.hasBeenSeen:
-        return Icon(
-          Icons.done_all,
-          color: MessageTimeStyle.seenByRowIconPrimaryColor(
-            timelineOverlayMessage,
-          ),
-          size: MessageTimeStyle.seenByRowIconSize,
-        );
-      case MessageStatus.error:
-        return Icon(
-          Icons.error,
-          color: colorScheme.error,
-          size: MessageTimeStyle.seenByRowIconSize,
-        );
-    }
+    )) {
+      MessageStatus.sending => (Icons.schedule, secondaryColor),
+      MessageStatus.sent => (Icons.done_all, secondaryColor),
+      MessageStatus.hasBeenSeen => (
+        Icons.done_all,
+        MessageTimeStyle.seenByRowIconPrimaryColor(timelineOverlayMessage),
+      ),
+      MessageStatus.error => (Icons.error, colorScheme.error),
+    };
+    return Icon(icon, color: color, size: size);
   }
 }

--- a/lib/pages/chat_list/chat_list_item_subtitle.dart
+++ b/lib/pages/chat_list/chat_list_item_subtitle.dart
@@ -4,7 +4,7 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/domain/model/room/room_preview_result.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
-import 'package:fluffychat/pages/chat/events/message_time_style.dart';
+import 'package:fluffychat/pages/chat/seen_by_row.dart';
 import 'package:fluffychat/pages/chat/typing_timer_wrapper.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_item_style.dart';
 import 'package:fluffychat/pages/chat_list/chat_preview_text.dart';
@@ -81,12 +81,16 @@ class ChatListItemSubtitle extends StatelessWidget with ChatListItemMixin {
             }
             final isMentioned = lastEvent.isMention == true;
             return lastEvent.senderId == room.client.userID
-                ? Icon(
-                    Icons.done_all,
-                    color: MessageTimeStyle.readReceiptColor(
-                      room.hasLastEventBeenSeenByOthers,
-                    ),
+                ? SeenByRow(
+                    eventStatus: lastEvent.status,
+                    timelineOverlayMessage: false,
                     size: 20,
+                    getSeenByUsers: lastEvent.receipts
+                        .where(
+                          (receipt) => receipt.user.id != room.client.userID,
+                        )
+                        .map((receipt) => receipt.user)
+                        .toList(),
                   )
                 : AnimatedContainer(
                     duration: TwakeThemes.animationDuration,

--- a/test/pages/chat/seen_by_row_test.dart
+++ b/test/pages/chat/seen_by_row_test.dart
@@ -1,0 +1,62 @@
+import 'package:fluffychat/pages/chat/seen_by_row.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+// getMessageStatus only checks whether the seen-by list is empty, so a bare
+// fake avoids building a real User (which would require a Room).
+class _FakeUser extends Fake implements User {}
+
+void main() {
+  const seenByRow = SeenByRow(
+    getSeenByUsers: [],
+    timelineOverlayMessage: false,
+  );
+  final seenByOthers = [_FakeUser()];
+
+  group('SeenByRow.getMessageStatus', () {
+    test('error status maps to error', () {
+      expect(
+        seenByRow.getMessageStatus(
+          seenByOthers,
+          eventStatus: EventStatus.error,
+        ),
+        MessageStatus.error,
+      );
+    });
+
+    test('null status maps to sending', () {
+      expect(seenByRow.getMessageStatus([]), MessageStatus.sending);
+    });
+
+    test('sending status maps to sending', () {
+      expect(
+        seenByRow.getMessageStatus([], eventStatus: EventStatus.sending),
+        MessageStatus.sending,
+      );
+    });
+
+    test('sent status maps to sent even with receipts', () {
+      expect(
+        seenByRow.getMessageStatus(seenByOthers, eventStatus: EventStatus.sent),
+        MessageStatus.sent,
+      );
+    });
+
+    test('synced without receipts maps to sent', () {
+      expect(
+        seenByRow.getMessageStatus([], eventStatus: EventStatus.synced),
+        MessageStatus.sent,
+      );
+    });
+
+    test('synced with receipts maps to hasBeenSeen', () {
+      expect(
+        seenByRow.getMessageStatus(
+          seenByOthers,
+          eventStatus: EventStatus.synced,
+        ),
+        MessageStatus.hasBeenSeen,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Ticket
Fixes #3203 

## Root cause
The chat list always showed a static double-check for the last message, not its actual send status.

<img width="1154" height="1032" alt="Capture d’écran 2026-07-02 à 10 37 16" src="https://github.com/user-attachments/assets/13b7bcf1-83fb-4e8c-8e24-688aa1b7bb7b" />
<img width="1154" height="1032" alt="Capture d’écran 2026-07-02 à 10 38 22" src="https://github.com/user-attachments/assets/626483fe-d6db-4324-ab39-54cce5022cd4" />

## Solution
Reflect the last message's status in the chat list (in particular for sending / error) by reusing the timeline's `SeenByRow` widget. I Added an optional `size` param to it (default unchanged).

## Impact description
Chat list shows pending and error state, the timeline is untouched.

## Test recommendations
Go offline then send, you should see the clock icon in both timeline and chat list, then red error icon on both. If you go back online, retry to send you should see the double-check icon.

## Demos
<img width="1725" height="993" alt="Capture d’écran 2026-07-02 à 10 11 47" src="https://github.com/user-attachments/assets/41a1fcd7-40d4-4a35-b790-92549b42276b" />

<img width="1725" height="993" alt="Capture d’écran 2026-07-02 à 10 10 36" src="https://github.com/user-attachments/assets/d4029793-57fc-488d-956a-fca75693653b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Read/seen indicators now appear more consistently in chat subtitles for your own messages.
  * Seen-status display now supports configurable icon sizing.

* **Bug Fixes**
  * Improved how message status icons are chosen and colored across sending, sent, seen, and error states.
  * Read receipts now better reflect who has seen a message, excluding the current user.

* **Tests**
  * Added coverage for message status mapping to help ensure read/seen indicators behave correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->