### PR TITLE
TW-3225: mentions and deleted messages style

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -215,8 +215,8 @@ class HtmlMessage extends StatelessWidget with LinkifyMixin {
           onTap: !room.isDirectChat ? onTap : null,
           textStyle: !room.isDirectChat
               ? defaultTextStyle?.copyWith(color: themeData.colorScheme.primary)
-              : Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurface,
+              : defaultTextStyle?.copyWith(
+                  color: themeData.colorScheme.onSurface,
                 ),
         );
       },

--- a/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
+++ b/lib/pages/chat/events/message/message_content_with_timestamp_builder.dart
@@ -647,6 +647,9 @@ class _MessageContentWithTimestampBuilderState
                 },
                 icon: item.action.getIcon(),
                 imagePath: item.action.getImagePath(),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: LinagoraSpacing.base,
+                ),
                 tooltip: item.action.getTitle(context),
                 preferBelow: false,
               );

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -325,22 +325,17 @@ extension LocalizedBody on Event {
   }
 
   TextStyle? getMessageTextStyle(BuildContext context, [Timeline? timeline]) {
-    if (redacted) {
-      return Theme.of(context).textTheme.bodyLarge?.copyWith(
-        fontSize: 17,
-        height: 24 / 17,
-        color: LinagoraRefColors.material().tertiary[30],
-      );
-    }
-
     if (isDisplayOnlyEmoji(timeline)) {
       return textStyleForOnlyEmoji(context);
     }
 
-    return Theme.of(context)
-        .extension<LinagoraTextThemeExtension>()!
-        .bodyMedium3
-        .copyWith(color: Theme.of(context).colorScheme.onSurface);
+    return Theme.of(
+      context,
+    ).extension<LinagoraTextThemeExtension>()!.bodyMedium3.copyWith(
+      color: redacted
+          ? LinagoraRefColors.material().tertiary[30]
+          : Theme.of(context).colorScheme.onSurface,
+    );
   }
 
   List<Client?> currentRoomBundle(MatrixState? matrix) {

--- a/lib/widgets/twake_components/twake_icon_button.dart
+++ b/lib/widgets/twake_components/twake_icon_button.dart
@@ -19,6 +19,8 @@ class TwakeIconButton extends StatelessWidget {
 
   final double? paddingAll;
 
+  final EdgeInsetsGeometry? padding;
+
   final double? size;
 
   final double? fill;
@@ -51,6 +53,7 @@ class TwakeIconButton extends StatelessWidget {
     this.imagePath,
     this.imageSize,
     this.paddingAll,
+    this.padding,
     this.size,
     this.fill,
     this.weight,
@@ -110,12 +113,12 @@ class TwakeIconButton extends StatelessWidget {
                   message: tooltip!,
                   triggerMode: tooltipTriggerMode,
                   child: Padding(
-                    padding: EdgeInsets.all(paddingAll ?? 8.0),
+                    padding: padding ?? EdgeInsets.all(paddingAll ?? 8.0),
                     child: iconWidget,
                   ),
                 )
               : Padding(
-                  padding: EdgeInsets.all(paddingAll ?? 8.0),
+                  padding: padding ?? EdgeInsets.all(paddingAll ?? 8.0),
                   child: iconWidget,
                 ),
         ),


### PR DESCRIPTION
## Ticket
Fixes #3225 and some others things

## Changes
- Welcome message now use the message body default text style
- Deleted messages: render same size as normal messages
- Remove vertical padding on hover action icons so hovering no longer shifts little message bubbles.

## Demos
### Before

https://github.com/user-attachments/assets/816154b3-e420-4c82-8d9d-ebffef39115f

### After

https://github.com/user-attachments/assets/e2c90332-ad1a-406e-b577-97525bffe79e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mention styling in chat messages, with better appearance in direct chats and for emoji-only messages.
  * Added more consistent spacing around message action buttons for a cleaner, easier-to-tap layout.

* **Bug Fixes**
  * Refined message text styling so redacted content and emoji-only messages display more appropriately across chat views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->