### PR TITLE
Fix contacts loading and refresh

### DIFF
--- a/lib/domain/app_state/contact/get_phonebook_contact_state.dart
+++ b/lib/domain/app_state/contact/get_phonebook_contact_state.dart
@@ -94,11 +94,15 @@ class GetPhoneBookContactFailure extends Failure {
 
 class GetHashDetailsFailure extends Failure {
   final dynamic exception;
+  final List<Contact> contacts;
 
-  const GetHashDetailsFailure({required this.exception});
+  const GetHashDetailsFailure({
+    required this.exception,
+    this.contacts = const [],
+  });
 
   @override
-  List<Object?> get props => [exception];
+  List<Object?> get props => [exception, contacts];
 }
 
 class LookUpContactFailure extends Failure {

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -472,7 +472,10 @@ class FederationLookUpPhonebookContactInteractor {
           hashDetails.algorithms == null ||
           hashDetails.algorithms!.isEmpty) {
         firstFailureRef(
-          const GetHashDetailsFailure(exception: 'Hash details is empty'),
+          GetHashDetailsFailure(
+            exception: 'Hash details is empty',
+            contacts: contacts,
+          ),
         );
         return null;
       }
@@ -488,7 +491,7 @@ class FederationLookUpPhonebookContactInteractor {
         'hash details failed for $federationUrl',
         e,
       );
-      firstFailureRef(GetHashDetailsFailure(exception: e));
+      firstFailureRef(GetHashDetailsFailure(exception: e, contacts: contacts));
       return null;
     }
   }

--- a/lib/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor.dart
@@ -73,8 +73,11 @@ class TwakeLookupPhonebookContactInteractor {
 
       if (res.lookupPepper?.isEmpty == true &&
           res.algorithms?.isEmpty == true) {
-        yield const Left(
-          GetHashDetailsFailure(exception: 'Hash details is empty'),
+        yield Left(
+          GetHashDetailsFailure(
+            exception: 'Hash details is empty',
+            contacts: contacts,
+          ),
         );
         return;
       }
@@ -84,7 +87,7 @@ class TwakeLookupPhonebookContactInteractor {
       Logs().e(
         'FederationLookUpPhonebookContactInteractor::execute: GetHashDetails: $e',
       );
-      yield Left(GetHashDetailsFailure(exception: e));
+      yield Left(GetHashDetailsFailure(exception: e, contacts: contacts));
       return;
     }
 

--- a/lib/pages/contacts_tab/contacts_tab.dart
+++ b/lib/pages/contacts_tab/contacts_tab.dart
@@ -32,7 +32,8 @@ class ContactsTabController extends State<ContactsTab>
         ComparablePresentationContactMixin,
         ContactsViewControllerMixin,
         AddressBooksMixin,
-        WidgetsBindingObserver {
+        WidgetsBindingObserver,
+        AutomaticKeepAliveClientMixin {
   final responsive = getIt.get<ResponsiveUtils>();
 
   Client get client => Matrix.of(context).client;
@@ -120,6 +121,18 @@ class ContactsTabController extends State<ContactsTab>
     }
   }
 
+  Future<void> retrySynchronizeContacts() async {
+    if (!mounted) {
+      return;
+    }
+
+    await retrySynchronizeContactsOnContactTab(
+      context: context,
+      client: Matrix.of(context).client,
+      matrixLocalizations: MatrixLocals(L10n.of(context)!),
+    );
+  }
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) async {
     await handleDidChangeAppLifecycleState(state, client: client);
@@ -133,8 +146,14 @@ class ContactsTabController extends State<ContactsTab>
   }
 
   @override
-  Widget build(BuildContext context) => ContactsTabView(
-    contactsController: this,
-    bottomNavigationBar: widget.bottomNavigationBar,
-  );
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return ContactsTabView(
+      contactsController: this,
+      bottomNavigationBar: widget.bottomNavigationBar,
+    );
+  }
 }

--- a/lib/pages/contacts_tab/contacts_tab.dart
+++ b/lib/pages/contacts_tab/contacts_tab.dart
@@ -44,6 +44,9 @@ class ContactsTabController extends State<ContactsTab>
   bool get enableRecentContacts => false;
 
   @override
+  bool get enablePhonebookContacts => supportInvitation();
+
+  @override
   void initState() {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       WidgetsBinding.instance.addObserver(this);

--- a/lib/pages/contacts_tab/contacts_tab_body_view.dart
+++ b/lib/pages/contacts_tab/contacts_tab_body_view.dart
@@ -18,23 +18,27 @@ class ContactsTabBodyView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CustomScrollView(
-      slivers: [
-        if (controller.client.userID != null)
-          SliverInviteFriendButton(userId: controller.client.userID!),
-        SliverWarningBanner(controller: controller),
-        SliverLoadingContacts(controller: controller),
-        SliverContactsWithMatrixId(controller: controller),
-        if (PlatformInfos.isMobile)
-          SliverPhonebookContactsWithMatrixId(controller: controller),
-        SliverContactsWithoutMatrixId(controller: controller),
-        if (PlatformInfos.isMobile)
-          SliverPhonebookContactsWithoutMatrixId(controller: controller),
-        SliverEmptyContacts(controller: controller),
-        const SliverToBoxAdapter(
-          child: SizedBox(height: ContactsTabViewStyle.padding),
-        ),
-      ],
+    return RefreshIndicator(
+      onRefresh: controller.retrySynchronizeContacts,
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          if (controller.client.userID != null)
+            SliverInviteFriendButton(userId: controller.client.userID!),
+          SliverWarningBanner(controller: controller),
+          SliverLoadingContacts(controller: controller),
+          SliverContactsWithMatrixId(controller: controller),
+          if (PlatformInfos.isMobile)
+            SliverPhonebookContactsWithMatrixId(controller: controller),
+          SliverContactsWithoutMatrixId(controller: controller),
+          if (PlatformInfos.isMobile)
+            SliverPhonebookContactsWithoutMatrixId(controller: controller),
+          SliverEmptyContacts(controller: controller),
+          const SliverToBoxAdapter(
+            child: SizedBox(height: ContactsTabViewStyle.padding),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/contacts_tab/empty_contacts_body.dart
+++ b/lib/pages/contacts_tab/empty_contacts_body.dart
@@ -5,7 +5,9 @@ import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 
 class EmptyContactBody extends StatelessWidget {
-  const EmptyContactBody({super.key});
+  const EmptyContactBody({super.key, this.onRetrySyncContacts});
+
+  final VoidCallback? onRetrySyncContacts;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +36,15 @@ class EmptyContactBody extends StatelessWidget {
             ),
             textAlign: TextAlign.center,
           ),
+          if (onRetrySyncContacts != null) ...[
+            const SizedBox(height: 16.0),
+            FilledButton.icon(
+              onPressed: onRetrySyncContacts,
+              icon: const Icon(Icons.sync, size: 20.0),
+              label: Text(L10n.of(context)!.tapToRetry),
+              style: FilledButton.styleFrom(shape: const StadiumBorder()),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/pages/contacts_tab/widgets/sliver_empty_contacts.dart
+++ b/lib/pages/contacts_tab/widgets/sliver_empty_contacts.dart
@@ -1,36 +1,13 @@
-import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_tab.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_tab_view_style.dart';
 import 'package:fluffychat/pages/contacts_tab/empty_contacts_body.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/no_contacts_found.dart';
-import 'package:fluffychat/presentation/model/contact/presentation_contact_success.dart';
 import 'package:flutter/material.dart';
 
 class SliverEmptyContacts extends StatelessWidget {
   const SliverEmptyContacts({required this.controller, super.key});
 
   final ContactsTabController controller;
-
-  bool _isLoading() => controller.presentationContactNotifier.value.fold(
-    (_) => false,
-    (s) => s is ContactsLoading,
-  );
-
-  bool _hasContactsData() => controller.presentationContactNotifier.value.fold(
-    (_) => false,
-    (s) =>
-        (s is PresentationContactsSuccess && s.contacts.isNotEmpty) ||
-        s is PresentationExternalContactSuccess,
-  );
-
-  bool _hasPhonebookData() =>
-      controller.presentationPhonebookContactNotifier.value.fold(
-        (_) => false,
-        (s) => s is PresentationContactsSuccess && s.contacts.isNotEmpty,
-      );
-
-  bool _hasRecentData() =>
-      controller.presentationRecentContactNotifier.value.isNotEmpty;
 
   @override
   Widget build(BuildContext context) {
@@ -41,15 +18,16 @@ class SliverEmptyContacts extends StatelessWidget {
         controller.presentationRecentContactNotifier,
       ]),
       builder: (context, _) {
-        if (_isLoading() ||
-            _hasContactsData() ||
-            _hasPhonebookData() ||
-            _hasRecentData()) {
+        if (controller.isWaitingContacts || controller.hasVisibleContacts) {
           return const SliverToBoxAdapter();
         }
         final keyword = controller.textEditingController.text;
         if (keyword.isEmpty) {
-          return const SliverToBoxAdapter(child: EmptyContactBody());
+          return SliverToBoxAdapter(
+            child: EmptyContactBody(
+              onRetrySyncContacts: controller.retrySynchronizeContacts,
+            ),
+          );
         }
         return SliverToBoxAdapter(
           child: Padding(

--- a/lib/pages/contacts_tab/widgets/sliver_loading_contacts.dart
+++ b/lib/pages/contacts_tab/widgets/sliver_loading_contacts.dart
@@ -1,4 +1,3 @@
-import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_tab.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/loading_contact_widget.dart';
 import 'package:flutter/material.dart';
@@ -10,15 +9,17 @@ class SliverLoadingContacts extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder(
-      valueListenable: controller.presentationContactNotifier,
-      builder: (context, state, _) {
-        return state.fold((_) => const SliverToBoxAdapter(), (success) {
-          if (success is ContactsLoading) {
-            return const SliverToBoxAdapter(child: LoadingContactWidget());
-          }
-          return const SliverToBoxAdapter();
-        });
+    return ListenableBuilder(
+      listenable: Listenable.merge([
+        controller.presentationContactNotifier,
+        controller.presentationPhonebookContactNotifier,
+        controller.presentationRecentContactNotifier,
+      ]),
+      builder: (context, _) {
+        if (controller.isWaitingContacts && !controller.hasVisibleContacts) {
+          return const SliverToBoxAdapter(child: LoadingContactWidget());
+        }
+        return const SliverToBoxAdapter();
       },
     );
   }

--- a/lib/pages/new_group/contacts_selection.dart
+++ b/lib/pages/new_group/contacts_selection.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/presentation/mixins/address_book_mixin.dart';
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
 import 'package:fluffychat/presentation/mixins/invite_external_contact_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/pages/new_group/contacts_selection_view.dart';
 import 'package:fluffychat/pages/new_group/selected_contacts_map_change_notifier.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
@@ -15,6 +16,7 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
     extends State<T>
     with
         InviteExternalContactMixin,
+        WellKnownMixin,
         ContactsViewControllerMixin,
         AddressBooksMixin,
         WidgetsBindingObserver {
@@ -33,6 +35,9 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
 
   bool get isFullScreen => true;
 
+  @override
+  bool get enablePhonebookContacts => supportInvitation();
+
   Client get client => Matrix.of(context).client;
 
   @override
@@ -41,6 +46,9 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
       WidgetsBinding.instance.addObserver(this);
       if (mounted) {
         listenAddressBookEvents(client);
+        discoveryInformationNotifier.value = Matrix.of(
+          context,
+        ).loginHomeserverSummary?.discoveryInformation;
         initialFetchContacts(
           context: context,
           client: client,

--- a/lib/pages/new_private_chat/new_private_chat.dart
+++ b/lib/pages/new_private_chat/new_private_chat.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/presentation/mixins/comparable_presentation_contact_m
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
 import 'package:fluffychat/presentation/mixins/go_to_group_chat_mixin.dart';
 import 'package:fluffychat/presentation/mixins/invite_external_contact_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/pages/new_private_chat/new_private_chat_view.dart';
 import 'package:fluffychat/presentation/mixins/go_to_direct_chat_mixin.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
@@ -25,6 +26,7 @@ class NewPrivateChat extends StatefulWidget {
 class NewPrivateChatController extends State<NewPrivateChat>
     with
         ComparablePresentationContactMixin,
+        WellKnownMixin,
         ContactsViewControllerMixin,
         GoToDraftChatMixin,
         WidgetsBindingObserver,
@@ -34,6 +36,9 @@ class NewPrivateChatController extends State<NewPrivateChat>
   final scrollController = ScrollController();
 
   @override
+  bool get enablePhonebookContacts => supportInvitation();
+
+  @override
   void initState() {
     super.initState();
     SchedulerBinding.instance.addPostFrameCallback((_) async {
@@ -41,6 +46,9 @@ class NewPrivateChatController extends State<NewPrivateChat>
       if (mounted) {
         final client = Matrix.of(context).client;
         listenAddressBookEvents(client);
+        discoveryInformationNotifier.value = Matrix.of(
+          context,
+        ).loginHomeserverSummary?.discoveryInformation;
         initialFetchContacts(
           context: context,
           client: client,

--- a/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
@@ -61,6 +61,11 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
     required PresentationContact contact,
     InvitationStatusResponse? invitationStatus,
   }) async {
+    Logs().d(
+      'ExpansionContactListTile::_handleMatrixIdNull '
+      'hasMatrixId=${widget.contact.matrixId?.isNotEmpty == true} '
+      'hasInvitation=${invitationStatus?.invitation != null}',
+    );
     if (invitationStatus?.invitation != null &&
         invitationStatus!.invitation?.hasMatrixId == true) {
       widget.onContactTap?.call();
@@ -71,7 +76,8 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
       widget.onContactTap?.call();
       return;
     }
-    if (client.userID == null && client.userID?.isEmpty == true) return;
+    if (!widget.enableInvitation) return;
+    if (client.userID == null || client.userID!.isEmpty) return;
     final result = await showAdaptiveBottomSheet<String?>(
       context: context,
       builder: (context) => ContactsInvitation(
@@ -117,10 +123,12 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
             bottom: 8.0,
           ),
           child: FutureBuilder<Profile?>(
-            key: widget.contact.matrixId != null
+            key: widget.contact.matrixId?.isNotEmpty == true
                 ? Key(widget.contact.matrixId!)
                 : null,
-            future: widget.contact.status == ContactStatus.active
+            future:
+                widget.contact.status == ContactStatus.active &&
+                    widget.contact.matrixId?.isNotEmpty == true
                 ? getProfile(context)
                 : null,
             builder: (context, snapshot) {
@@ -387,6 +395,10 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
         contact: contact,
         invitationStatus: invitationStatus,
       );
+    }
+
+    if (contact.matrixId == null || contact.matrixId!.isEmpty) {
+      return null;
     }
 
     if (widget.onContactTap != null) {

--- a/lib/pages/new_private_chat/widget/expansion_phonebook_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_phonebook_contact_list_tile.dart
@@ -62,6 +62,11 @@ class _ExpansionPhonebookContactListTileState
     required PresentationContact contact,
     InvitationStatusResponse? invitationStatus,
   }) async {
+    Logs().d(
+      'ExpansionPhonebookContactListTile::_handleMatrixIdNull '
+      'hasMatrixId=${widget.contact.matrixId?.isNotEmpty == true} '
+      'hasInvitation=${invitationStatus?.invitation != null}',
+    );
     if (invitationStatus?.invitation != null &&
         invitationStatus!.invitation?.hasMatrixId == true) {
       widget.onContactTap?.call();
@@ -72,7 +77,8 @@ class _ExpansionPhonebookContactListTileState
       widget.onContactTap?.call();
       return;
     }
-    if (client.userID == null && client.userID?.isEmpty == true) return;
+    if (!widget.enableInvitation) return;
+    if (client.userID == null || client.userID!.isEmpty) return;
     final result = await showAdaptiveBottomSheet<String?>(
       context: context,
       builder: (context) => ContactsInvitation(
@@ -118,10 +124,12 @@ class _ExpansionPhonebookContactListTileState
             bottom: 8.0,
           ),
           child: FutureBuilder<Profile?>(
-            key: widget.contact.matrixId != null
+            key: widget.contact.matrixId?.isNotEmpty == true
                 ? Key(widget.contact.matrixId!)
                 : null,
-            future: widget.contact.status == ContactStatus.active
+            future:
+                widget.contact.status == ContactStatus.active &&
+                    widget.contact.matrixId?.isNotEmpty == true
                 ? getProfile(context)
                 : null,
             builder: (context, snapshot) {
@@ -376,6 +384,10 @@ class _ExpansionPhonebookContactListTileState
         contact: contact,
         invitationStatus: invitationStatus,
       );
+    }
+
+    if (contact.matrixId == null || contact.matrixId!.isEmpty) {
+      return null;
     }
 
     if (widget.onContactTap != null) {

--- a/lib/pages/search/search_contacts_and_chats_controller.dart
+++ b/lib/pages/search/search_contacts_and_chats_controller.dart
@@ -148,6 +148,11 @@ class SearchContactsAndChatsController
             .value
             .getFailureOrNull<RegisterTokenFailure>()
             ?.contacts ??
+        contactManger
+            .getPhonebookContactsNotifier()
+            .value
+            .getFailureOrNull<GetHashDetailsFailure>()
+            ?.contacts ??
         [];
     return phoneBookContacts;
   }

--- a/lib/pages/search/search_contacts_and_chats_controller.dart
+++ b/lib/pages/search/search_contacts_and_chats_controller.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/pages/search/search_debouncer_mixin.dart';
 import 'package:fluffychat/pages/search/search_mixin.dart';
 import 'package:fluffychat/presentation/extensions/contact/presentation_contact_extension.dart';
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search_state_extension.dart';
 import 'package:fluffychat/utils/extension/presentation_search_extension.dart';
@@ -22,7 +23,11 @@ import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart' hide Contact;
 
 class SearchContactsAndChatsController
-    with SearchDebouncerMixin, SearchMixin, ContactsViewControllerMixin {
+    with
+        SearchDebouncerMixin,
+        SearchMixin,
+        WellKnownMixin,
+        ContactsViewControllerMixin {
   final BuildContext context;
 
   SearchContactsAndChatsController(this.context);
@@ -38,6 +43,9 @@ class SearchContactsAndChatsController
 
   final isShowChatsAndContactsNotifier = ValueNotifier(false);
 
+  @override
+  bool get enablePhonebookContacts => supportInvitation();
+
   void toggleShowMore() {
     isShowChatsAndContactsNotifier.toggle();
   }
@@ -50,6 +58,9 @@ class SearchContactsAndChatsController
   List<Room> get _rooms => client.rooms;
 
   Future<void> init() async {
+    discoveryInformationNotifier.value = Matrix.of(
+      context,
+    ).loginHomeserverSummary?.discoveryInformation;
     initializeDebouncer((keyword) {
       _searchChatsFromLocal(keyword: keyword);
     });

--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -76,13 +76,34 @@ mixin class ContactsViewControllerMixin {
   bool _canReadPhonebookContacts(PermissionStatus? status) =>
       status == PermissionStatus.granted || status == PermissionStatus.limited;
 
+  bool get enablePhonebookContacts => true;
+
   Future<bool> _isPhonebookContactsAvailable() async {
+    if (!enablePhonebookContacts) {
+      contactsPermissionStatus = null;
+      return false;
+    }
+
     final currentContactsPermissionStatus = PlatformInfos.isMobile
         ? await _permissionHandlerService.contactsPermissionStatus
         : null;
     contactsPermissionStatus = currentContactsPermissionStatus;
     return PlatformInfos.isMobile &&
         _canReadPhonebookContacts(currentContactsPermissionStatus);
+  }
+
+  Future<void> _initPhonebookPermission(BuildContext context) async {
+    if (!enablePhonebookContacts) {
+      warningBannerNotifier.value = WarningContactsBannerState.hide;
+      return;
+    }
+
+    if (PlatformInfos.isMobile &&
+        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
+      await displayContactPermissionDialog(context);
+    } else {
+      await _initWarningBanner();
+    }
   }
 
   bool get phoneBookFilterSuccess => presentationPhonebookContactNotifier.value
@@ -132,6 +153,10 @@ mixin class ContactsViewControllerMixin {
   bool get enableRecentContacts => true;
 
   Future displayContactPermissionDialog(BuildContext context) async {
+    if (!enablePhonebookContacts) {
+      return;
+    }
+
     final fetchContactsPermissionStatus =
         await _permissionHandlerService.contactsPermissionStatus;
 
@@ -169,6 +194,11 @@ mixin class ContactsViewControllerMixin {
   }
 
   Future<void> _initWarningBanner() async {
+    if (!enablePhonebookContacts) {
+      warningBannerNotifier.value = WarningContactsBannerState.hide;
+      return;
+    }
+
     if (!PlatformInfos.isMobile) {
       return;
     }
@@ -195,7 +225,7 @@ mixin class ContactsViewControllerMixin {
     AppLifecycleState state, {
     required Client client,
   }) async {
-    if (!PlatformInfos.isMobile) {
+    if (!enablePhonebookContacts || !PlatformInfos.isMobile) {
       return;
     }
     Logs().i(
@@ -235,12 +265,7 @@ mixin class ContactsViewControllerMixin {
     required MatrixLocalizations matrixLocalizations,
     bool forceRun = false,
   }) async {
-    if (PlatformInfos.isMobile &&
-        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
-      await displayContactPermissionDialog(context);
-    } else {
-      await _initWarningBanner();
-    }
+    await _initPhonebookPermission(context);
     _refreshAllContacts(
       context: context,
       client: client,
@@ -279,12 +304,7 @@ mixin class ContactsViewControllerMixin {
     required Client client,
     required MatrixLocalizations matrixLocalizations,
   }) async {
-    if (PlatformInfos.isMobile &&
-        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
-      await displayContactPermissionDialog(context);
-    } else {
-      await _initWarningBanner();
-    }
+    await _initPhonebookPermission(context);
     _refreshAllContacts(
       context: context,
       client: client,
@@ -322,12 +342,7 @@ mixin class ContactsViewControllerMixin {
     required Client client,
     required MatrixLocalizations matrixLocalizations,
   }) async {
-    if (PlatformInfos.isMobile &&
-        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
-      await displayContactPermissionDialog(context);
-    } else {
-      await _initWarningBanner();
-    }
+    await _initPhonebookPermission(context);
 
     if (client.userID == null) {
       return;
@@ -375,7 +390,13 @@ mixin class ContactsViewControllerMixin {
   }) {
     final keyword = _debouncer.value.trim();
     _refreshContacts(keyword);
-    _refreshPhoneBookContacts(keyword);
+    if (enablePhonebookContacts) {
+      _refreshPhoneBookContacts(keyword);
+    } else if (!presentationPhonebookContactNotifier.isDisposed) {
+      presentationPhonebookContactNotifier.value = const Right(
+        GetPhonebookContactsInitial(),
+      );
+    }
     if (enableRecentContacts) {
       _refreshRecentContacts(
         context: context,
@@ -695,6 +716,10 @@ mixin class ContactsViewControllerMixin {
   Future<void> _handleRequestContactsPermission({
     required Client client,
   }) async {
+    if (!enablePhonebookContacts) {
+      return;
+    }
+
     final currentContactsPermissionStatus = await _permissionHandlerService
         .requestContactsPermissionActions();
     if (_canReadPhonebookContacts(currentContactsPermissionStatus)) {
@@ -731,6 +756,10 @@ mixin class ContactsViewControllerMixin {
   }
 
   List<String> _flatMatrixIdsFromPhonebookContacts() {
+    if (!enablePhonebookContacts) {
+      return [];
+    }
+
     final phonebookContacts =
         contactsManager
             .getPhonebookContactsNotifier()

--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -73,8 +73,57 @@ mixin class ContactsViewControllerMixin {
 
   PermissionStatus? contactsPermissionStatus;
 
+  bool _canReadPhonebookContacts(PermissionStatus? status) =>
+      status == PermissionStatus.granted || status == PermissionStatus.limited;
+
+  Future<bool> _isPhonebookContactsAvailable() async {
+    final currentContactsPermissionStatus = PlatformInfos.isMobile
+        ? await _permissionHandlerService.contactsPermissionStatus
+        : null;
+    contactsPermissionStatus = currentContactsPermissionStatus;
+    return PlatformInfos.isMobile &&
+        _canReadPhonebookContacts(currentContactsPermissionStatus);
+  }
+
   bool get phoneBookFilterSuccess => presentationPhonebookContactNotifier.value
       .fold((_) => false, (success) => success is GetPhonebookContactsSuccess);
+
+  bool get hasVisibleContacts =>
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) =>
+            (success is PresentationContactsSuccess &&
+                success.contacts.isNotEmpty) ||
+            success is PresentationExternalContactSuccess,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) =>
+            success is PresentationContactsSuccess &&
+            success.contacts.isNotEmpty,
+      ) ||
+      presentationRecentContactNotifier.value.isNotEmpty;
+
+  bool get isLoadingContacts =>
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is ContactsLoading,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is GetPhonebookContactsLoading,
+      );
+
+  bool get isWaitingContacts =>
+      isLoadingContacts ||
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is ContactsInitial,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is GetPhonebookContactsInitial,
+      );
 
   /// Whether recent contacts (DMs found by the SDK) are mixed into the
   /// contacts list. The Contacts page must reflect the ToM Address Book only,
@@ -88,7 +137,8 @@ mixin class ContactsViewControllerMixin {
 
     contactsPermissionStatus = fetchContactsPermissionStatus;
 
-    if (PlatformInfos.isMobile && !fetchContactsPermissionStatus.isGranted) {
+    if (PlatformInfos.isMobile &&
+        !_canReadPhonebookContacts(fetchContactsPermissionStatus)) {
       await showDialog(
         useRootNavigator: false,
         context: context,
@@ -128,7 +178,7 @@ mixin class ContactsViewControllerMixin {
       'ContactsViewControllerMixin::_initWarningBanner: Contact Permission $currentContactPermission',
     );
 
-    if (currentContactPermission.isGranted) {
+    if (_canReadPhonebookContacts(currentContactPermission)) {
       contactsPermissionStatus = currentContactPermission;
       warningBannerNotifier.value = WarningContactsBannerState.hide;
       return;
@@ -170,7 +220,7 @@ mixin class ContactsViewControllerMixin {
       }
 
       if (currentContactPermission != contactsPermissionStatus &&
-          currentContactPermission.isGranted) {
+          _canReadPhonebookContacts(currentContactPermission)) {
         contactsPermissionStatus = currentContactPermission;
         warningBannerNotifier.value = WarningContactsBannerState.hide;
         contactsManager.synchronizePhonebookContacts(withMxId: client.userID!);
@@ -219,9 +269,7 @@ mixin class ContactsViewControllerMixin {
     await contactsManager.initialSynchronizeContacts(
       withMxId: client.userID!,
       isAvailableSupportPhonebookContacts:
-          PlatformInfos.isMobile &&
-          contactsPermissionStatus != null &&
-          contactsPermissionStatus == PermissionStatus.granted,
+          await _isPhonebookContactsAvailable(),
       forceRun: forceRun,
     );
   }
@@ -265,9 +313,37 @@ mixin class ContactsViewControllerMixin {
     await contactsManager.synchronizeContactsOnContactTab(
       withMxId: client.userID!,
       isAvailableSupportPhonebookContacts:
-          PlatformInfos.isMobile &&
-          contactsPermissionStatus != null &&
-          contactsPermissionStatus == PermissionStatus.granted,
+          await _isPhonebookContactsAvailable(),
+    );
+  }
+
+  Future<void> retrySynchronizeContactsOnContactTab({
+    required BuildContext context,
+    required Client client,
+    required MatrixLocalizations matrixLocalizations,
+  }) async {
+    if (PlatformInfos.isMobile &&
+        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
+      await displayContactPermissionDialog(context);
+    } else {
+      await _initWarningBanner();
+    }
+
+    if (client.userID == null) {
+      return;
+    }
+
+    await contactsManager.cancelAllSubscriptions();
+    await contactsManager.reSyncContacts();
+    _refreshAllContacts(
+      context: context,
+      client: client,
+      matrixLocalizations: matrixLocalizations,
+    );
+    await contactsManager.synchronizeContactsOnContactTab(
+      withMxId: client.userID!,
+      isAvailableSupportPhonebookContacts:
+          await _isPhonebookContactsAvailable(),
     );
   }
 
@@ -453,6 +529,23 @@ mixin class ContactsViewControllerMixin {
               }
             }
 
+            if (failure is GetHashDetailsFailure) {
+              final filteredContacts = failure.contacts
+                  .searchContacts(keyword)
+                  .expand((contact) => contact.toPresentationContacts())
+                  .toList();
+              if (filteredContacts.isEmpty) {
+                return Left(GetPresentationContactsEmpty(keyword: keyword));
+              } else {
+                return Right(
+                  GetPresentationContactsSuccess(
+                    contacts: filteredContacts,
+                    keyword: keyword,
+                  ),
+                );
+              }
+            }
+
             return Left(failure);
           },
           (success) {
@@ -586,8 +679,11 @@ mixin class ContactsViewControllerMixin {
   }
 
   void onSelectedContact() {
-    textEditingController.clear();
     searchFocusNode.requestFocus();
+    textEditingController.selection = TextSelection(
+      baseOffset: 0,
+      extentOffset: textEditingController.text.length,
+    );
   }
 
   void closeSearchBar() {
@@ -601,7 +697,7 @@ mixin class ContactsViewControllerMixin {
   }) async {
     final currentContactsPermissionStatus = await _permissionHandlerService
         .requestContactsPermissionActions();
-    if (currentContactsPermissionStatus == PermissionStatus.granted) {
+    if (_canReadPhonebookContacts(currentContactsPermissionStatus)) {
       contactsManager.synchronizePhonebookContacts(withMxId: client.userID!);
       warningBannerNotifier.value = WarningContactsBannerState.hide;
     } else {

--- a/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body_view.dart
+++ b/lib/widgets/layouts/adaptive_layout/app_adaptive_scaffold_body_view.dart
@@ -241,11 +241,16 @@ class _ColumnPageView extends StatelessWidget {
   }) {
     return ValueListenableBuilder<AdaptiveDestinationEnum>(
       valueListenable: activeNavigationBarNotifier,
+      child: navigatorBarWidget,
       builder: (context, currentNavigatorBar, child) {
-        if (navigatorBarType == currentNavigatorBar) {
-          return navigatorBarWidget;
-        }
-        return const SizedBox();
+        final isActive = navigatorBarType == currentNavigatorBar;
+        return TickerMode(
+          enabled: isActive,
+          child: Offstage(
+            offstage: !isActive,
+            child: child ?? const SizedBox(),
+          ),
+        );
       },
     );
   }

--- a/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
@@ -189,7 +189,12 @@ void main() {
           interactor.execute(argument: testArgument),
           emitsInOrder([
             const Right(GetPhonebookContactsLoading()),
-            Left(GetHashDetailsFailure(exception: expectedException)),
+            Left(
+              GetHashDetailsFailure(
+                exception: expectedException,
+                contacts: testContacts,
+              ),
+            ),
           ]),
         );
       });
@@ -408,8 +413,11 @@ void main() {
           interactor.execute(argument: testArgument),
           emitsInOrder([
             const Right(GetPhonebookContactsLoading()),
-            const Left(
-              GetHashDetailsFailure(exception: 'Hash details is empty'),
+            Left(
+              GetHashDetailsFailure(
+                exception: 'Hash details is empty',
+                contacts: testContacts,
+              ),
             ),
           ]),
         );

--- a/test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart
@@ -591,7 +591,10 @@ void main() {
           emitsInOrder(<dynamic>[
             const Right<Failure, Success>(GetPhonebookContactsLoading()),
             Left<Failure, Success>(
-              GetHashDetailsFailure(exception: expectedException),
+              GetHashDetailsFailure(
+                exception: expectedException,
+                contacts: contacts,
+              ),
             ),
           ]),
         );


### PR DESCRIPTION
## Summary
- keep contacts tab state alive between navigations
- avoid retry/loader flicker while contact sources are still loading
- add pull-to-refresh to resync ToM and phonebook contact sources

## Test
- fvm flutter analyze lib/pages/contacts_tab/contacts_tab.dart lib/pages/contacts_tab/contacts_tab_body_view.dart lib/pages/contacts_tab/widgets/sliver_empty_contacts.dart lib/pages/contacts_tab/widgets/sliver_loading_contacts.dart lib/presentation/mixins/contacts_view_controller_mixin.dart
- manually run on iOS device Mangue

https://github.com/user-attachments/assets/c72d9641-7393-4e5c-8240-5b0e9f70666e

<img width="660" height="1434" alt="Capture d’écran 2026-07-06 à 16 29 43" src="https://github.com/user-attachments/assets/3b15a949-a6b0-448e-bcbd-648011c9de7e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added pull-to-refresh to the Contacts tab, enabling retry of contact synchronization.
  * Empty contact states can now display a retry button when syncing is possible.
  * Phonebook lookup flows now surface previously collected contacts for more complete results when hash-details are missing.

* **Bug Fixes**
  * Improved Contacts tab state management (including keep-alive behavior) for smoother loading/waiting/empty transitions.
  * Hardened chat contact tile handling to avoid invalid actions when Matrix IDs are empty or missing.

* **Improvements**
  * Updated phonebook permission/readability logic to better reflect limited vs granted access, and adjusted related UI refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->