### PR TITLE
feat(riverpod): migrate invitation screen

### DIFF
--- a/lib/domain/app_state/contact/get_phonebook_contact_state.dart
+++ b/lib/domain/app_state/contact/get_phonebook_contact_state.dart
@@ -94,11 +94,15 @@ class GetPhoneBookContactFailure extends Failure {
 
 class GetHashDetailsFailure extends Failure {
   final dynamic exception;
+  final List<Contact> contacts;
 
-  const GetHashDetailsFailure({required this.exception});
+  const GetHashDetailsFailure({
+    required this.exception,
+    this.contacts = const [],
+  });
 
   @override
-  List<Object?> get props => [exception];
+  List<Object?> get props => [exception, contacts];
 }
 
 class LookUpContactFailure extends Failure {

--- a/lib/domain/contact_manager/contacts_manager.dart
+++ b/lib/domain/contact_manager/contacts_manager.dart
@@ -232,27 +232,33 @@ class ContactsManager {
     bool isAvailableSupportPhonebookContacts = false,
     required String withMxId,
   }) async {
+    if (isAvailableSupportPhonebookContacts) {
+      unawaited(
+        _lookUpPhonebookContactsInContact(
+          isAvailableSupportPhonebookContacts:
+              isAvailableSupportPhonebookContacts,
+          withMxId: withMxId,
+        ),
+      );
+    }
+
     tomContactsSubscription =
         getTomContactsInteractor.execute().listen((event) {
             _contactsNotifier.value = event;
           })
           ..onDone(() async {
             Logs().d('ContactsManager::_getAllContactsOnContactTab: done');
-            await _lookUpPhonebookContactsInContact(
-              isAvailableSupportPhonebookContacts:
-                  isAvailableSupportPhonebookContacts,
-              withMxId: withMxId,
-            );
+            if (!isAvailableSupportPhonebookContacts) {
+              _isSynchronizing = false;
+            }
           })
           ..onError((error) async {
             Logs().d(
               'ContactsManager::_getAllContactsOnContactTab: error - $error',
             );
-            await _lookUpPhonebookContactsInContact(
-              isAvailableSupportPhonebookContacts:
-                  isAvailableSupportPhonebookContacts,
-              withMxId: withMxId,
-            );
+            if (!isAvailableSupportPhonebookContacts) {
+              _isSynchronizing = false;
+            }
           });
   }
 

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -472,7 +472,10 @@ class FederationLookUpPhonebookContactInteractor {
           hashDetails.algorithms == null ||
           hashDetails.algorithms!.isEmpty) {
         firstFailureRef(
-          const GetHashDetailsFailure(exception: 'Hash details is empty'),
+          GetHashDetailsFailure(
+            exception: 'Hash details is empty',
+            contacts: contacts,
+          ),
         );
         return null;
       }
@@ -488,7 +491,7 @@ class FederationLookUpPhonebookContactInteractor {
         'hash details failed for $federationUrl',
         e,
       );
-      firstFailureRef(GetHashDetailsFailure(exception: e));
+      firstFailureRef(GetHashDetailsFailure(exception: e, contacts: contacts));
       return null;
     }
   }

--- a/lib/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor.dart
@@ -73,8 +73,11 @@ class TwakeLookupPhonebookContactInteractor {
 
       if (res.lookupPepper?.isEmpty == true &&
           res.algorithms?.isEmpty == true) {
-        yield const Left(
-          GetHashDetailsFailure(exception: 'Hash details is empty'),
+        yield Left(
+          GetHashDetailsFailure(
+            exception: 'Hash details is empty',
+            contacts: contacts,
+          ),
         );
         return;
       }
@@ -84,7 +87,7 @@ class TwakeLookupPhonebookContactInteractor {
       Logs().e(
         'FederationLookUpPhonebookContactInteractor::execute: GetHashDetails: $e',
       );
-      yield Left(GetHashDetailsFailure(exception: e));
+      yield Left(GetHashDetailsFailure(exception: e, contacts: contacts));
       return;
     }
 

--- a/lib/domain/usecase/invitation/generate_invitation_link_interactor.dart
+++ b/lib/domain/usecase/invitation/generate_invitation_link_interactor.dart
@@ -32,7 +32,18 @@ class GenerateInvitationLinkInteractor {
         GenerateInvitationLinkSuccessState(link: res.link, id: res.id),
       );
     } catch (e) {
-      Logs().e('GenerateInvitationLinkInteractor::execute', e);
+      if (e is DioException) {
+        Logs().e(
+          'GenerateInvitationLinkInteractor::execute DioException '
+          'status=${e.response?.statusCode} '
+          'type=${e.type} '
+          'path=${e.requestOptions.path} '
+          'data=${e.response?.data}',
+          e,
+        );
+      } else {
+        Logs().e('GenerateInvitationLinkInteractor::execute', e);
+      }
       if (e is DioException &&
           e.response?.statusCode == 400 &&
           e.response?.data is Map<String, dynamic>) {

--- a/lib/domain/usecase/invitation/send_invitation_interactor.dart
+++ b/lib/domain/usecase/invitation/send_invitation_interactor.dart
@@ -35,7 +35,18 @@ class SendInvitationInteractor {
         ),
       );
     } catch (e) {
-      Logs().e('SendInvitationInteractor::execute', e);
+      if (e is DioException) {
+        Logs().e(
+          'SendInvitationInteractor::execute DioException '
+          'status=${e.response?.statusCode} '
+          'type=${e.type} '
+          'path=${e.requestOptions.path} '
+          'data=${_safeResponseDataSummary(e.response?.data)}',
+          e,
+        );
+      } else {
+        Logs().e('SendInvitationInteractor::execute', e);
+      }
       if (e is DioException &&
           e.response?.statusCode == 400 &&
           e.response?.data is Map<String, dynamic>) {
@@ -77,5 +88,15 @@ class SendInvitationInteractor {
       Logs().e('SendInvitationInteractor::_tryToNormalizePhoneNumber', e);
     }
     return normalizedPhoneNumber;
+  }
+
+  String _safeResponseDataSummary(Object? data) {
+    if (data == null) {
+      return 'null';
+    }
+    if (data is Map) {
+      return 'Map(keys=${data.keys.join(',')})';
+    }
+    return data.runtimeType.toString();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_app_lock/flutter_app_lock.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_vodozemac/flutter_vodozemac.dart' as vod;
 import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -124,13 +125,15 @@ Future<void> startGui(List<Client> clients) async {
   // problems on other platforms if we wrap it always.
   await sentryInit(
     runApp: runApp,
-    app: PlatformInfos.isMobile
-        ? AppLock(
-            builder: (args) => TwakeApp(clients: clients),
-            lockScreen: const LockScreen(),
-            enabled: pin?.isNotEmpty ?? false,
-          )
-        : TwakeApp(clients: clients),
+    app: ProviderScope(
+      child: PlatformInfos.isMobile
+          ? AppLock(
+              builder: (args) => TwakeApp(clients: clients),
+              lockScreen: const LockScreen(),
+              enabled: pin?.isNotEmpty ?? false,
+            )
+          : TwakeApp(clients: clients),
+    ),
   );
 }
 

--- a/lib/pages/contacts_tab/contacts_invitation.dart
+++ b/lib/pages/contacts_tab/contacts_invitation.dart
@@ -1,24 +1,22 @@
-import 'package:dartz/dartz.dart' hide State;
+import 'package:dartz/dartz.dart';
 import 'package:fluffychat/app_state/failure.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/data/model/invitation/invitation_status_response.dart';
-import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/invitation/generate_invitation_link_state.dart';
 import 'package:fluffychat/domain/app_state/invitation/send_invitation_state.dart';
-import 'package:fluffychat/domain/model/invitation/invitation_medium_enum.dart';
-import 'package:fluffychat/domain/usecase/invitation/generate_invitation_link_interactor.dart';
-import 'package:fluffychat/domain/usecase/invitation/send_invitation_interactor.dart';
-import 'package:fluffychat/domain/usecase/invitation/store_invitation_status_interactor.dart';
+import 'package:fluffychat/pages/contacts_tab/contacts_invitation_state.dart';
+import 'package:fluffychat/pages/contacts_tab/contacts_invitation_view_model.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_invitation_view.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
 import 'package:fluffychat/utils/dialog/twake_dialog.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:matrix/matrix.dart';
 import 'package:share_plus/share_plus.dart';
 
-class ContactsInvitation extends StatefulWidget {
+class ContactsInvitation extends ConsumerStatefulWidget {
   final PresentationContact contact;
   final String userId;
   final InvitationStatusResponse? invitationStatus;
@@ -31,87 +29,31 @@ class ContactsInvitation extends StatefulWidget {
   });
 
   @override
-  State<ContactsInvitation> createState() => ContactsInvitationController();
+  ConsumerState<ContactsInvitation> createState() =>
+      _ContactsInvitationScreenState();
 }
 
-class ContactsInvitationController extends State<ContactsInvitation> {
-  final SendInvitationInteractor _sendInvitationInteractor = getIt
-      .get<SendInvitationInteractor>();
+class _ContactsInvitationScreenState extends ConsumerState<ContactsInvitation> {
+  bool get _isSelectionLocked =>
+      widget.invitationStatus?.invitation?.medium != null;
 
-  final GenerateInvitationLinkInteractor _generateInvitationLinkInteractor =
-      getIt.get<GenerateInvitationLinkInteractor>();
-
-  final StoreInvitationStatusInteractor _hiveStoreInvitationStatusInteractor =
-      getIt.get<StoreInvitationStatusInteractor>();
-
-  final ValueNotifier<PresentationThirdPartyContact?> selectedContact =
-      ValueNotifier(null);
-
-  final ValueNotifier<Either<Failure, Success>> sendInvitationNotifier =
-      ValueNotifier(const Right(SendInvitationInitial()));
-
-  final ValueNotifier<Either<Failure, Success>> generateInvitationLinkNotifier =
-      ValueNotifier(const Right(GenerateInvitationLinkInitial()));
-
-  void onSelectContact(PresentationThirdPartyContact contact) {
-    if (widget.invitationStatus?.invitation?.medium != null) return;
-    if (selectedContact.value == null) {
-      selectedContact.value = contact;
-    } else {
-      if (selectedContact.value == contact) {
-        selectedContact.value = null;
-      } else {
-        selectedContact.value = contact;
+  void _listenStateEffects() {
+    ref.listen<ContactsInvitationState>(contactsInvitationViewModelProvider, (
+      previous,
+      next,
+    ) {
+      if (previous?.sendInvitationState != next.sendInvitationState) {
+        _onSendInvitationStateChanged(next.sendInvitationState);
       }
-    }
+      if (previous?.generateInvitationLinkState !=
+          next.generateInvitationLinkState) {
+        _onGenerateInvitationLinkStateChanged(next.generateInvitationLinkState);
+      }
+    });
   }
 
-  ({String contact, InvitationMediumEnum medium})? _getInvitationData(
-    PresentationThirdPartyContact contact,
-  ) {
-    return switch (contact) {
-      final PresentationPhoneNumber phoneNumber => (
-        contact: phoneNumber.phoneNumber,
-        medium: InvitationMediumEnum.phone,
-      ),
-      final PresentationEmail email => (
-        contact: email.email,
-        medium: InvitationMediumEnum.email,
-      ),
-      _ => null,
-    };
-  }
-
-  void onSendInvitation(PresentationThirdPartyContact contact) {
-    final invitationData = _getInvitationData(contact);
-
-    if (invitationData != null) {
-      _sendInvitationInteractor
-          .execute(
-            contact: invitationData.contact,
-            medium: invitationData.medium,
-            contactId: widget.contact.id ?? '',
-          )
-          .listen((state) {
-            sendInvitationNotifier.value = state;
-          });
-    }
-  }
-
-  void _onSelectContactDefault(PresentationContact contact) {
-    if (contact.phoneNumbers != null && contact.phoneNumbers!.isNotEmpty) {
-      onSelectContact(contact.phoneNumbers!.first);
-      return;
-    }
-
-    if (contact.emails != null && contact.emails!.isNotEmpty) {
-      onSelectContact(contact.emails!.first);
-      return;
-    }
-  }
-
-  void _onSendInvitationStateListener() {
-    sendInvitationNotifier.value.fold(
+  void _onSendInvitationStateChanged(Either<Failure, Success> state) {
+    state.fold(
       (failure) {
         if (failure is InvitationAlreadySentState) {
           TwakeSnackBar.show(
@@ -135,7 +77,7 @@ class ContactsInvitationController extends State<ContactsInvitation> {
       },
       (success) {
         if (success is SendInvitationSuccessState) {
-          _onStoreInvitationStatusInteractor(
+          _onStoreInvitationStatus(
             userId: widget.userId,
             contactId: widget.contact.id ?? '',
             invitationId: success.sendInvitationResponse.id ?? '',
@@ -151,22 +93,8 @@ class ContactsInvitationController extends State<ContactsInvitation> {
     );
   }
 
-  void onGenerateInvitationLink() {
-    final contact = widget.contact.primaryContact;
-    if (contact == null) {
-      return;
-    }
-    final invitationData = _getInvitationData(contact);
-
-    if (invitationData != null) {
-      _generateInvitationLinkInteractor.execute().listen((state) {
-        generateInvitationLinkNotifier.value = state;
-      });
-    }
-  }
-
-  void _onGenerateInvitationLinkStateListener() {
-    generateInvitationLinkNotifier.value.fold(
+  void _onGenerateInvitationLinkStateChanged(Either<Failure, Success> state) {
+    state.fold(
       (failure) {
         TwakeDialog.hideLoadingDialog(context);
 
@@ -209,42 +137,67 @@ class ContactsInvitationController extends State<ContactsInvitation> {
     );
   }
 
-  void _onStoreInvitationStatusInteractor({
+  void _onStoreInvitationStatus({
     required String userId,
     required String contactId,
     required String invitationId,
   }) {
-    if (contactId.isEmpty || invitationId.isEmpty) {
-      return;
-    }
-    _hiveStoreInvitationStatusInteractor
-        .execute(
+    ref
+        .read(contactsInvitationViewModelProvider.notifier)
+        .storeInvitationStatus(
           userId: userId,
           contactId: contactId,
           invitationId: invitationId,
-        )
-        .listen((state) {
-          Logs().d(
-            'ContactsInvitationController::_onStoreInvitationStatusInteractor',
-            state,
-          );
-        });
+        );
   }
 
   @override
   void initState() {
-    _onSelectContactDefault(widget.contact);
-    sendInvitationNotifier.addListener(() {
-      _onSendInvitationStateListener();
-    });
-    generateInvitationLinkNotifier.addListener(() {
-      _onGenerateInvitationLinkStateListener();
-    });
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      ref
+          .read(contactsInvitationViewModelProvider.notifier)
+          .selectDefaultContact(
+            widget.contact,
+            isSelectionLocked: _isSelectionLocked,
+          );
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    return ContactsInvitationView(controller: this, contact: widget.contact);
+    _listenStateEffects();
+    final state = ref.watch(contactsInvitationViewModelProvider);
+    return ContactsInvitationView(
+      contact: widget.contact,
+      state: state,
+      onGenerateInvitationLink: () {
+        ref
+            .read(contactsInvitationViewModelProvider.notifier)
+            .generateInvitationLink(widget.contact);
+      },
+      onSelectContact: (contact) {
+        ref
+            .read(contactsInvitationViewModelProvider.notifier)
+            .selectContact(contact, isSelectionLocked: _isSelectionLocked);
+      },
+      onSendInvitation: (contact) {
+        Logs().d(
+          'ContactsInvitation::onSendInvitation '
+          'contactId=${widget.contact.id} '
+          'selectedContactType=${contact.runtimeType} '
+          'userIdPresent=${widget.userId.isNotEmpty}',
+        );
+        ref
+            .read(contactsInvitationViewModelProvider.notifier)
+            .sendInvitation(
+              contact: contact,
+              contactId: widget.contact.id ?? '',
+            );
+      },
+    );
   }
 }

--- a/lib/pages/contacts_tab/contacts_invitation_state.dart
+++ b/lib/pages/contacts_tab/contacts_invitation_state.dart
@@ -1,0 +1,44 @@
+import 'package:dartz/dartz.dart';
+import 'package:equatable/equatable.dart';
+import 'package:fluffychat/app_state/failure.dart';
+import 'package:fluffychat/app_state/success.dart';
+import 'package:fluffychat/domain/app_state/invitation/generate_invitation_link_state.dart';
+import 'package:fluffychat/domain/app_state/invitation/send_invitation_state.dart';
+import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
+
+class ContactsInvitationState extends Equatable {
+  final PresentationThirdPartyContact? selectedContact;
+  final Either<Failure, Success> sendInvitationState;
+  final Either<Failure, Success> generateInvitationLinkState;
+
+  const ContactsInvitationState({
+    this.selectedContact,
+    this.sendInvitationState = const Right(SendInvitationInitial()),
+    this.generateInvitationLinkState = const Right(
+      GenerateInvitationLinkInitial(),
+    ),
+  });
+
+  ContactsInvitationState copyWith({
+    PresentationThirdPartyContact? selectedContact,
+    bool clearSelectedContact = false,
+    Either<Failure, Success>? sendInvitationState,
+    Either<Failure, Success>? generateInvitationLinkState,
+  }) {
+    return ContactsInvitationState(
+      selectedContact: clearSelectedContact
+          ? null
+          : selectedContact ?? this.selectedContact,
+      sendInvitationState: sendInvitationState ?? this.sendInvitationState,
+      generateInvitationLinkState:
+          generateInvitationLinkState ?? this.generateInvitationLinkState,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    selectedContact,
+    sendInvitationState,
+    generateInvitationLinkState,
+  ];
+}

--- a/lib/pages/contacts_tab/contacts_invitation_view.dart
+++ b/lib/pages/contacts_tab/contacts_invitation_view.dart
@@ -1,5 +1,5 @@
 import 'package:fluffychat/domain/app_state/invitation/send_invitation_state.dart';
-import 'package:fluffychat/pages/contacts_tab/contacts_invitation.dart';
+import 'package:fluffychat/pages/contacts_tab/contacts_invitation_state.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_invitation_style.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
 import 'package:flutter/material.dart';
@@ -8,12 +8,18 @@ import 'package:fluffychat/generated/l10n/app_localizations.dart';
 
 class ContactsInvitationView extends StatelessWidget {
   final PresentationContact contact;
-  final ContactsInvitationController controller;
+  final ContactsInvitationState state;
+  final VoidCallback onGenerateInvitationLink;
+  final ValueChanged<PresentationThirdPartyContact> onSelectContact;
+  final ValueChanged<PresentationThirdPartyContact> onSendInvitation;
 
   const ContactsInvitationView({
     super.key,
     required this.contact,
-    required this.controller,
+    required this.state,
+    required this.onGenerateInvitationLink,
+    required this.onSelectContact,
+    required this.onSendInvitation,
   });
 
   @override
@@ -45,7 +51,7 @@ class ContactsInvitationView extends StatelessWidget {
                   textAlign: TextAlign.center,
                 ),
                 InkWell(
-                  onTap: () => controller.onGenerateInvitationLink(),
+                  onTap: onGenerateInvitationLink,
                   highlightColor: Colors.transparent,
                   focusColor: Colors.transparent,
                   splashColor: Colors.transparent,
@@ -88,14 +94,14 @@ class ContactsInvitationView extends StatelessWidget {
                               highlightColor: Colors.transparent,
                               focusColor: Colors.transparent,
                               splashColor: Colors.transparent,
-                              onTap: () =>
-                                  controller.onSelectContact(phoneNumber),
-                              child: ValueListenableBuilder(
-                                valueListenable: controller.selectedContact,
-                                builder: (context, contact, _) {
+                              onTap: () => onSelectContact(phoneNumber),
+                              child: Builder(
+                                builder: (context) {
+                                  final selectedContact = state.selectedContact;
                                   final isSelectedContact =
-                                      contact is PresentationPhoneNumber &&
-                                      contact.phoneNumber ==
+                                      selectedContact
+                                          is PresentationPhoneNumber &&
+                                      selectedContact.phoneNumber ==
                                           phoneNumber.phoneNumber;
                                   return Padding(
                                     padding: const EdgeInsets.symmetric(
@@ -210,13 +216,13 @@ class ContactsInvitationView extends StatelessWidget {
                               highlightColor: Colors.transparent,
                               focusColor: Colors.transparent,
                               splashColor: Colors.transparent,
-                              onTap: () => controller.onSelectContact(email),
-                              child: ValueListenableBuilder(
-                                valueListenable: controller.selectedContact,
-                                builder: (context, contact, _) {
+                              onTap: () => onSelectContact(email),
+                              child: Builder(
+                                builder: (context) {
+                                  final selectedContact = state.selectedContact;
                                   final isSelectedContact =
-                                      contact is PresentationEmail &&
-                                      contact.email == email.email;
+                                      selectedContact is PresentationEmail &&
+                                      selectedContact.email == email.email;
                                   return Padding(
                                     padding: const EdgeInsets.symmetric(
                                       vertical: 8,
@@ -325,82 +331,81 @@ class ContactsInvitationView extends StatelessWidget {
                     ),
                   ),
                 ),
-                ValueListenableBuilder(
-                  valueListenable: controller.selectedContact,
-                  builder: (context, selectedContact, child) {
-                    if (selectedContact == null) {
-                      return const SizedBox.shrink();
-                    }
-                    return InkWell(
-                      hoverColor: Colors.transparent,
-                      highlightColor: Colors.transparent,
-                      focusColor: Colors.transparent,
-                      splashColor: Colors.transparent,
-                      onTap: () => controller.onSendInvitation(selectedContact),
-                      child: Padding(
-                        padding: ContactsInvitationStyle.verticalPadding,
-                        child: Container(
-                          width: double.infinity,
-                          height: ContactsInvitationStyle.heightSendButton,
-                          decoration: BoxDecoration(
-                            color: LinagoraSysColors.material().primary,
-                            borderRadius: ContactsInvitationStyle.borderRadius,
-                          ),
-                          child: ValueListenableBuilder(
-                            valueListenable: controller.sendInvitationNotifier,
-                            builder: (context, state, child) => state.fold(
-                              (failure) => child!,
-                              (success) {
-                                if (success is SendInvitationLoadingState) {
-                                  return Row(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      SizedBox(
-                                        width: 28,
-                                        height: 28,
-                                        child:
-                                            CircularProgressIndicator.adaptive(
-                                              strokeWidth: 2,
-                                              backgroundColor:
-                                                  LinagoraSysColors.material()
-                                                      .onPrimary,
-                                            ),
-                                      ),
-                                    ],
-                                  );
-                                }
-                                return child!;
-                              },
-                            ),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Text(
-                                  L10n.of(context)!.sendInvitation,
-                                  style: Theme.of(context).textTheme.labelLarge
-                                      ?.copyWith(
-                                        color: LinagoraSysColors.material()
-                                            .onPrimary,
-                                      ),
-                                ),
-                                const SizedBox(width: 8),
-                                Icon(
-                                  Icons.send_outlined,
-                                  color: LinagoraSysColors.material().onPrimary,
-                                ),
-                              ],
-                            ),
-                          ),
+                if (state.selectedContact != null)
+                  InkWell(
+                    hoverColor: Colors.transparent,
+                    highlightColor: Colors.transparent,
+                    focusColor: Colors.transparent,
+                    splashColor: Colors.transparent,
+                    onTap: state.sendInvitationState.fold(
+                      (_) =>
+                          () => onSendInvitation(state.selectedContact!),
+                      (success) => success is SendInvitationLoadingState
+                          ? null
+                          : () => onSendInvitation(state.selectedContact!),
+                    ),
+                    child: Padding(
+                      padding: ContactsInvitationStyle.verticalPadding,
+                      child: Container(
+                        width: double.infinity,
+                        height: ContactsInvitationStyle.heightSendButton,
+                        decoration: BoxDecoration(
+                          color: LinagoraSysColors.material().primary,
+                          borderRadius: ContactsInvitationStyle.borderRadius,
+                        ),
+                        child: state.sendInvitationState.fold(
+                          (failure) => _SendInvitationButtonContent(),
+                          (success) {
+                            if (success is SendInvitationLoadingState) {
+                              return Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  SizedBox(
+                                    width: 28,
+                                    height: 28,
+                                    child: CircularProgressIndicator.adaptive(
+                                      strokeWidth: 2,
+                                      backgroundColor:
+                                          LinagoraSysColors.material()
+                                              .onPrimary,
+                                    ),
+                                  ),
+                                ],
+                              );
+                            }
+                            return _SendInvitationButtonContent();
+                          },
                         ),
                       ),
-                    );
-                  },
-                ),
+                    ),
+                  ),
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+class _SendInvitationButtonContent extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text(
+          L10n.of(context)!.sendInvitation,
+          style: Theme.of(context).textTheme.labelLarge?.copyWith(
+            color: LinagoraSysColors.material().onPrimary,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Icon(
+          Icons.send_outlined,
+          color: LinagoraSysColors.material().onPrimary,
+        ),
+      ],
     );
   }
 }

--- a/lib/pages/contacts_tab/contacts_invitation_view_model.dart
+++ b/lib/pages/contacts_tab/contacts_invitation_view_model.dart
@@ -1,0 +1,144 @@
+import 'package:fluffychat/domain/model/invitation/invitation_medium_enum.dart';
+import 'package:fluffychat/pages/contacts_tab/contacts_invitation_state.dart';
+import 'package:fluffychat/pages/contacts_tab/providers/contacts_invitation_providers.dart';
+import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
+import 'package:matrix/matrix.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'contacts_invitation_view_model.g.dart';
+
+@riverpod
+class ContactsInvitationViewModel extends _$ContactsInvitationViewModel {
+  @override
+  ContactsInvitationState build() => const ContactsInvitationState();
+
+  void selectDefaultContact(
+    PresentationContact contact, {
+    required bool isSelectionLocked,
+  }) {
+    if (state.selectedContact != null) {
+      return;
+    }
+    final phoneNumbers = contact.phoneNumbers;
+    if (phoneNumbers != null && phoneNumbers.isNotEmpty) {
+      selectContact(phoneNumbers.first, isSelectionLocked: isSelectionLocked);
+      return;
+    }
+
+    final emails = contact.emails;
+    if (emails != null && emails.isNotEmpty) {
+      selectContact(emails.first, isSelectionLocked: isSelectionLocked);
+    }
+  }
+
+  void selectContact(
+    PresentationThirdPartyContact contact, {
+    required bool isSelectionLocked,
+  }) {
+    if (isSelectionLocked) {
+      return;
+    }
+    if (state.selectedContact == contact) {
+      state = state.copyWith(clearSelectedContact: true);
+      return;
+    }
+    state = state.copyWith(selectedContact: contact);
+  }
+
+  Future<void> sendInvitation({
+    required PresentationThirdPartyContact contact,
+    required String contactId,
+  }) async {
+    final invitationData = _getInvitationData(contact);
+    if (invitationData == null) {
+      Logs().e(
+        'ContactsInvitationViewModel::sendInvitation '
+        'missing invitation data for ${contact.runtimeType}',
+      );
+      return;
+    }
+
+    Logs().d(
+      'ContactsInvitationViewModel::sendInvitation '
+      'contactId=$contactId '
+      'medium=${invitationData.medium.value} '
+      'contactLength=${invitationData.contact.length}',
+    );
+
+    await for (final nextState
+        in ref
+            .read(sendInvitationInteractorProvider)
+            .execute(
+              contact: invitationData.contact,
+              medium: invitationData.medium,
+              contactId: contactId,
+            )) {
+      Logs().d('ContactsInvitationViewModel::sendInvitation state=$nextState');
+      if (!ref.mounted) {
+        return;
+      }
+      state = state.copyWith(sendInvitationState: nextState);
+    }
+  }
+
+  Future<void> generateInvitationLink(PresentationContact contact) async {
+    final primaryContact = contact.primaryContact;
+    if (primaryContact == null) {
+      return;
+    }
+    final invitationData = _getInvitationData(primaryContact);
+    if (invitationData == null) {
+      return;
+    }
+
+    await for (final nextState
+        in ref
+            .read(generateInvitationLinkInteractorProvider)
+            .execute(
+              contact: invitationData.contact,
+              medium: invitationData.medium,
+            )) {
+      if (!ref.mounted) {
+        return;
+      }
+      state = state.copyWith(generateInvitationLinkState: nextState);
+    }
+  }
+
+  Future<void> storeInvitationStatus({
+    required String userId,
+    required String contactId,
+    required String invitationId,
+  }) async {
+    if (contactId.isEmpty || invitationId.isEmpty) {
+      return;
+    }
+
+    await for (final nextState
+        in ref
+            .read(storeInvitationStatusInteractorProvider)
+            .execute(
+              userId: userId,
+              contactId: contactId,
+              invitationId: invitationId,
+            )) {
+      Logs().d('ContactsInvitationViewModel::storeInvitationStatus', nextState);
+    }
+  }
+
+  ({String contact, InvitationMediumEnum medium})? _getInvitationData(
+    PresentationThirdPartyContact contact,
+  ) {
+    return switch (contact) {
+      final PresentationPhoneNumber phoneNumber => (
+        contact: phoneNumber.phoneNumber,
+        medium: InvitationMediumEnum.phone,
+      ),
+      final PresentationEmail email => (
+        contact: email.email,
+        medium: InvitationMediumEnum.email,
+      ),
+      _ => null,
+    };
+  }
+}

--- a/lib/pages/contacts_tab/contacts_invitation_view_model.g.dart
+++ b/lib/pages/contacts_tab/contacts_invitation_view_model.g.dart
@@ -1,0 +1,71 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'contacts_invitation_view_model.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(ContactsInvitationViewModel)
+const contactsInvitationViewModelProvider =
+    ContactsInvitationViewModelProvider._();
+
+final class ContactsInvitationViewModelProvider
+    extends
+        $NotifierProvider<
+          ContactsInvitationViewModel,
+          ContactsInvitationState
+        > {
+  const ContactsInvitationViewModelProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'contactsInvitationViewModelProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$contactsInvitationViewModelHash();
+
+  @$internal
+  @override
+  ContactsInvitationViewModel create() => ContactsInvitationViewModel();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ContactsInvitationState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<ContactsInvitationState>(value),
+    );
+  }
+}
+
+String _$contactsInvitationViewModelHash() =>
+    r'1f6efad6ae4bcd070f66f0d44dc6227959fb5940';
+
+abstract class _$ContactsInvitationViewModel
+    extends $Notifier<ContactsInvitationState> {
+  ContactsInvitationState build();
+  @$mustCallSuper
+  @override
+  void runBuild() {
+    final created = build();
+    final ref =
+        this.ref as $Ref<ContactsInvitationState, ContactsInvitationState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<ContactsInvitationState, ContactsInvitationState>,
+              ContactsInvitationState,
+              Object?,
+              Object?
+            >;
+    element.handleValue(ref, created);
+  }
+}

--- a/lib/pages/contacts_tab/contacts_tab.dart
+++ b/lib/pages/contacts_tab/contacts_tab.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/presentation/mixins/address_book_mixin.dart';
 import 'package:fluffychat/presentation/mixins/comparable_presentation_contact_mixin.dart';
@@ -32,7 +34,8 @@ class ContactsTabController extends State<ContactsTab>
         ComparablePresentationContactMixin,
         ContactsViewControllerMixin,
         AddressBooksMixin,
-        WidgetsBindingObserver {
+        WidgetsBindingObserver,
+        AutomaticKeepAliveClientMixin {
   final responsive = getIt.get<ResponsiveUtils>();
 
   Client get client => Matrix.of(context).client;
@@ -43,6 +46,9 @@ class ContactsTabController extends State<ContactsTab>
   bool get enableRecentContacts => false;
 
   @override
+  bool get enablePhonebookContacts => supportInvitation();
+
+  @override
   void initState() {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       WidgetsBinding.instance.addObserver(this);
@@ -51,6 +57,9 @@ class ContactsTabController extends State<ContactsTab>
         discoveryInformationNotifier.value = Matrix.of(
           context,
         ).loginHomeserverSummary?.discoveryInformation;
+        if (discoveryInformationNotifier.value == null) {
+          unawaited(_loadWellKnownAndRetryContacts());
+        }
         synchronizeContactsOnContactTab(
           context: context,
           client: Matrix.of(context).client,
@@ -61,6 +70,19 @@ class ContactsTabController extends State<ContactsTab>
 
     _listenFocusTextEditing();
     super.initState();
+  }
+
+  Future<void> _loadWellKnownAndRetryContacts() async {
+    await getWellKnownInformation(client);
+    if (!mounted || !supportInvitation()) {
+      return;
+    }
+
+    await retrySynchronizeContactsOnContactTab(
+      context: context,
+      client: client,
+      matrixLocalizations: MatrixLocals(L10n.of(context)!),
+    );
   }
 
   void _listenFocusTextEditing() {
@@ -120,6 +142,18 @@ class ContactsTabController extends State<ContactsTab>
     }
   }
 
+  Future<void> retrySynchronizeContacts() async {
+    if (!mounted) {
+      return;
+    }
+
+    await retrySynchronizeContactsOnContactTab(
+      context: context,
+      client: Matrix.of(context).client,
+      matrixLocalizations: MatrixLocals(L10n.of(context)!),
+    );
+  }
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) async {
     await handleDidChangeAppLifecycleState(state, client: client);
@@ -133,8 +167,14 @@ class ContactsTabController extends State<ContactsTab>
   }
 
   @override
-  Widget build(BuildContext context) => ContactsTabView(
-    contactsController: this,
-    bottomNavigationBar: widget.bottomNavigationBar,
-  );
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return ContactsTabView(
+      contactsController: this,
+      bottomNavigationBar: widget.bottomNavigationBar,
+    );
+  }
 }

--- a/lib/pages/contacts_tab/contacts_tab_body_view.dart
+++ b/lib/pages/contacts_tab/contacts_tab_body_view.dart
@@ -18,23 +18,27 @@ class ContactsTabBodyView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CustomScrollView(
-      slivers: [
-        if (controller.client.userID != null)
-          SliverInviteFriendButton(userId: controller.client.userID!),
-        SliverWarningBanner(controller: controller),
-        SliverLoadingContacts(controller: controller),
-        SliverContactsWithMatrixId(controller: controller),
-        if (PlatformInfos.isMobile)
-          SliverPhonebookContactsWithMatrixId(controller: controller),
-        SliverContactsWithoutMatrixId(controller: controller),
-        if (PlatformInfos.isMobile)
-          SliverPhonebookContactsWithoutMatrixId(controller: controller),
-        SliverEmptyContacts(controller: controller),
-        const SliverToBoxAdapter(
-          child: SizedBox(height: ContactsTabViewStyle.padding),
-        ),
-      ],
+    return RefreshIndicator(
+      onRefresh: controller.retrySynchronizeContacts,
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          if (controller.client.userID != null)
+            SliverInviteFriendButton(userId: controller.client.userID!),
+          SliverWarningBanner(controller: controller),
+          SliverLoadingContacts(controller: controller),
+          SliverContactsWithMatrixId(controller: controller),
+          if (PlatformInfos.isMobile)
+            SliverPhonebookContactsWithMatrixId(controller: controller),
+          SliverContactsWithoutMatrixId(controller: controller),
+          if (PlatformInfos.isMobile)
+            SliverPhonebookContactsWithoutMatrixId(controller: controller),
+          SliverEmptyContacts(controller: controller),
+          const SliverToBoxAdapter(
+            child: SizedBox(height: ContactsTabViewStyle.padding),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/contacts_tab/empty_contacts_body.dart
+++ b/lib/pages/contacts_tab/empty_contacts_body.dart
@@ -5,7 +5,9 @@ import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:linagora_design_flutter/colors/linagora_ref_colors.dart';
 
 class EmptyContactBody extends StatelessWidget {
-  const EmptyContactBody({super.key});
+  const EmptyContactBody({super.key, this.onRetrySyncContacts});
+
+  final VoidCallback? onRetrySyncContacts;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +36,15 @@ class EmptyContactBody extends StatelessWidget {
             ),
             textAlign: TextAlign.center,
           ),
+          if (onRetrySyncContacts != null) ...[
+            const SizedBox(height: 16.0),
+            FilledButton.icon(
+              onPressed: onRetrySyncContacts,
+              icon: const Icon(Icons.sync, size: 20.0),
+              label: Text(L10n.of(context)!.tapToRetry),
+              style: FilledButton.styleFrom(shape: const StadiumBorder()),
+            ),
+          ],
         ],
       ),
     );

--- a/lib/pages/contacts_tab/providers/contacts_invitation_providers.dart
+++ b/lib/pages/contacts_tab/providers/contacts_invitation_providers.dart
@@ -1,0 +1,19 @@
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/domain/usecase/invitation/generate_invitation_link_interactor.dart';
+import 'package:fluffychat/domain/usecase/invitation/send_invitation_interactor.dart';
+import 'package:fluffychat/domain/usecase/invitation/store_invitation_status_interactor.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'contacts_invitation_providers.g.dart';
+
+@riverpod
+SendInvitationInteractor sendInvitationInteractor(Ref ref) =>
+    getIt.get<SendInvitationInteractor>();
+
+@riverpod
+GenerateInvitationLinkInteractor generateInvitationLinkInteractor(Ref ref) =>
+    getIt.get<GenerateInvitationLinkInteractor>();
+
+@riverpod
+StoreInvitationStatusInteractor storeInvitationStatusInteractor(Ref ref) =>
+    getIt.get<StoreInvitationStatusInteractor>();

--- a/lib/pages/contacts_tab/providers/contacts_invitation_providers.g.dart
+++ b/lib/pages/contacts_tab/providers/contacts_invitation_providers.g.dart
@@ -1,0 +1,160 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'contacts_invitation_providers.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(sendInvitationInteractor)
+const sendInvitationInteractorProvider = SendInvitationInteractorProvider._();
+
+final class SendInvitationInteractorProvider
+    extends
+        $FunctionalProvider<
+          SendInvitationInteractor,
+          SendInvitationInteractor,
+          SendInvitationInteractor
+        >
+    with $Provider<SendInvitationInteractor> {
+  const SendInvitationInteractorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'sendInvitationInteractorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$sendInvitationInteractorHash();
+
+  @$internal
+  @override
+  $ProviderElement<SendInvitationInteractor> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  SendInvitationInteractor create(Ref ref) {
+    return sendInvitationInteractor(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SendInvitationInteractor value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SendInvitationInteractor>(value),
+    );
+  }
+}
+
+String _$sendInvitationInteractorHash() =>
+    r'68c099a6f3ea05dfce359cc1708a5bfb3f7aadcd';
+
+@ProviderFor(generateInvitationLinkInteractor)
+const generateInvitationLinkInteractorProvider =
+    GenerateInvitationLinkInteractorProvider._();
+
+final class GenerateInvitationLinkInteractorProvider
+    extends
+        $FunctionalProvider<
+          GenerateInvitationLinkInteractor,
+          GenerateInvitationLinkInteractor,
+          GenerateInvitationLinkInteractor
+        >
+    with $Provider<GenerateInvitationLinkInteractor> {
+  const GenerateInvitationLinkInteractorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'generateInvitationLinkInteractorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$generateInvitationLinkInteractorHash();
+
+  @$internal
+  @override
+  $ProviderElement<GenerateInvitationLinkInteractor> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  GenerateInvitationLinkInteractor create(Ref ref) {
+    return generateInvitationLinkInteractor(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(GenerateInvitationLinkInteractor value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<GenerateInvitationLinkInteractor>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$generateInvitationLinkInteractorHash() =>
+    r'91d5690a72cec880b1cb060e56fa7876c3b41ef6';
+
+@ProviderFor(storeInvitationStatusInteractor)
+const storeInvitationStatusInteractorProvider =
+    StoreInvitationStatusInteractorProvider._();
+
+final class StoreInvitationStatusInteractorProvider
+    extends
+        $FunctionalProvider<
+          StoreInvitationStatusInteractor,
+          StoreInvitationStatusInteractor,
+          StoreInvitationStatusInteractor
+        >
+    with $Provider<StoreInvitationStatusInteractor> {
+  const StoreInvitationStatusInteractorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'storeInvitationStatusInteractorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$storeInvitationStatusInteractorHash();
+
+  @$internal
+  @override
+  $ProviderElement<StoreInvitationStatusInteractor> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  StoreInvitationStatusInteractor create(Ref ref) {
+    return storeInvitationStatusInteractor(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(StoreInvitationStatusInteractor value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<StoreInvitationStatusInteractor>(
+        value,
+      ),
+    );
+  }
+}
+
+String _$storeInvitationStatusInteractorHash() =>
+    r'91736a968b6faa9631b79c7f052595594386f010';

--- a/lib/pages/contacts_tab/widgets/sliver_empty_contacts.dart
+++ b/lib/pages/contacts_tab/widgets/sliver_empty_contacts.dart
@@ -1,36 +1,13 @@
-import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_tab.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_tab_view_style.dart';
 import 'package:fluffychat/pages/contacts_tab/empty_contacts_body.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/no_contacts_found.dart';
-import 'package:fluffychat/presentation/model/contact/presentation_contact_success.dart';
 import 'package:flutter/material.dart';
 
 class SliverEmptyContacts extends StatelessWidget {
   const SliverEmptyContacts({required this.controller, super.key});
 
   final ContactsTabController controller;
-
-  bool _isLoading() => controller.presentationContactNotifier.value.fold(
-    (_) => false,
-    (s) => s is ContactsLoading,
-  );
-
-  bool _hasContactsData() => controller.presentationContactNotifier.value.fold(
-    (_) => false,
-    (s) =>
-        (s is PresentationContactsSuccess && s.contacts.isNotEmpty) ||
-        s is PresentationExternalContactSuccess,
-  );
-
-  bool _hasPhonebookData() =>
-      controller.presentationPhonebookContactNotifier.value.fold(
-        (_) => false,
-        (s) => s is PresentationContactsSuccess && s.contacts.isNotEmpty,
-      );
-
-  bool _hasRecentData() =>
-      controller.presentationRecentContactNotifier.value.isNotEmpty;
 
   @override
   Widget build(BuildContext context) {
@@ -41,15 +18,16 @@ class SliverEmptyContacts extends StatelessWidget {
         controller.presentationRecentContactNotifier,
       ]),
       builder: (context, _) {
-        if (_isLoading() ||
-            _hasContactsData() ||
-            _hasPhonebookData() ||
-            _hasRecentData()) {
+        if (controller.isWaitingContacts || controller.hasVisibleContacts) {
           return const SliverToBoxAdapter();
         }
         final keyword = controller.textEditingController.text;
         if (keyword.isEmpty) {
-          return const SliverToBoxAdapter(child: EmptyContactBody());
+          return SliverToBoxAdapter(
+            child: EmptyContactBody(
+              onRetrySyncContacts: controller.retrySynchronizeContacts,
+            ),
+          );
         }
         return SliverToBoxAdapter(
           child: Padding(

--- a/lib/pages/contacts_tab/widgets/sliver_loading_contacts.dart
+++ b/lib/pages/contacts_tab/widgets/sliver_loading_contacts.dart
@@ -1,4 +1,3 @@
-import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_tab.dart';
 import 'package:fluffychat/pages/new_private_chat/widget/loading_contact_widget.dart';
 import 'package:flutter/material.dart';
@@ -10,15 +9,17 @@ class SliverLoadingContacts extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder(
-      valueListenable: controller.presentationContactNotifier,
-      builder: (context, state, _) {
-        return state.fold((_) => const SliverToBoxAdapter(), (success) {
-          if (success is ContactsLoading) {
-            return const SliverToBoxAdapter(child: LoadingContactWidget());
-          }
-          return const SliverToBoxAdapter();
-        });
+    return ListenableBuilder(
+      listenable: Listenable.merge([
+        controller.presentationContactNotifier,
+        controller.presentationPhonebookContactNotifier,
+        controller.presentationRecentContactNotifier,
+      ]),
+      builder: (context, _) {
+        if (controller.isWaitingContacts && !controller.hasVisibleContacts) {
+          return const SliverToBoxAdapter(child: LoadingContactWidget());
+        }
+        return const SliverToBoxAdapter();
       },
     );
   }

--- a/lib/pages/new_group/contacts_selection.dart
+++ b/lib/pages/new_group/contacts_selection.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/presentation/mixins/address_book_mixin.dart';
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
 import 'package:fluffychat/presentation/mixins/invite_external_contact_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/pages/new_group/contacts_selection_view.dart';
 import 'package:fluffychat/pages/new_group/selected_contacts_map_change_notifier.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
@@ -15,6 +16,7 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
     extends State<T>
     with
         InviteExternalContactMixin,
+        WellKnownMixin,
         ContactsViewControllerMixin,
         AddressBooksMixin,
         WidgetsBindingObserver {
@@ -33,6 +35,9 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
 
   bool get isFullScreen => true;
 
+  @override
+  bool get enablePhonebookContacts => supportInvitation();
+
   Client get client => Matrix.of(context).client;
 
   @override
@@ -41,6 +46,9 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
       WidgetsBinding.instance.addObserver(this);
       if (mounted) {
         listenAddressBookEvents(client);
+        discoveryInformationNotifier.value = Matrix.of(
+          context,
+        ).loginHomeserverSummary?.discoveryInformation;
         initialFetchContacts(
           context: context,
           client: client,

--- a/lib/pages/new_private_chat/new_private_chat.dart
+++ b/lib/pages/new_private_chat/new_private_chat.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/presentation/mixins/comparable_presentation_contact_m
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
 import 'package:fluffychat/presentation/mixins/go_to_group_chat_mixin.dart';
 import 'package:fluffychat/presentation/mixins/invite_external_contact_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/pages/new_private_chat/new_private_chat_view.dart';
 import 'package:fluffychat/presentation/mixins/go_to_direct_chat_mixin.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
@@ -25,6 +26,7 @@ class NewPrivateChat extends StatefulWidget {
 class NewPrivateChatController extends State<NewPrivateChat>
     with
         ComparablePresentationContactMixin,
+        WellKnownMixin,
         ContactsViewControllerMixin,
         GoToDraftChatMixin,
         WidgetsBindingObserver,
@@ -34,6 +36,9 @@ class NewPrivateChatController extends State<NewPrivateChat>
   final scrollController = ScrollController();
 
   @override
+  bool get enablePhonebookContacts => supportInvitation();
+
+  @override
   void initState() {
     super.initState();
     SchedulerBinding.instance.addPostFrameCallback((_) async {
@@ -41,6 +46,9 @@ class NewPrivateChatController extends State<NewPrivateChat>
       if (mounted) {
         final client = Matrix.of(context).client;
         listenAddressBookEvents(client);
+        discoveryInformationNotifier.value = Matrix.of(
+          context,
+        ).loginHomeserverSummary?.discoveryInformation;
         initialFetchContacts(
           context: context,
           client: client,

--- a/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
@@ -61,6 +61,11 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
     required PresentationContact contact,
     InvitationStatusResponse? invitationStatus,
   }) async {
+    Logs().d(
+      'ExpansionContactListTile::_handleMatrixIdNull '
+      'hasMatrixId=${widget.contact.matrixId?.isNotEmpty == true} '
+      'hasInvitation=${invitationStatus?.invitation != null}',
+    );
     if (invitationStatus?.invitation != null &&
         invitationStatus!.invitation?.hasMatrixId == true) {
       widget.onContactTap?.call();
@@ -71,7 +76,8 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
       widget.onContactTap?.call();
       return;
     }
-    if (client.userID == null && client.userID?.isEmpty == true) return;
+    if (!widget.enableInvitation) return;
+    if (client.userID == null || client.userID!.isEmpty) return;
     final result = await showAdaptiveBottomSheet<String?>(
       context: context,
       builder: (context) => ContactsInvitation(
@@ -117,10 +123,12 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
             bottom: 8.0,
           ),
           child: FutureBuilder<Profile?>(
-            key: widget.contact.matrixId != null
+            key: widget.contact.matrixId?.isNotEmpty == true
                 ? Key(widget.contact.matrixId!)
                 : null,
-            future: widget.contact.status == ContactStatus.active
+            future:
+                widget.contact.status == ContactStatus.active &&
+                    widget.contact.matrixId?.isNotEmpty == true
                 ? getProfile(context)
                 : null,
             builder: (context, snapshot) {
@@ -387,6 +395,10 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
         contact: contact,
         invitationStatus: invitationStatus,
       );
+    }
+
+    if (contact.matrixId == null || contact.matrixId!.isEmpty) {
+      return null;
     }
 
     if (widget.onContactTap != null) {

--- a/lib/pages/new_private_chat/widget/expansion_phonebook_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_phonebook_contact_list_tile.dart
@@ -62,6 +62,11 @@ class _ExpansionPhonebookContactListTileState
     required PresentationContact contact,
     InvitationStatusResponse? invitationStatus,
   }) async {
+    Logs().d(
+      'ExpansionPhonebookContactListTile::_handleMatrixIdNull '
+      'hasMatrixId=${widget.contact.matrixId?.isNotEmpty == true} '
+      'hasInvitation=${invitationStatus?.invitation != null}',
+    );
     if (invitationStatus?.invitation != null &&
         invitationStatus!.invitation?.hasMatrixId == true) {
       widget.onContactTap?.call();
@@ -72,7 +77,8 @@ class _ExpansionPhonebookContactListTileState
       widget.onContactTap?.call();
       return;
     }
-    if (client.userID == null && client.userID?.isEmpty == true) return;
+    if (!widget.enableInvitation) return;
+    if (client.userID == null || client.userID!.isEmpty) return;
     final result = await showAdaptiveBottomSheet<String?>(
       context: context,
       builder: (context) => ContactsInvitation(
@@ -118,10 +124,12 @@ class _ExpansionPhonebookContactListTileState
             bottom: 8.0,
           ),
           child: FutureBuilder<Profile?>(
-            key: widget.contact.matrixId != null
+            key: widget.contact.matrixId?.isNotEmpty == true
                 ? Key(widget.contact.matrixId!)
                 : null,
-            future: widget.contact.status == ContactStatus.active
+            future:
+                widget.contact.status == ContactStatus.active &&
+                    widget.contact.matrixId?.isNotEmpty == true
                 ? getProfile(context)
                 : null,
             builder: (context, snapshot) {
@@ -376,6 +384,10 @@ class _ExpansionPhonebookContactListTileState
         contact: contact,
         invitationStatus: invitationStatus,
       );
+    }
+
+    if (contact.matrixId == null || contact.matrixId!.isEmpty) {
+      return null;
     }
 
     if (widget.onContactTap != null) {

--- a/lib/pages/search/search_contacts_and_chats_controller.dart
+++ b/lib/pages/search/search_contacts_and_chats_controller.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/pages/search/search_debouncer_mixin.dart';
 import 'package:fluffychat/pages/search/search_mixin.dart';
 import 'package:fluffychat/presentation/extensions/contact/presentation_contact_extension.dart';
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search_state_extension.dart';
 import 'package:fluffychat/utils/extension/presentation_search_extension.dart';
@@ -22,7 +23,11 @@ import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart' hide Contact;
 
 class SearchContactsAndChatsController
-    with SearchDebouncerMixin, SearchMixin, ContactsViewControllerMixin {
+    with
+        SearchDebouncerMixin,
+        SearchMixin,
+        WellKnownMixin,
+        ContactsViewControllerMixin {
   final BuildContext context;
 
   SearchContactsAndChatsController(this.context);
@@ -38,6 +43,9 @@ class SearchContactsAndChatsController
 
   final isShowChatsAndContactsNotifier = ValueNotifier(false);
 
+  @override
+  bool get enablePhonebookContacts => supportInvitation();
+
   void toggleShowMore() {
     isShowChatsAndContactsNotifier.toggle();
   }
@@ -50,6 +58,9 @@ class SearchContactsAndChatsController
   List<Room> get _rooms => client.rooms;
 
   Future<void> init() async {
+    discoveryInformationNotifier.value = Matrix.of(
+      context,
+    ).loginHomeserverSummary?.discoveryInformation;
     initializeDebouncer((keyword) {
       _searchChatsFromLocal(keyword: keyword);
     });
@@ -147,6 +158,11 @@ class SearchContactsAndChatsController
             .getPhonebookContactsNotifier()
             .value
             .getFailureOrNull<RegisterTokenFailure>()
+            ?.contacts ??
+        contactManger
+            .getPhonebookContactsNotifier()
+            .value
+            .getFailureOrNull<GetHashDetailsFailure>()
             ?.contacts ??
         [];
     return phoneBookContacts;

--- a/lib/pages/splash/splash.dart
+++ b/lib/pages/splash/splash.dart
@@ -17,7 +17,7 @@ class _SplashState extends State<Splash> {
     Future.delayed(const Duration(seconds: 2), () {
       if (!context.mounted) return;
 
-      context.pushReplacement('/');
+      context.go('/');
     });
   }
 

--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/domain/app_state/contact/get_phonebook_contact_state.dart';
 import 'package:fluffychat/domain/app_state/search/search_state.dart';
 import 'package:fluffychat/domain/contact_manager/contacts_manager.dart';
+import 'package:fluffychat/domain/model/contact/contact.dart' as contact_model;
 import 'package:fluffychat/domain/model/contact/contact_type.dart';
 import 'package:fluffychat/domain/model/extensions/contact/contact_extension.dart';
 import 'package:fluffychat/domain/usecase/search/search_recent_chat_interactor.dart';
@@ -73,8 +74,78 @@ mixin class ContactsViewControllerMixin {
 
   PermissionStatus? contactsPermissionStatus;
 
+  bool _canReadPhonebookContacts(PermissionStatus? status) =>
+      status == PermissionStatus.granted || status == PermissionStatus.limited;
+
+  bool get enablePhonebookContacts => true;
+
+  Future<bool> _isPhonebookContactsAvailable() async {
+    if (!enablePhonebookContacts) {
+      contactsPermissionStatus = null;
+      return false;
+    }
+
+    final currentContactsPermissionStatus = PlatformInfos.isMobile
+        ? await _permissionHandlerService.contactsPermissionStatus
+        : null;
+    contactsPermissionStatus = currentContactsPermissionStatus;
+    return PlatformInfos.isMobile &&
+        _canReadPhonebookContacts(currentContactsPermissionStatus);
+  }
+
+  Future<void> _initPhonebookPermission(BuildContext context) async {
+    if (!enablePhonebookContacts) {
+      warningBannerNotifier.value = WarningContactsBannerState.hide;
+      return;
+    }
+
+    if (PlatformInfos.isMobile &&
+        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
+      await displayContactPermissionDialog(context);
+    } else {
+      await _initWarningBanner();
+    }
+  }
+
   bool get phoneBookFilterSuccess => presentationPhonebookContactNotifier.value
       .fold((_) => false, (success) => success is GetPhonebookContactsSuccess);
+
+  bool get hasVisibleContacts =>
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) =>
+            (success is PresentationContactsSuccess &&
+                success.contacts.isNotEmpty) ||
+            success is PresentationExternalContactSuccess,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) =>
+            success is PresentationContactsSuccess &&
+            success.contacts.isNotEmpty,
+      ) ||
+      presentationRecentContactNotifier.value.isNotEmpty;
+
+  bool get isLoadingContacts =>
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is ContactsLoading,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is GetPhonebookContactsLoading,
+      );
+
+  bool get isWaitingContacts =>
+      isLoadingContacts ||
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is ContactsInitial,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is GetPhonebookContactsInitial,
+      );
 
   /// Whether recent contacts (DMs found by the SDK) are mixed into the
   /// contacts list. The Contacts page must reflect the ToM Address Book only,
@@ -83,12 +154,17 @@ mixin class ContactsViewControllerMixin {
   bool get enableRecentContacts => true;
 
   Future displayContactPermissionDialog(BuildContext context) async {
+    if (!enablePhonebookContacts) {
+      return;
+    }
+
     final fetchContactsPermissionStatus =
         await _permissionHandlerService.contactsPermissionStatus;
 
     contactsPermissionStatus = fetchContactsPermissionStatus;
 
-    if (PlatformInfos.isMobile && !fetchContactsPermissionStatus.isGranted) {
+    if (PlatformInfos.isMobile &&
+        !_canReadPhonebookContacts(fetchContactsPermissionStatus)) {
       await showDialog(
         useRootNavigator: false,
         context: context,
@@ -119,6 +195,11 @@ mixin class ContactsViewControllerMixin {
   }
 
   Future<void> _initWarningBanner() async {
+    if (!enablePhonebookContacts) {
+      warningBannerNotifier.value = WarningContactsBannerState.hide;
+      return;
+    }
+
     if (!PlatformInfos.isMobile) {
       return;
     }
@@ -128,7 +209,7 @@ mixin class ContactsViewControllerMixin {
       'ContactsViewControllerMixin::_initWarningBanner: Contact Permission $currentContactPermission',
     );
 
-    if (currentContactPermission.isGranted) {
+    if (_canReadPhonebookContacts(currentContactPermission)) {
       contactsPermissionStatus = currentContactPermission;
       warningBannerNotifier.value = WarningContactsBannerState.hide;
       return;
@@ -145,7 +226,7 @@ mixin class ContactsViewControllerMixin {
     AppLifecycleState state, {
     required Client client,
   }) async {
-    if (!PlatformInfos.isMobile) {
+    if (!enablePhonebookContacts || !PlatformInfos.isMobile) {
       return;
     }
     Logs().i(
@@ -170,7 +251,7 @@ mixin class ContactsViewControllerMixin {
       }
 
       if (currentContactPermission != contactsPermissionStatus &&
-          currentContactPermission.isGranted) {
+          _canReadPhonebookContacts(currentContactPermission)) {
         contactsPermissionStatus = currentContactPermission;
         warningBannerNotifier.value = WarningContactsBannerState.hide;
         contactsManager.synchronizePhonebookContacts(withMxId: client.userID!);
@@ -185,12 +266,7 @@ mixin class ContactsViewControllerMixin {
     required MatrixLocalizations matrixLocalizations,
     bool forceRun = false,
   }) async {
-    if (PlatformInfos.isMobile &&
-        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
-      await displayContactPermissionDialog(context);
-    } else {
-      await _initWarningBanner();
-    }
+    await _initPhonebookPermission(context);
     _refreshAllContacts(
       context: context,
       client: client,
@@ -219,9 +295,7 @@ mixin class ContactsViewControllerMixin {
     await contactsManager.initialSynchronizeContacts(
       withMxId: client.userID!,
       isAvailableSupportPhonebookContacts:
-          PlatformInfos.isMobile &&
-          contactsPermissionStatus != null &&
-          contactsPermissionStatus == PermissionStatus.granted,
+          await _isPhonebookContactsAvailable(),
       forceRun: forceRun,
     );
   }
@@ -231,12 +305,7 @@ mixin class ContactsViewControllerMixin {
     required Client client,
     required MatrixLocalizations matrixLocalizations,
   }) async {
-    if (PlatformInfos.isMobile &&
-        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
-      await displayContactPermissionDialog(context);
-    } else {
-      await _initWarningBanner();
-    }
+    await _initPhonebookPermission(context);
     _refreshAllContacts(
       context: context,
       client: client,
@@ -265,9 +334,32 @@ mixin class ContactsViewControllerMixin {
     await contactsManager.synchronizeContactsOnContactTab(
       withMxId: client.userID!,
       isAvailableSupportPhonebookContacts:
-          PlatformInfos.isMobile &&
-          contactsPermissionStatus != null &&
-          contactsPermissionStatus == PermissionStatus.granted,
+          await _isPhonebookContactsAvailable(),
+    );
+  }
+
+  Future<void> retrySynchronizeContactsOnContactTab({
+    required BuildContext context,
+    required Client client,
+    required MatrixLocalizations matrixLocalizations,
+  }) async {
+    await _initPhonebookPermission(context);
+
+    if (client.userID == null) {
+      return;
+    }
+
+    await contactsManager.cancelAllSubscriptions();
+    await contactsManager.reSyncContacts();
+    _refreshAllContacts(
+      context: context,
+      client: client,
+      matrixLocalizations: matrixLocalizations,
+    );
+    await contactsManager.synchronizeContactsOnContactTab(
+      withMxId: client.userID!,
+      isAvailableSupportPhonebookContacts:
+          await _isPhonebookContactsAvailable(),
     );
   }
 
@@ -299,7 +391,13 @@ mixin class ContactsViewControllerMixin {
   }) {
     final keyword = _debouncer.value.trim();
     _refreshContacts(keyword);
-    _refreshPhoneBookContacts(keyword);
+    if (enablePhonebookContacts) {
+      _refreshPhoneBookContacts(keyword);
+    } else if (!presentationPhonebookContactNotifier.isDisposed) {
+      presentationPhonebookContactNotifier.value = const Right(
+        GetPhonebookContactsInitial(),
+      );
+    }
     if (enableRecentContacts) {
       _refreshRecentContacts(
         context: context,
@@ -380,102 +478,71 @@ mixin class ContactsViewControllerMixin {
 
   Future<void> _refreshPhoneBookContacts(String keyword) async {
     if (presentationPhonebookContactNotifier.isDisposed) return;
-    presentationPhonebookContactNotifier.value = contactsManager
-        .getPhonebookContactsNotifier()
-        .value
-        .fold(
-          (failure) {
-            if (failure is LookUpPhonebookContactPartialFailed) {
-              final filteredContacts = failure.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
+    presentationPhonebookContactNotifier
+        .value = contactsManager.getPhonebookContactsNotifier().value.fold(
+      (failure) {
+        if (failure is LookUpPhonebookContactPartialFailed) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
 
-            if (failure is GetPhonebookContactsFailure) {
-              final filteredContacts = failure.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
+        if (failure is GetPhonebookContactsFailure) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
 
-            if (failure is RequestTokenFailure) {
-              final filteredContacts = failure.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
+        if (failure is RequestTokenFailure) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
 
-            if (failure is RegisterTokenFailure) {
-              final filteredContacts = failure.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
+        if (failure is RegisterTokenFailure) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
 
-            return Left(failure);
-          },
-          (success) {
-            if (success is GetPhonebookContactsSuccess) {
-              final filteredContacts = success.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              _refreshContacts(keyword);
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
-            return Right(success);
-          },
-        );
+        if (failure is GetHashDetailsFailure) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
+
+        return Left(failure);
+      },
+      (success) {
+        if (success is GetPhonebookContactsSuccess) {
+          final filteredContacts = success.contacts
+              .searchContacts(keyword)
+              .expand((contact) => contact.toPresentationContacts())
+              .toList();
+          _refreshContacts(keyword);
+          if (filteredContacts.isEmpty) {
+            return Left(GetPresentationContactsEmpty(keyword: keyword));
+          } else {
+            return Right(
+              GetPresentationContactsSuccess(
+                contacts: filteredContacts,
+                keyword: keyword,
+              ),
+            );
+          }
+        }
+        return Right(success);
+      },
+    );
+  }
+
+  Either<Failure, Success> _mapPhonebookContactsToPresentation(
+    List<contact_model.Contact> contacts,
+    String keyword,
+  ) {
+    final filteredContacts = contacts
+        .searchContacts(keyword)
+        .expand((contact) => contact.toPresentationContacts())
+        .toList();
+    if (filteredContacts.isEmpty) {
+      return Left(GetPresentationContactsEmpty(keyword: keyword));
+    }
+    return Right(
+      GetPresentationContactsSuccess(
+        contacts: filteredContacts,
+        keyword: keyword,
+      ),
+    );
   }
 
   Either<Failure, Success> _handleSearchExternalContact(
@@ -599,9 +666,13 @@ mixin class ContactsViewControllerMixin {
   Future<void> _handleRequestContactsPermission({
     required Client client,
   }) async {
+    if (!enablePhonebookContacts) {
+      return;
+    }
+
     final currentContactsPermissionStatus = await _permissionHandlerService
         .requestContactsPermissionActions();
-    if (currentContactsPermissionStatus == PermissionStatus.granted) {
+    if (_canReadPhonebookContacts(currentContactsPermissionStatus)) {
       contactsManager.synchronizePhonebookContacts(withMxId: client.userID!);
       warningBannerNotifier.value = WarningContactsBannerState.hide;
     } else {
@@ -635,6 +706,10 @@ mixin class ContactsViewControllerMixin {
   }
 
   List<String> _flatMatrixIdsFromPhonebookContacts() {
+    if (!enablePhonebookContacts) {
+      return [];
+    }
+
     final phonebookContacts =
         contactsManager
             .getPhonebookContactsNotifier()

--- a/lib/presentation/mixins/wellknown_mixin.dart
+++ b/lib/presentation/mixins/wellknown_mixin.dart
@@ -1,4 +1,9 @@
+import 'dart:convert';
+
+import 'package:fluffychat/utils/custom_http_client.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:matrix/matrix.dart';
 
 mixin WellKnownMixin {
@@ -10,17 +15,55 @@ mixin WellKnownMixin {
       ValueNotifier(null);
 
   Future<void> getWellKnownInformation(Client client) async {
+    final homeserver = client.homeserver;
+    if (homeserver == null) {
+      return;
+    }
+    final result = await discoverFromHomeserver(homeserver);
+    if (result == null) return;
+    Logs().d('WellKnownMixin::getWellKnownInformation() well-known $result');
+    discoveryInformationNotifier.value = result;
+  }
+
+  static Future<DiscoveryInformation?> discoverFromHomeserver(
+    Uri homeserver, {
+    http.Client? httpClient,
+  }) async {
+    final client = httpClient ?? _createHttpClient();
     try {
-      final result = await client.getWellknown();
-      Logs().d('WellKnownMixin::getWellKnownInformation() well-known $result');
-      discoveryInformationNotifier.value = result;
-    } catch (e) {
-      Logs().e(
-        'WellKnownMixin::getWellKnownInformation() Error checking wellknown '
-        'status (keeping previous value): $e',
+      final response = await client.get(
+        Uri.https(homeserver.authority, '/.well-known/matrix/client'),
       );
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw FormatException(
+          'Well-known request failed with status ${response.statusCode}',
+        );
+      }
+      final discoveryJson = jsonDecode(utf8.decode(response.bodyBytes));
+      if (discoveryJson is! Map) {
+        throw const FormatException('Well-known response is not a JSON object');
+      }
+      return DiscoveryInformation.fromJson(
+        Map<String, Object?>.from(discoveryJson),
+      );
+    } catch (e, s) {
+      Logs().e(
+        'WellKnownMixin::discoverFromHomeserver() Error checking wellknown '
+        'status (keeping previous value): $e',
+        e,
+        s,
+      );
+      return null;
+    } finally {
+      if (httpClient == null) {
+        client.close();
+      }
     }
   }
+
+  static http.Client _createHttpClient() => PlatformInfos.isAndroid
+      ? CustomHttpClient.createHTTPClient()
+      : http.Client();
 
   bool supportInvitation() {
     final additionalProperties =

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -17,6 +17,7 @@ import 'package:fluffychat/event/twake_event_types.dart';
 import 'package:fluffychat/pages/chat/events/audio_message/audio_player_widget.dart';
 import 'package:fluffychat/presentation/mixins/connectivity_mixin.dart';
 import 'package:fluffychat/presentation/mixins/init_config_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/presentation/model/client_login_state_event.dart';
 import 'package:fluffychat/widgets/layouts/agruments/logout_body_args.dart';
 import 'package:flutter_emoji_mart/flutter_emoji_mart.dart';
@@ -1179,17 +1180,24 @@ class MatrixState extends State<Matrix>
     final previousDiscovery =
         loginHomeserverSummary?.discoveryInformation ??
         (db is HiveCollectionsDatabase ? await db.getWellKnown() : null);
+    final discoveredInformation =
+        previousDiscovery ??
+        await WellKnownMixin.discoverFromHomeserver(newClient.homeserver!);
     final newSummary = await newClient
         .checkHomeserver(newClient.homeserver!, checkWellKnown: false)
         .toHomeserverSummary();
-    if (newSummary.discoveryInformation == null && previousDiscovery != null) {
+    if (newSummary.discoveryInformation == null &&
+        discoveredInformation != null) {
       loginHomeserverSummary = HomeserverSummary(
-        discoveryInformation: previousDiscovery,
+        discoveryInformation: discoveredInformation,
         versions: newSummary.versions,
         loginFlows: newSummary.loginFlows,
       );
     } else {
       loginHomeserverSummary = newSummary;
+    }
+    if (db is HiveCollectionsDatabase) {
+      await db.storeWellKnown(loginHomeserverSummary?.discoveryInformation);
     }
     Logs().d(
       'Matrix::_getHomeserverInformation: appTwakeInformation ${loginHomeserverSummary?.appTwakeInformation}',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,26 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
+      sha256: a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.1"
+    version: "8.4.0"
+  analyzer_buffer:
+    dependency: transitive
+    description:
+      name: analyzer_buffer
+      sha256: aba2f75e63b3135fd1efaa8b6abefe1aa6e41b6bd9806221620fa48f98156033
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.11"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.10"
   animated_text_kit:
     dependency: transitive
     description:
@@ -317,10 +333,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -473,6 +489,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  custom_lint_core:
+    dependency: transitive
+    description:
+      name: custom_lint_core
+      sha256: "85b339346154d5646952d44d682965dfe9e12cae5febd706f0db3aa5010d6423"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.1"
+  custom_lint_visitor:
+    dependency: transitive
+    description:
+      name: custom_lint_visitor
+      sha256: "91f2a81e9f0abb4b9f3bb529f78b6227ce6050300d1ae5b1e2c69c66c7a566d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0+8.4.0"
   dart_style:
     dependency: transitive
     description:
@@ -1230,6 +1262,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0+4"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: ca2480512a8e840291325249f4857e363ffa5d1b77b132e189c9313a9d9fb9e0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   flutter_rust_bridge:
     dependency: transitive
     description:
@@ -1361,13 +1401,13 @@ packages:
     source: hosted
     version: "9.0.0"
   freezed_annotation:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: c87ff004c8aa6af2d531668b46a4ea379f7191dc6dfa066acd53d506da6e044b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -1900,18 +1940,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   matrix:
     dependency: "direct main"
     description:
@@ -2014,10 +2054,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -2075,6 +2115,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
+  node_preamble:
+    dependency: transitive
+    description:
+      name: node_preamble
+      sha256: "6e7eac89047ab8a8d26cf16127b5ed26de65209847630400f9aefd7cd5c730db"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   octo_image:
     dependency: transitive
     description:
@@ -2637,6 +2685,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.0.10"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "135723ec44dfba141bc4696224048a408336e794228a0117439e7ad0a8be6d05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  riverpod_analyzer_utils:
+    dependency: transitive
+    description:
+      name: riverpod_analyzer_utils
+      sha256: c971e50f678d55c87d9e3b5015df7fcaadb2302a84ea101247cf99387b4554fe
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0-dev.6"
+  riverpod_annotation:
+    dependency: "direct main"
+    description:
+      name: riverpod_annotation
+      sha256: "1f9c1bc10b13f68ebc83ab391e77a865ff796880461d2a60c5ce301e1fb65f51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  riverpod_generator:
+    dependency: "direct dev"
+    description:
+      name: riverpod_generator
+      sha256: "178d6bfa6de66d7db97db2466e5fad2da91a678ab376a7309235eec731755046"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   rxdart:
     dependency: "direct main"
     description:
@@ -2805,6 +2885,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  shelf_packages_handler:
+    dependency: transitive
+    description:
+      name: shelf_packages_handler
+      sha256: "89f967eca29607c933ba9571d838be31d67f53f6e4ee15147d5dc2934fee1b1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
+  shelf_static:
+    dependency: transitive
+    description:
+      name: shelf_static
+      sha256: c87c3875f91262785dade62d135760c2c69cb217ac759485334c5857ad89f6e3
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -2972,6 +3068,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   storage_space:
     dependency: "direct main"
     description:
@@ -3052,22 +3156,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
+  test:
+    dependency: transitive
+    description:
+      name: test
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.17"
   timezone:
     dependency: transitive
     description:
@@ -3471,6 +3583,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   webrtc_interface:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -228,10 +228,13 @@ dependencies:
   path: ^1.8.0
   web: ^1.1.1
   storage_space: ^1.2.0
+  flutter_riverpod: 3.0.0
+  riverpod_annotation: 3.0.0
 
 dev_dependencies:
   sentry_dart_plugin: ^3.2.1
   build_runner: 2.10.5
+  riverpod_generator: 3.0.0
   flutter_launcher_icons: ^0.13.1
   flutter_lints: ^3.0.2
   flutter_native_splash: ^2.0.3+1
@@ -290,6 +293,9 @@ msix_config:
   install_certificate: false
 
 dependency_overrides:
+  # Required by riverpod_generator 3.0.0 while flutter_emoji_mart still pins
+  # freezed_annotation ^2.4.1.
+  freezed_annotation: 3.0.0
   http: 1.2.2
   # This otherwise breaks on linux with flutter 3.7.0, let's override it for now.
   file_selector: ^0.9.2+2

--- a/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
@@ -189,7 +189,12 @@ void main() {
           interactor.execute(argument: testArgument),
           emitsInOrder([
             const Right(GetPhonebookContactsLoading()),
-            Left(GetHashDetailsFailure(exception: expectedException)),
+            Left(
+              GetHashDetailsFailure(
+                exception: expectedException,
+                contacts: testContacts,
+              ),
+            ),
           ]),
         );
       });
@@ -408,8 +413,11 @@ void main() {
           interactor.execute(argument: testArgument),
           emitsInOrder([
             const Right(GetPhonebookContactsLoading()),
-            const Left(
-              GetHashDetailsFailure(exception: 'Hash details is empty'),
+            Left(
+              GetHashDetailsFailure(
+                exception: 'Hash details is empty',
+                contacts: testContacts,
+              ),
             ),
           ]),
         );

--- a/test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart
@@ -591,7 +591,10 @@ void main() {
           emitsInOrder(<dynamic>[
             const Right<Failure, Success>(GetPhonebookContactsLoading()),
             Left<Failure, Success>(
-              GetHashDetailsFailure(exception: expectedException),
+              GetHashDetailsFailure(
+                exception: expectedException,
+                contacts: contacts,
+              ),
             ),
           ]),
         );

--- a/test/pages/contacts_tab/contacts_invitation_view_model_test.dart
+++ b/test/pages/contacts_tab/contacts_invitation_view_model_test.dart
@@ -1,0 +1,71 @@
+import 'package:fluffychat/domain/model/contact/contact.dart';
+import 'package:fluffychat/pages/contacts_tab/contacts_invitation_view_model.dart';
+import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer();
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  test('selectDefaultContact selects first phone number', () {
+    final phoneNumber = PresentationPhoneNumber(
+      phoneNumber: '+33123456789',
+      thirdPartyId: 'phone-id',
+      thirdPartyIdType: ThirdPartyIdType.msisdn,
+    );
+    final contact = PresentationContact(phoneNumbers: {phoneNumber});
+
+    container
+        .read(contactsInvitationViewModelProvider.notifier)
+        .selectDefaultContact(contact, isSelectionLocked: false);
+
+    expect(
+      container.read(contactsInvitationViewModelProvider).selectedContact,
+      phoneNumber,
+    );
+  });
+
+  test('selectContact toggles selected contact', () {
+    final email = PresentationEmail(
+      email: 'test@example.com',
+      thirdPartyId: 'email-id',
+      thirdPartyIdType: ThirdPartyIdType.email,
+    );
+    final viewModel = container.read(
+      contactsInvitationViewModelProvider.notifier,
+    );
+
+    viewModel.selectContact(email, isSelectionLocked: false);
+    viewModel.selectContact(email, isSelectionLocked: false);
+
+    expect(
+      container.read(contactsInvitationViewModelProvider).selectedContact,
+      isNull,
+    );
+  });
+
+  test('selectContact ignores selection when locked', () {
+    final email = PresentationEmail(
+      email: 'test@example.com',
+      thirdPartyId: 'email-id',
+      thirdPartyIdType: ThirdPartyIdType.email,
+    );
+
+    container
+        .read(contactsInvitationViewModelProvider.notifier)
+        .selectContact(email, isSelectionLocked: true);
+
+    expect(
+      container.read(contactsInvitationViewModelProvider).selectedContact,
+      isNull,
+    );
+  });
+}

--- a/test/pages/contacts_tab/providers/contacts_invitation_providers_test.dart
+++ b/test/pages/contacts_tab/providers/contacts_invitation_providers_test.dart
@@ -1,0 +1,57 @@
+import 'package:fluffychat/domain/usecase/invitation/generate_invitation_link_interactor.dart';
+import 'package:fluffychat/domain/usecase/invitation/send_invitation_interactor.dart';
+import 'package:fluffychat/domain/usecase/invitation/store_invitation_status_interactor.dart';
+import 'package:fluffychat/pages/contacts_tab/providers/contacts_invitation_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mockito/mockito.dart';
+
+class MockSendInvitationInteractor extends Mock
+    implements SendInvitationInteractor {}
+
+class MockGenerateInvitationLinkInteractor extends Mock
+    implements GenerateInvitationLinkInteractor {}
+
+class MockStoreInvitationStatusInteractor extends Mock
+    implements StoreInvitationStatusInteractor {}
+
+void main() {
+  tearDown(() async {
+    await GetIt.instance.reset();
+  });
+
+  test('invitation providers expose legacy get_it interactors', () {
+    final sendInvitationInteractor = MockSendInvitationInteractor();
+    final generateInvitationLinkInteractor =
+        MockGenerateInvitationLinkInteractor();
+    final storeInvitationStatusInteractor =
+        MockStoreInvitationStatusInteractor();
+
+    GetIt.instance.registerSingleton<SendInvitationInteractor>(
+      sendInvitationInteractor,
+    );
+    GetIt.instance.registerSingleton<GenerateInvitationLinkInteractor>(
+      generateInvitationLinkInteractor,
+    );
+    GetIt.instance.registerSingleton<StoreInvitationStatusInteractor>(
+      storeInvitationStatusInteractor,
+    );
+
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(sendInvitationInteractorProvider),
+      same(sendInvitationInteractor),
+    );
+    expect(
+      container.read(generateInvitationLinkInteractorProvider),
+      same(generateInvitationLinkInteractor),
+    );
+    expect(
+      container.read(storeInvitationStatusInteractorProvider),
+      same(storeInvitationStatusInteractor),
+    );
+  });
+}

--- a/test/presentation/mixins/wellknown_mixin_test.dart
+++ b/test/presentation/mixins/wellknown_mixin_test.dart
@@ -1,6 +1,10 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:matrix/matrix.dart';
+import 'dart:convert';
+
 import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:matrix/matrix.dart';
 
 class DummyController with WellKnownMixin {}
 
@@ -100,6 +104,35 @@ void main() {
       );
 
       expect(controller.supportInvitation(), isFalse);
+    });
+
+    test('discoverFromHomeserver uses homeserver well-known URL', () async {
+      final requests = <Uri>[];
+      final httpClient = MockClient((request) async {
+        requests.add(request.url);
+        return http.Response.bytes(
+          utf8.encode(
+            jsonEncode({
+              'm.homeserver': {'base_url': 'https://matrix.domain.xyz'},
+              'app.twake.chat': {'enable_invitations': true},
+            }),
+          ),
+          200,
+        );
+      });
+
+      final result = await WellKnownMixin.discoverFromHomeserver(
+        Uri.parse('https://matrix.domain.xyz/some/path'),
+        httpClient: httpClient,
+      );
+
+      expect(requests, [
+        Uri.parse('https://matrix.domain.xyz/.well-known/matrix/client'),
+      ]);
+      expect(result, isNotNull);
+      expect(result!.additionalProperties['app.twake.chat'], {
+        'enable_invitations': true,
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR fixes the local contacts and invitation flow. The goal is to make local contacts visible earlier, drive local contact invitation support from WellKnown, migrate invitation state to Riverpod 3, and avoid blocking the UI when ToM or identity services are slow or fail.

Sorry for the number of modified files. The change touches several layers because the bug crossed WellKnown discovery, contact loading, invitation state management, and UI rendering.

## Fixed Issues

- Local contacts were not displayed because phonebook loading depended too much on the ToM contacts and federation flow. If a remote call was slow or failed, the UI could stay in loading.
- Contact loading could take too long because local phonebook contacts were effectively blocked behind `/addressbook` and enrichment calls.
- WellKnown could be resolved from the Matrix ID domain instead of the real homeserver. In that case the response could be HTML instead of JSON, leaving `supportInvitation()` disabled.
- Android WellKnown discovery used a direct `http.get`, bypassing the custom Matrix SDK HTTP client. It now uses the same custom HTTP client on Android.
- Invitation logic still had direct `getIt` access. It now goes through Riverpod 3 providers generated with `@riverpod`.
- Local contacts could be lost when federation, hash lookup, token request, or registration failed. Raw phonebook contacts are now preserved as a fallback.
- Splash navigation now uses `context.go('/')`, which better matches the top-level GoRouter flow.

## Additions

- Added `ContactsInvitationState` to represent selected contact, generated invitation link, loading, and error states.
- Added `ContactsInvitationViewModel` to move invitation behavior out of the widget layer.
- Added Riverpod providers for invitation dependencies and state management.
- Added tests for invitation providers and view model behavior.
- Added a WellKnown test that verifies homeserver-based `/.well-known/matrix/client` discovery and JSON parsing.

## Technical Choices

- Phonebook and ToM contacts now load in parallel because they are independent data sources.
- Raw local contacts are kept when enrichment fails because federation matching is useful but should not be required to display phonebook contacts.
- `@riverpod` providers wrap the existing DI dependencies, keeping the existing repository/usecase setup while making the invitation flow testable and Riverpod-compliant.


https://github.com/user-attachments/assets/56559f3c-b61c-4c44-b7f8-6f0ea0dd92d2


## Validation

- `flutter analyze` passed on the critical touched files.
- `flutter test test/presentation/mixins/wellknown_mixin_test.dart` passed.
- Contacts manager tests passed before push.
- iOS run on Mangue: app leaves the splash screen and local contacts are visible even when identity calls fail.
