### PR TITLE
Fix web image viewer original asset loading

### DIFF
--- a/lib/pages/image_viewer/image_viewer.dart
+++ b/lib/pages/image_viewer/image_viewer.dart
@@ -61,6 +61,8 @@ class ImageViewerController extends State<ImageViewer> {
   StreamSubscription? streamSubcription;
 
   final _webOverlay = MediaViewerWebOverlay.image();
+  String? _webAttachmentEventId;
+  Future<MatrixFile>? _webAttachmentFuture;
 
   @override
   void initState() {
@@ -80,7 +82,7 @@ class ImageViewerController extends State<ImageViewer> {
   /// the DOM so the browser's native "Save Image As" context menu works.
   Future<void> _injectWebImageOverlay(Event event) async {
     try {
-      final matrixFile = await event.downloadAndDecryptAttachment();
+      final matrixFile = await webAttachmentFuture(event);
       if (!mounted) return;
       final mimeType = event.mimeType ?? 'image/jpeg';
       _webOverlay.attach(
@@ -91,6 +93,20 @@ class ImageViewerController extends State<ImageViewer> {
     } catch (e) {
       Logs().e('ImageViewerController: failed to inject web overlay', e);
     }
+  }
+
+  Future<MatrixFile> webAttachmentFuture(Event event) {
+    if (_webAttachmentEventId != event.eventId) {
+      _webAttachmentEventId = event.eventId;
+      _webAttachmentFuture = event.downloadAndDecryptAttachment().catchError((
+        e,
+      ) {
+        _webAttachmentEventId = null;
+        _webAttachmentFuture = null;
+        throw e;
+      });
+    }
+    return _webAttachmentFuture!;
   }
 
   Future<void> handleDownloadFile(Event event) async {

--- a/lib/pages/image_viewer/image_viewer_view.dart
+++ b/lib/pages/image_viewer/image_viewer_view.dart
@@ -130,16 +130,17 @@ class _ImageWidget extends StatelessWidget {
         );
       }
       return FutureBuilder(
-        // Download full image for GIFs to preserve animation
-        future: event.downloadAndDecryptAttachment(
-          getThumbnail: !event.isGifImage,
-        ),
+        future: controller.webAttachmentFuture(event),
         builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return const Icon(Icons.broken_image_outlined, color: Colors.white);
+          }
           if (snapshot.data == null || snapshot.data!.bytes.isEmpty != false) {
             return const CircularProgressIndicator();
           }
           return Image.memory(
             snapshot.data!.bytes,
+            fit: BoxFit.contain,
             cacheWidth: width != null
                 ? (width! * MediaQuery.devicePixelRatioOf(context)).toInt()
                 : null,


### PR DESCRIPTION
## Summary
- Fix web image viewer to load the original image instead of the thumbnail.
- Keep thumbnail usage in chat bubbles unchanged.
- Cache the web attachment future and clear it on failure so later calls can retry.
- Use contain fit for full-screen image display.

## Root cause
The web image viewer requested thumbnails for non-GIF images, so full-screen preview could display a low-resolution asset while download used the original file.

Fixes #3199

## Validation
- dart format --set-exit-if-changed lib/pages/image_viewer/image_viewer.dart lib/pages/image_viewer/image_viewer_view.dart
- flutter analyze lib/pages/image_viewer/image_viewer.dart lib/pages/image_viewer/image_viewer_view.dart