### PR TITLE
TW-3196: Improve download progress display for files

### DIFF
--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -261,7 +261,8 @@ class MessageContent extends StatelessWidget
               mainAxisSize: MainAxisSize.min,
               children: [
                 if (!PlatformInfos.isWeb) ...[
-                  if (event.isSending()) ...[
+                  if (event.isSending() ||
+                      event.status == EventStatus.error) ...[
                     MessageUploadingContent(
                       event: event,
                       style: const MessageFileTileStyle(),
@@ -269,7 +270,8 @@ class MessageContent extends StatelessWidget
                   ] else
                     MessageDownloadContent(event),
                 ] else ...[
-                  if (event.isSending()) ...[
+                  if (event.isSending() ||
+                      event.status == EventStatus.error) ...[
                     OptionalSelectionContainerDisabled(
                       isEnabled:
                           PlatformInfos.isWeb && !event.isCaptionModeOrReply(),

--- a/lib/pages/chat/events/message_upload_content.dart
+++ b/lib/pages/chat/events/message_upload_content.dart
@@ -108,17 +108,17 @@ class _MessageUploadingContentState extends State<MessageUploadingContent>
                             shape: BoxShape.circle,
                           ),
                         ),
-                        if (uploadProgress != 0)
-                          SizedBox(
-                            width: widget.style.circularProgressLoadingSize,
-                            height: widget.style.circularProgressLoadingSize,
-                            child: CircularLoadingDownloadWidget(
-                              style: widget.style,
-                              downloadProgress: uploadProgress != 1
-                                  ? uploadProgress
-                                  : null,
-                            ),
+                        SizedBox(
+                          width: widget.style.circularProgressLoadingSize,
+                          height: widget.style.circularProgressLoadingSize,
+                          child: CircularLoadingDownloadWidget(
+                            style: widget.style,
+                            downloadProgress:
+                                (uploadProgress == null || uploadProgress == 1)
+                                ? null
+                                : uploadProgress,
                           ),
+                        ),
                         Container(
                           width: widget.style.downloadIconSize,
                           decoration: BoxDecoration(
@@ -176,11 +176,12 @@ class _MessageUploadingContentState extends State<MessageUploadingContent>
                             builder: ((context, uploadFileState, child) {
                               if (uploadFileState is UploadingFileUIState &&
                                   uploadFileState.total != null &&
-                                  uploadFileState.receive != null &&
-                                  uploadFileState.total! >=
-                                      IntExtension.oneKB) {
+                                  uploadFileState.receive != null) {
                                 return Text(
-                                  '${uploadFileState.receive!.bytesToMB(placeDecimal: 2)} MB / ${uploadFileState.total!.bytesToMB(placeDecimal: 2)} MB',
+                                  IntExtension.formatTransferProgress(
+                                    uploadFileState.receive!,
+                                    uploadFileState.total!,
+                                  ),
                                   style: widget.style.textInformationStyle(
                                     context,
                                   ),

--- a/lib/utils/matrix_sdk_extensions/int_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/int_extension.dart
@@ -11,7 +11,35 @@ extension IntExtension on int {
     return this ~/ (1024 * 1024);
   }
 
-  static const oneKB = 1024 * 1024;
+  static const oneKB = 1024;
+
+  static const oneMB = 1024 * 1024;
+
+  /// Formats a transfer-progress string, picking the unit from [total].
+  ///
+  /// Uses MB for files >= 1 MB and KB for smaller ones, so sub-1MB transfers
+  /// still show visible progress instead of "0.00 MB / 0.00 MB". When
+  /// [includeTotal] is false only the received half is returned (e.g.
+  /// "12 KB / "), letting the caller render the total separately.
+  static String formatTransferProgress(
+    int receive,
+    int total, {
+    bool includeTotal = true,
+  }) {
+    final useMB = total >= oneMB;
+    final unit = useMB ? 'MB' : 'KB';
+    final decimals = useMB ? 2 : 0;
+    final receiveText = useMB
+        ? receive.bytesToMB(placeDecimal: decimals)
+        : receive.bytesToKB(placeDecimal: decimals);
+    if (!includeTotal) {
+      return '$receiveText $unit / ';
+    }
+    final totalText = useMB
+        ? total.bytesToMB(placeDecimal: decimals)
+        : total.bytesToKB(placeDecimal: decimals);
+    return '$receiveText $unit / $totalText $unit';
+  }
 
   String formatNumberAudioDuration() {
     String numberStr = toString();

--- a/lib/widgets/file_widget/file_tile_widget.dart
+++ b/lib/widgets/file_widget/file_tile_widget.dart
@@ -65,10 +65,13 @@ class TextInformationOfFile extends StatelessWidget {
             builder: ((context, downloadFileState, child) {
               if (downloadFileState is DownloadingPresentationState &&
                   downloadFileState.total != null &&
-                  downloadFileState.receive != null &&
-                  downloadFileState.total! >= IntExtension.oneKB) {
+                  downloadFileState.receive != null) {
                 return Text(
-                  '${downloadFileState.receive!.bytesToMB(placeDecimal: 1)} MB / ',
+                  IntExtension.formatTransferProgress(
+                    downloadFileState.receive!,
+                    downloadFileState.total!,
+                    includeTotal: false,
+                  ),
                   style: style,
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,


### PR DESCRIPTION
## Ticket
**Related issue**

- #3196 
- #3195 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:
- Improve upload progress display for files
 
https://github.com/user-attachments/assets/86c63c0a-be74-4e37-b284-a5036bf8dc70

- Fixed: Show uploading content for events with error status

https://github.com/user-attachments/assets/44027c49-55df-4dfb-b5de-edf34df8fb30



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File uploads now show the uploading/progress state when an error occurs, instead of switching to a download-style view.
  * Upload and download progress indicators now display consistently, including cases where progress starts at 0.
  * File transfer text now shows more accurate progress formatting for both small and large files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->