### PR TITLE
Fix sync error header visibility and Sentry reporting

### DIFF
--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -35,10 +35,7 @@ class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
       if (!mounted) return;
 
       final client = Matrix.of(context).client;
-      final hide =
-          client.onSync.value != null &&
-          update.status != SyncStatus.error &&
-          client.prevBatch != null;
+      final hide = client.onSync.value != null && client.prevBatch != null;
 
       if (_lastStatus?.status != update.status || _lastHideState != hide) {
         setState(() {
@@ -63,10 +60,7 @@ class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
         _lastStatus ??
         client.onSyncStatus.value ??
         const SyncStatusUpdate(SyncStatus.waitingForResponse);
-    final hide =
-        client.onSync.value != null &&
-        status.status != SyncStatus.error &&
-        client.prevBatch != null;
+    final hide = client.onSync.value != null && client.prevBatch != null;
 
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 200),

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -396,6 +396,10 @@ class MatrixState extends State<Matrix>
   final onKeyVerificationRequestSub = <String, StreamSubscription>{};
   final onNotification = <String, StreamSubscription>{};
   final onLoginStateChanged = <String, StreamSubscription<LoginState>>{};
+  final onSyncStatusSub = <String, StreamSubscription>{};
+  final _lastSyncErrorSentAt = <String, DateTime>{};
+
+  static const _syncErrorSentryThrottle = Duration(minutes: 10);
 
   /// Re-registers the Web Push pusher when the app language changes so its
   /// (generic) notification text follows the account language.
@@ -543,6 +547,9 @@ class MatrixState extends State<Matrix>
     onUiaRequest[name] ??= currentClient.onUiaRequest.stream.listen(
       uiaRequestHandler,
     );
+    onSyncStatusSub[name] ??= currentClient.onSyncStatus.stream.listen(
+      (update) => _handleSyncStatusUpdate(currentClient, update),
+    );
     if (PlatformInfos.isWeb || PlatformInfos.isLinux) {
       Future<void> initWebNotifications() async {
         if (kIsWeb) {
@@ -599,6 +606,45 @@ class MatrixState extends State<Matrix>
         }
       }
     });
+  }
+
+  void _handleSyncStatusUpdate(Client client, SyncStatusUpdate update) {
+    if (update.status != SyncStatus.error || update.error == null) return;
+
+    _captureSyncError(client, update);
+  }
+
+  void _captureSyncError(Client client, SyncStatusUpdate update) {
+    final error = update.error;
+    if (error == null) return;
+
+    final exception = error.exception ?? Exception('Unknown Matrix sync error');
+    final errorType = exception.runtimeType.toString();
+    final throttleKey = '${client.clientName}:$errorType';
+    final now = DateTime.now();
+    final lastSentAt = _lastSyncErrorSentAt[throttleKey];
+    if (lastSentAt != null &&
+        now.difference(lastSentAt) < _syncErrorSentryThrottle) {
+      return;
+    }
+
+    _lastSyncErrorSentAt[throttleKey] = now;
+    // ignore: unawaited_futures
+    Sentry.captureException(
+      exception,
+      stackTrace: error.stackTrace,
+      withScope: (scope) async {
+        await scope.setTag('sync_status', update.status.name);
+        await scope.setTag('sync_error_type', errorType);
+        await scope.setContexts('matrix_sync', {
+          'has_prev_batch': client.prevBatch != null,
+          'has_sync_value': client.onSync.value != null,
+          'is_logged': client.isLogged(),
+          'platform': PlatformInfos.clientName,
+          'sync_pending': client.syncPending,
+        });
+      },
+    );
   }
 
   Future<void> _requestNotificationPermission() async {
@@ -751,6 +797,8 @@ class MatrixState extends State<Matrix>
     onNotification.remove(name);
     await onUiaRequest[name]?.cancel();
     onUiaRequest.remove(name);
+    await onSyncStatusSub[name]?.cancel();
+    onSyncStatusSub.remove(name);
     final webPushListener = _webPushLocaleListener;
     if (webPushListener != null) {
       LocalizationService.currentLocale.removeListener(webPushListener);
@@ -1474,6 +1522,9 @@ class MatrixState extends State<Matrix>
       s.cancel();
     }
     for (final s in onUiaRequest.values) {
+      s.cancel();
+    }
+    for (final s in onSyncStatusSub.values) {
       s.cancel();
     }
     onClientLoginStateChanged.close();

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -631,8 +631,7 @@ class MatrixState extends State<Matrix>
     _lastSyncErrorSentAt[throttleKey] = now;
     // ignore: unawaited_futures
     Sentry.captureException(
-      exception,
-      stackTrace: error.stackTrace,
+      Exception('Matrix sync error: $errorType'),
       withScope: (scope) async {
         await scope.setTag('sync_status', update.status.name);
         await scope.setTag('sync_error_type', errorType);


### PR DESCRIPTION
## Summary

Fixes #3201.

- Hide the connection status header after a first successful sync, even when the Matrix SDK emits `SyncStatus.error`.
- Report Matrix sync errors to Sentry with lightweight, non-sensitive context and a 10-minute throttle per client/error type.

## Root cause

On mobile, the header logic treated `SyncStatus.error` as a visible state even when the client already had a `prevBatch` and a previous sync value. A transient sync-loop exception could therefore bring back the "Waiting for response" banner although the app was not necessarily offline.

## Validation

| Step | Evidence |
| --- | --- |
| Original issue screenshot | https://github.com/linagora/twake-on-matrix/issues/3201 |
| After fix: no visible sync banner with an existing sync state | `/tmp/twake-ios-recheck.png` |
| Forced reproduction: injected `Exception('injected /sync failure')` in the sync path to force `SyncStatus.error` | `/tmp/twake-ios-injected-sync-error.png` |
| Previous forced-error evidence showing the visible "Waiting for response" banner | `/tmp/twake-sync-error.png` |

<img width="1320" height="2868" alt="twake-ios-recheck" src="https://github.com/user-attachments/assets/206b33e5-27c8-46c3-912c-dd56afd33eca" />

With injected error before fix : 
<img width="1320" height="2868" alt="twake-ios-injected-sync-error" src="https://github.com/user-attachments/assets/ebe9952f-341e-4098-8c2c-d9a27375e893" />



Static check:

```console
flutter analyze lib/widgets/connection_status_header.dart lib/widgets/matrix.dart
```

Result: no issues found.

## Trade-off

This sync error is useful technical signal, but it is not actionable for the user once the app already has synced data. We now keep the UI quiet for non-fatal sync errors and send them to Sentry instead. Fatal or explicit auth errors should still use their dedicated user-facing flows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed connection status header visibility so the sync indicator displays consistently based on actual sync availability.
  * Enhanced sync error handling by capturing Matrix sync failures for monitoring while throttling repeated reports to reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
