### PR TITLE
Fix sync error header visibility and Sentry reporting

### DIFF
--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -35,10 +35,7 @@ class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
       if (!mounted) return;
 
       final client = Matrix.of(context).client;
-      final hide =
-          client.onSync.value != null &&
-          update.status != SyncStatus.error &&
-          client.prevBatch != null;
+      final hide = client.onSync.value != null && client.prevBatch != null;
 
       if (_lastStatus?.status != update.status || _lastHideState != hide) {
         setState(() {
@@ -63,10 +60,7 @@ class ConnectionStatusHeaderState extends State<ConnectionStatusHeader> {
         _lastStatus ??
         client.onSyncStatus.value ??
         const SyncStatusUpdate(SyncStatus.waitingForResponse);
-    final hide =
-        client.onSync.value != null &&
-        status.status != SyncStatus.error &&
-        client.prevBatch != null;
+    final hide = client.onSync.value != null && client.prevBatch != null;
 
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 200),

--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -89,7 +89,7 @@ extension on SyncStatusUpdate {
       case SyncStatus.waitingForResponse:
         return l10n!.waitingForResponse;
       case SyncStatus.error:
-        return error?.exception?.toString() ?? l10n!.oopsSomethingWentWrong;
+        return l10n!.oopsSomethingWentWrong;
       case SyncStatus.processing:
       case SyncStatus.cleaningUp:
       case SyncStatus.finished:

--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -89,7 +89,7 @@ extension on SyncStatusUpdate {
       case SyncStatus.waitingForResponse:
         return l10n!.waitingForResponse;
       case SyncStatus.error:
-        return l10n!.oopsSomethingWentWrong;
+        return error?.exception?.toString() ?? l10n!.oopsSomethingWentWrong;
       case SyncStatus.processing:
       case SyncStatus.cleaningUp:
       case SyncStatus.finished:

--- a/lib/widgets/connection_status_header.dart
+++ b/lib/widgets/connection_status_header.dart
@@ -89,7 +89,7 @@ extension on SyncStatusUpdate {
       case SyncStatus.waitingForResponse:
         return l10n!.waitingForResponse;
       case SyncStatus.error:
-        return l10n!.waitingForResponse;
+        return l10n!.oopsSomethingWentWrong;
       case SyncStatus.processing:
       case SyncStatus.cleaningUp:
       case SyncStatus.finished:

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -396,6 +396,10 @@ class MatrixState extends State<Matrix>
   final onKeyVerificationRequestSub = <String, StreamSubscription>{};
   final onNotification = <String, StreamSubscription>{};
   final onLoginStateChanged = <String, StreamSubscription<LoginState>>{};
+  final onSyncStatusSub = <String, StreamSubscription>{};
+  final _lastSyncErrorSentAt = <String, DateTime>{};
+
+  static const _syncErrorSentryThrottle = Duration(minutes: 10);
 
   /// Re-registers the Web Push pusher when the app language changes so its
   /// (generic) notification text follows the account language.
@@ -543,6 +547,9 @@ class MatrixState extends State<Matrix>
     onUiaRequest[name] ??= currentClient.onUiaRequest.stream.listen(
       uiaRequestHandler,
     );
+    onSyncStatusSub[name] ??= currentClient.onSyncStatus.stream.listen(
+      (update) => _handleSyncStatusUpdate(currentClient, update),
+    );
     if (PlatformInfos.isWeb || PlatformInfos.isLinux) {
       Future<void> initWebNotifications() async {
         if (kIsWeb) {
@@ -599,6 +606,45 @@ class MatrixState extends State<Matrix>
         }
       }
     });
+  }
+
+  void _handleSyncStatusUpdate(Client client, SyncStatusUpdate update) {
+    if (update.status != SyncStatus.error || update.error == null) return;
+
+    _captureSyncError(client, update);
+  }
+
+  void _captureSyncError(Client client, SyncStatusUpdate update) {
+    final error = update.error;
+    if (error == null) return;
+
+    final exception = error.exception ?? Exception('Unknown Matrix sync error');
+    final errorType = exception.runtimeType.toString();
+    final throttleKey = '${client.clientName}:$errorType';
+    final now = DateTime.now();
+    final lastSentAt = _lastSyncErrorSentAt[throttleKey];
+    if (lastSentAt != null &&
+        now.difference(lastSentAt) < _syncErrorSentryThrottle) {
+      return;
+    }
+
+    _lastSyncErrorSentAt[throttleKey] = now;
+    // ignore: unawaited_futures
+    Sentry.captureException(
+      exception,
+      stackTrace: error.stackTrace,
+      withScope: (scope) async {
+        await scope.setTag('sync_status', update.status.name);
+        await scope.setTag('sync_error_type', errorType);
+        await scope.setContexts('matrix_sync', {
+          'has_prev_batch': client.prevBatch != null,
+          'has_sync_value': client.onSync.value != null,
+          'is_logged': client.isLogged(),
+          'platform': PlatformInfos.clientName,
+          'sync_pending': client.syncPending,
+        });
+      },
+    );
   }
 
   Future<void> _requestNotificationPermission() async {
@@ -751,6 +797,8 @@ class MatrixState extends State<Matrix>
     onNotification.remove(name);
     await onUiaRequest[name]?.cancel();
     onUiaRequest.remove(name);
+    await onSyncStatusSub[name]?.cancel();
+    onSyncStatusSub.remove(name);
     final webPushListener = _webPushLocaleListener;
     if (webPushListener != null) {
       LocalizationService.currentLocale.removeListener(webPushListener);
@@ -1474,6 +1522,9 @@ class MatrixState extends State<Matrix>
       s.cancel();
     }
     for (final s in onUiaRequest.values) {
+      s.cancel();
+    }
+    for (final s in onSyncStatusSub.values) {
       s.cancel();
     }
     onClientLoginStateChanged.close();

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -631,8 +631,7 @@ class MatrixState extends State<Matrix>
     _lastSyncErrorSentAt[throttleKey] = now;
     // ignore: unawaited_futures
     Sentry.captureException(
-      exception,
-      stackTrace: error.stackTrace,
+      Exception('Matrix sync error: $errorType'),
       withScope: (scope) async {
         await scope.setTag('sync_status', update.status.name);
         await scope.setTag('sync_error_type', errorType);


### PR DESCRIPTION
## Summary

Fixes #3201. Replaces #3206.

- Hide the connection status header after a first successful sync, even when the Matrix SDK emits `SyncStatus.error`.
- Report Matrix sync errors to Sentry with lightweight context and throttling.
- Redact sync error payloads before sending them to Sentry.

## Validation

- `flutter analyze lib/widgets/connection_status_header.dart lib/widgets/matrix.dart`
- GitHub checks from previous PR were green.

## Note

This keeps non-fatal sync errors quiet in the UI once data already exists, while preserving technical signal in Sentry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection status visibility so the header updates consistently when sync data is available.
  * Corrected error messaging so sync errors display the proper localized “something went wrong” text.
  * Fixed sync error handling by throttling repeated error reports for the same client/error type to reduce duplicate alerts and improve reliability.
  * Enhanced error reporting context to include key sync details for more actionable diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->