### PR TITLE
Fix patrol CI

### DIFF
--- a/integration_test/robots/new_chat_robot.dart
+++ b/integration_test/robots/new_chat_robot.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/pages/new_group/contacts_selection_view.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -47,9 +48,11 @@ class NewChatRobot extends CoreRobot {
 
   Future<void> clickOnNewGroupChatIcon() async {
     await getNewGroupChatIcon().tap();
-    // The "Add members" AppBar title is mobile-only (absent on web's wide
-    // layout); wait for the add-members search affordance instead.
-    await $.waitUntilVisible($(find.byIcon(Icons.search)).first);
+    // The add-members screen (`ContactsSelectionView`) opens directly in search
+    // mode (`openSearchBar()` in its initState), so the standalone search icon
+    // is gone and the search `TextField` is shown inline. Wait for that field
+    // instead of the removed `Icons.search` affordance.
+    await $.waitUntilVisible($(ContactsSelectionView).$(TextField).first);
   }
 
   List<TwakeListItemRobot> getListOfAccount() {

--- a/integration_test/scenarios/chat_list_scenarios.dart
+++ b/integration_test/scenarios/chat_list_scenarios.dart
@@ -48,12 +48,12 @@ class ChatListSearchScenario extends BaseTestScenario {
       'Search by $_searchByMatrixAddress expected exactly 1 group',
     );
 
-    // Diacritic-insensitive: title with 'a' replaced by 'à' should still match.
-    final diacriticQuery = _searchByTitle.replaceAll('a', 'à');
+    // Diacritic-insensitive: title with 'U' replaced by 'Ù' should still match.
+    final diacriticQuery = _searchByTitle.replaceAll('U', 'Ù');
     s.softAssertEquals(
       diacriticQuery != _searchByTitle,
       true,
-      'SearchByTitle must contain "a" to verify diacritic-insensitive search',
+      'SearchByTitle must contain "U" to verify diacritic-insensitive search',
     );
     await _search(diacriticQuery);
     s.softAssertEquals(


### PR DESCRIPTION
## Description

This PR fixes (proof here https://github.com/linagora/twake-on-matrix/actions/runs/28815367094) two little e2e test mistakes introduced by: 

- [#3159](https://github.com/linagora/twake-on-matrix/issues/3159)
- [#3190](https://github.com/linagora/twake-on-matrix/issues/3190)

There is still one test that fail (introduced by [#3159](https://github.com/linagora/twake-on-matrix/issues/3159)) but this last issue need to be fixed in https://github.com/linagora/twake-on-matrix/pull/3173 as it's related to contact search (cc @aparesy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat creation flow to wait for the inline search field on the add-members screen, matching the current UI behavior.
  * Updated search test coverage for diacritic-insensitive matching with a revised example case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->