### PR TITLE
fix: load local contacts from homeserver well-known

### DIFF
--- a/lib/domain/app_state/contact/get_phonebook_contact_state.dart
+++ b/lib/domain/app_state/contact/get_phonebook_contact_state.dart
@@ -94,11 +94,15 @@ class GetPhoneBookContactFailure extends Failure {
 
 class GetHashDetailsFailure extends Failure {
   final dynamic exception;
+  final List<Contact> contacts;
 
-  const GetHashDetailsFailure({required this.exception});
+  const GetHashDetailsFailure({
+    required this.exception,
+    this.contacts = const [],
+  });
 
   @override
-  List<Object?> get props => [exception];
+  List<Object?> get props => [exception, contacts];
 }
 
 class LookUpContactFailure extends Failure {

--- a/lib/domain/contact_manager/contacts_manager.dart
+++ b/lib/domain/contact_manager/contacts_manager.dart
@@ -409,6 +409,8 @@ class ContactsManager {
 
       if (e is FederationConfigurationNotFound) {
         await _handleTwakeLookUpPhoneBookContacts();
+      } else {
+        _isSynchronizing = false;
       }
     }
   }

--- a/lib/domain/contact_manager/contacts_manager.dart
+++ b/lib/domain/contact_manager/contacts_manager.dart
@@ -232,27 +232,33 @@ class ContactsManager {
     bool isAvailableSupportPhonebookContacts = false,
     required String withMxId,
   }) async {
+    if (isAvailableSupportPhonebookContacts) {
+      unawaited(
+        _lookUpPhonebookContactsInContact(
+          isAvailableSupportPhonebookContacts:
+              isAvailableSupportPhonebookContacts,
+          withMxId: withMxId,
+        ),
+      );
+    }
+
     tomContactsSubscription =
         getTomContactsInteractor.execute().listen((event) {
             _contactsNotifier.value = event;
           })
           ..onDone(() async {
             Logs().d('ContactsManager::_getAllContactsOnContactTab: done');
-            await _lookUpPhonebookContactsInContact(
-              isAvailableSupportPhonebookContacts:
-                  isAvailableSupportPhonebookContacts,
-              withMxId: withMxId,
-            );
+            if (!isAvailableSupportPhonebookContacts) {
+              _isSynchronizing = false;
+            }
           })
           ..onError((error) async {
             Logs().d(
               'ContactsManager::_getAllContactsOnContactTab: error - $error',
             );
-            await _lookUpPhonebookContactsInContact(
-              isAvailableSupportPhonebookContacts:
-                  isAvailableSupportPhonebookContacts,
-              withMxId: withMxId,
-            );
+            if (!isAvailableSupportPhonebookContacts) {
+              _isSynchronizing = false;
+            }
           });
   }
 

--- a/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor.dart
@@ -472,7 +472,10 @@ class FederationLookUpPhonebookContactInteractor {
           hashDetails.algorithms == null ||
           hashDetails.algorithms!.isEmpty) {
         firstFailureRef(
-          const GetHashDetailsFailure(exception: 'Hash details is empty'),
+          GetHashDetailsFailure(
+            exception: 'Hash details is empty',
+            contacts: contacts,
+          ),
         );
         return null;
       }
@@ -488,7 +491,7 @@ class FederationLookUpPhonebookContactInteractor {
         'hash details failed for $federationUrl',
         e,
       );
-      firstFailureRef(GetHashDetailsFailure(exception: e));
+      firstFailureRef(GetHashDetailsFailure(exception: e, contacts: contacts));
       return null;
     }
   }

--- a/lib/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor.dart
+++ b/lib/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor.dart
@@ -73,8 +73,11 @@ class TwakeLookupPhonebookContactInteractor {
 
       if (res.lookupPepper?.isEmpty == true &&
           res.algorithms?.isEmpty == true) {
-        yield const Left(
-          GetHashDetailsFailure(exception: 'Hash details is empty'),
+        yield Left(
+          GetHashDetailsFailure(
+            exception: 'Hash details is empty',
+            contacts: contacts,
+          ),
         );
         return;
       }
@@ -84,7 +87,7 @@ class TwakeLookupPhonebookContactInteractor {
       Logs().e(
         'FederationLookUpPhonebookContactInteractor::execute: GetHashDetails: $e',
       );
-      yield Left(GetHashDetailsFailure(exception: e));
+      yield Left(GetHashDetailsFailure(exception: e, contacts: contacts));
       return;
     }
 

--- a/lib/domain/usecase/invitation/hive_get_invitation_status_interactor.dart
+++ b/lib/domain/usecase/invitation/hive_get_invitation_status_interactor.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/app_state/failure.dart';
 import 'package:fluffychat/app_state/success.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/app_state/invitation/hive_get_invitation_status_state.dart';
+import 'package:fluffychat/domain/exception/invitation/invitation_status_not_found.dart';
 import 'package:fluffychat/domain/repository/invitation/hive_invitation_status_repository.dart';
 import 'package:matrix/matrix.dart';
 
@@ -34,7 +35,9 @@ class HiveGetInvitationStatusInteractor {
         ),
       );
     } catch (e) {
-      Logs().e('HiveGetInvitationStatusInteractor::execute', e);
+      if (e is! InvitationStatusNotFound) {
+        Logs().e('HiveGetInvitationStatusInteractor::execute', e);
+      }
       yield Left(
         HiveGetInvitationStatusFailureState(
           exception: e,

--- a/lib/pages/contacts_tab/contacts_tab.dart
+++ b/lib/pages/contacts_tab/contacts_tab.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/presentation/mixins/address_book_mixin.dart';
 import 'package:fluffychat/presentation/mixins/comparable_presentation_contact_mixin.dart';
@@ -32,7 +34,8 @@ class ContactsTabController extends State<ContactsTab>
         ComparablePresentationContactMixin,
         ContactsViewControllerMixin,
         AddressBooksMixin,
-        WidgetsBindingObserver {
+        WidgetsBindingObserver,
+        AutomaticKeepAliveClientMixin {
   final responsive = getIt.get<ResponsiveUtils>();
 
   Client get client => Matrix.of(context).client;
@@ -43,6 +46,9 @@ class ContactsTabController extends State<ContactsTab>
   bool get enableRecentContacts => false;
 
   @override
+  bool get showPhonebookContacts => supportInvitation();
+
+  @override
   void initState() {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       WidgetsBinding.instance.addObserver(this);
@@ -51,6 +57,9 @@ class ContactsTabController extends State<ContactsTab>
         discoveryInformationNotifier.value = Matrix.of(
           context,
         ).loginHomeserverSummary?.discoveryInformation;
+        if (discoveryInformationNotifier.value == null) {
+          unawaited(_loadWellKnownAndRetryContacts());
+        }
         synchronizeContactsOnContactTab(
           context: context,
           client: Matrix.of(context).client,
@@ -61,6 +70,19 @@ class ContactsTabController extends State<ContactsTab>
 
     _listenFocusTextEditing();
     super.initState();
+  }
+
+  Future<void> _loadWellKnownAndRetryContacts() async {
+    await getWellKnownInformation(client);
+    if (!mounted || !supportInvitation()) {
+      return;
+    }
+
+    await retrySynchronizeContactsOnContactTab(
+      context: context,
+      client: client,
+      matrixLocalizations: MatrixLocals(L10n.of(context)!),
+    );
   }
 
   void _listenFocusTextEditing() {
@@ -133,8 +155,14 @@ class ContactsTabController extends State<ContactsTab>
   }
 
   @override
-  Widget build(BuildContext context) => ContactsTabView(
-    contactsController: this,
-    bottomNavigationBar: widget.bottomNavigationBar,
-  );
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return ContactsTabView(
+      contactsController: this,
+      bottomNavigationBar: widget.bottomNavigationBar,
+    );
+  }
 }

--- a/lib/pages/new_group/contacts_selection.dart
+++ b/lib/pages/new_group/contacts_selection.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/presentation/mixins/address_book_mixin.dart';
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
 import 'package:fluffychat/presentation/mixins/invite_external_contact_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/pages/new_group/contacts_selection_view.dart';
 import 'package:fluffychat/pages/new_group/selected_contacts_map_change_notifier.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
@@ -15,6 +16,7 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
     extends State<T>
     with
         InviteExternalContactMixin,
+        WellKnownMixin,
         ContactsViewControllerMixin,
         AddressBooksMixin,
         WidgetsBindingObserver {
@@ -33,6 +35,9 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
 
   bool get isFullScreen => true;
 
+  @override
+  bool get showPhonebookContacts => supportInvitation();
+
   Client get client => Matrix.of(context).client;
 
   @override
@@ -41,6 +46,9 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
       WidgetsBinding.instance.addObserver(this);
       if (mounted) {
         listenAddressBookEvents(client);
+        discoveryInformationNotifier.value = Matrix.of(
+          context,
+        ).loginHomeserverSummary?.discoveryInformation;
         initialFetchContacts(
           context: context,
           client: client,

--- a/lib/pages/new_private_chat/new_private_chat.dart
+++ b/lib/pages/new_private_chat/new_private_chat.dart
@@ -3,6 +3,7 @@ import 'package:fluffychat/presentation/mixins/comparable_presentation_contact_m
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
 import 'package:fluffychat/presentation/mixins/go_to_group_chat_mixin.dart';
 import 'package:fluffychat/presentation/mixins/invite_external_contact_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/pages/new_private_chat/new_private_chat_view.dart';
 import 'package:fluffychat/presentation/mixins/go_to_direct_chat_mixin.dart';
 import 'package:fluffychat/presentation/model/contact/presentation_contact.dart';
@@ -25,6 +26,7 @@ class NewPrivateChat extends StatefulWidget {
 class NewPrivateChatController extends State<NewPrivateChat>
     with
         ComparablePresentationContactMixin,
+        WellKnownMixin,
         ContactsViewControllerMixin,
         GoToDraftChatMixin,
         WidgetsBindingObserver,
@@ -34,6 +36,9 @@ class NewPrivateChatController extends State<NewPrivateChat>
   final scrollController = ScrollController();
 
   @override
+  bool get showPhonebookContacts => supportInvitation();
+
+  @override
   void initState() {
     super.initState();
     SchedulerBinding.instance.addPostFrameCallback((_) async {
@@ -41,6 +46,9 @@ class NewPrivateChatController extends State<NewPrivateChat>
       if (mounted) {
         final client = Matrix.of(context).client;
         listenAddressBookEvents(client);
+        discoveryInformationNotifier.value = Matrix.of(
+          context,
+        ).loginHomeserverSummary?.discoveryInformation;
         initialFetchContacts(
           context: context,
           client: client,

--- a/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_contact_list_tile.dart
@@ -61,6 +61,11 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
     required PresentationContact contact,
     InvitationStatusResponse? invitationStatus,
   }) async {
+    Logs().d(
+      'ExpansionContactListTile::_handleMatrixIdNull '
+      'hasMatrixId=${widget.contact.matrixId?.isNotEmpty == true} '
+      'hasInvitation=${invitationStatus?.invitation != null}',
+    );
     if (invitationStatus?.invitation != null &&
         invitationStatus!.invitation?.hasMatrixId == true) {
       widget.onContactTap?.call();
@@ -71,7 +76,8 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
       widget.onContactTap?.call();
       return;
     }
-    if (client.userID == null && client.userID?.isEmpty == true) return;
+    if (!widget.enableInvitation) return;
+    if (client.userID == null || client.userID!.isEmpty) return;
     final result = await showAdaptiveBottomSheet<String?>(
       context: context,
       builder: (context) => ContactsInvitation(
@@ -117,10 +123,12 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
             bottom: 8.0,
           ),
           child: FutureBuilder<Profile?>(
-            key: widget.contact.matrixId != null
+            key: widget.contact.matrixId?.isNotEmpty == true
                 ? Key(widget.contact.matrixId!)
                 : null,
-            future: widget.contact.status == ContactStatus.active
+            future:
+                widget.contact.status == ContactStatus.active &&
+                    widget.contact.matrixId?.isNotEmpty == true
                 ? getProfile(context)
                 : null,
             builder: (context, snapshot) {
@@ -387,6 +395,10 @@ class _ExpansionContactListTileState extends State<ExpansionContactListTile>
         contact: contact,
         invitationStatus: invitationStatus,
       );
+    }
+
+    if (contact.matrixId == null || contact.matrixId!.isEmpty) {
+      return null;
     }
 
     if (widget.onContactTap != null) {

--- a/lib/pages/new_private_chat/widget/expansion_phonebook_contact_list_tile.dart
+++ b/lib/pages/new_private_chat/widget/expansion_phonebook_contact_list_tile.dart
@@ -62,6 +62,11 @@ class _ExpansionPhonebookContactListTileState
     required PresentationContact contact,
     InvitationStatusResponse? invitationStatus,
   }) async {
+    Logs().d(
+      'ExpansionPhonebookContactListTile::_handleMatrixIdNull '
+      'hasMatrixId=${widget.contact.matrixId?.isNotEmpty == true} '
+      'hasInvitation=${invitationStatus?.invitation != null}',
+    );
     if (invitationStatus?.invitation != null &&
         invitationStatus!.invitation?.hasMatrixId == true) {
       widget.onContactTap?.call();
@@ -72,7 +77,8 @@ class _ExpansionPhonebookContactListTileState
       widget.onContactTap?.call();
       return;
     }
-    if (client.userID == null && client.userID?.isEmpty == true) return;
+    if (!widget.enableInvitation) return;
+    if (client.userID == null || client.userID!.isEmpty) return;
     final result = await showAdaptiveBottomSheet<String?>(
       context: context,
       builder: (context) => ContactsInvitation(
@@ -118,10 +124,12 @@ class _ExpansionPhonebookContactListTileState
             bottom: 8.0,
           ),
           child: FutureBuilder<Profile?>(
-            key: widget.contact.matrixId != null
+            key: widget.contact.matrixId?.isNotEmpty == true
                 ? Key(widget.contact.matrixId!)
                 : null,
-            future: widget.contact.status == ContactStatus.active
+            future:
+                widget.contact.status == ContactStatus.active &&
+                    widget.contact.matrixId?.isNotEmpty == true
                 ? getProfile(context)
                 : null,
             builder: (context, snapshot) {
@@ -376,6 +384,10 @@ class _ExpansionPhonebookContactListTileState
         contact: contact,
         invitationStatus: invitationStatus,
       );
+    }
+
+    if (contact.matrixId == null || contact.matrixId!.isEmpty) {
+      return null;
     }
 
     if (widget.onContactTap != null) {

--- a/lib/pages/search/search_contacts_and_chats_controller.dart
+++ b/lib/pages/search/search_contacts_and_chats_controller.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/pages/search/search_debouncer_mixin.dart';
 import 'package:fluffychat/pages/search/search_mixin.dart';
 import 'package:fluffychat/presentation/extensions/contact/presentation_contact_extension.dart';
 import 'package:fluffychat/presentation/mixins/contacts_view_controller_mixin.dart';
+import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search.dart';
 import 'package:fluffychat/presentation/model/search/presentation_search_state_extension.dart';
 import 'package:fluffychat/utils/extension/presentation_search_extension.dart';
@@ -22,7 +23,11 @@ import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart' hide Contact;
 
 class SearchContactsAndChatsController
-    with SearchDebouncerMixin, SearchMixin, ContactsViewControllerMixin {
+    with
+        SearchDebouncerMixin,
+        SearchMixin,
+        WellKnownMixin,
+        ContactsViewControllerMixin {
   final BuildContext context;
 
   SearchContactsAndChatsController(this.context);
@@ -38,6 +43,9 @@ class SearchContactsAndChatsController
 
   final isShowChatsAndContactsNotifier = ValueNotifier(false);
 
+  @override
+  bool get showPhonebookContacts => supportInvitation();
+
   void toggleShowMore() {
     isShowChatsAndContactsNotifier.toggle();
   }
@@ -50,6 +58,9 @@ class SearchContactsAndChatsController
   List<Room> get _rooms => client.rooms;
 
   Future<void> init() async {
+    discoveryInformationNotifier.value = Matrix.of(
+      context,
+    ).loginHomeserverSummary?.discoveryInformation;
     initializeDebouncer((keyword) {
       _searchChatsFromLocal(keyword: keyword);
     });
@@ -147,6 +158,11 @@ class SearchContactsAndChatsController
             .getPhonebookContactsNotifier()
             .value
             .getFailureOrNull<RegisterTokenFailure>()
+            ?.contacts ??
+        contactManger
+            .getPhonebookContactsNotifier()
+            .value
+            .getFailureOrNull<GetHashDetailsFailure>()
             ?.contacts ??
         [];
     return phoneBookContacts;

--- a/lib/presentation/mixins/contacts_view_controller_mixin.dart
+++ b/lib/presentation/mixins/contacts_view_controller_mixin.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:fluffychat/domain/app_state/contact/get_phonebook_contact_state.dart';
 import 'package:fluffychat/domain/app_state/search/search_state.dart';
 import 'package:fluffychat/domain/contact_manager/contacts_manager.dart';
+import 'package:fluffychat/domain/model/contact/contact.dart' as contact_model;
 import 'package:fluffychat/domain/model/contact/contact_type.dart';
 import 'package:fluffychat/domain/model/extensions/contact/contact_extension.dart';
 import 'package:fluffychat/domain/usecase/search/search_recent_chat_interactor.dart';
@@ -73,8 +74,80 @@ mixin class ContactsViewControllerMixin {
 
   PermissionStatus? contactsPermissionStatus;
 
+  bool _canReadPhonebookContacts(PermissionStatus? status) =>
+      status == PermissionStatus.granted || status == PermissionStatus.limited;
+
+  bool get enablePhonebookLookup => true;
+
+  bool get showPhonebookContacts => true;
+
+  Future<bool> _isPhonebookContactsAvailable() async {
+    if (!enablePhonebookLookup) {
+      contactsPermissionStatus = null;
+      return false;
+    }
+
+    final currentContactsPermissionStatus = PlatformInfos.isMobile
+        ? await _permissionHandlerService.contactsPermissionStatus
+        : null;
+    contactsPermissionStatus = currentContactsPermissionStatus;
+    return PlatformInfos.isMobile &&
+        _canReadPhonebookContacts(currentContactsPermissionStatus);
+  }
+
+  Future<void> _initPhonebookPermission(BuildContext context) async {
+    if (!enablePhonebookLookup) {
+      warningBannerNotifier.value = WarningContactsBannerState.hide;
+      return;
+    }
+
+    if (PlatformInfos.isMobile &&
+        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
+      await displayContactPermissionDialog(context);
+    } else {
+      await _initWarningBanner();
+    }
+  }
+
   bool get phoneBookFilterSuccess => presentationPhonebookContactNotifier.value
       .fold((_) => false, (success) => success is GetPhonebookContactsSuccess);
+
+  bool get hasVisibleContacts =>
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) =>
+            (success is PresentationContactsSuccess &&
+                success.contacts.isNotEmpty) ||
+            success is PresentationExternalContactSuccess,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) =>
+            success is PresentationContactsSuccess &&
+            success.contacts.isNotEmpty,
+      ) ||
+      presentationRecentContactNotifier.value.isNotEmpty;
+
+  bool get isLoadingContacts =>
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is ContactsLoading,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is GetPhonebookContactsLoading,
+      );
+
+  bool get isWaitingContacts =>
+      isLoadingContacts ||
+      presentationContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is ContactsInitial,
+      ) ||
+      presentationPhonebookContactNotifier.value.fold(
+        (_) => false,
+        (success) => success is GetPhonebookContactsInitial,
+      );
 
   /// Whether recent contacts (DMs found by the SDK) are mixed into the
   /// contacts list. The Contacts page must reflect the ToM Address Book only,
@@ -83,12 +156,17 @@ mixin class ContactsViewControllerMixin {
   bool get enableRecentContacts => true;
 
   Future displayContactPermissionDialog(BuildContext context) async {
+    if (!enablePhonebookLookup) {
+      return;
+    }
+
     final fetchContactsPermissionStatus =
         await _permissionHandlerService.contactsPermissionStatus;
 
     contactsPermissionStatus = fetchContactsPermissionStatus;
 
-    if (PlatformInfos.isMobile && !fetchContactsPermissionStatus.isGranted) {
+    if (PlatformInfos.isMobile &&
+        !_canReadPhonebookContacts(fetchContactsPermissionStatus)) {
       await showDialog(
         useRootNavigator: false,
         context: context,
@@ -119,6 +197,11 @@ mixin class ContactsViewControllerMixin {
   }
 
   Future<void> _initWarningBanner() async {
+    if (!enablePhonebookLookup) {
+      warningBannerNotifier.value = WarningContactsBannerState.hide;
+      return;
+    }
+
     if (!PlatformInfos.isMobile) {
       return;
     }
@@ -128,7 +211,7 @@ mixin class ContactsViewControllerMixin {
       'ContactsViewControllerMixin::_initWarningBanner: Contact Permission $currentContactPermission',
     );
 
-    if (currentContactPermission.isGranted) {
+    if (_canReadPhonebookContacts(currentContactPermission)) {
       contactsPermissionStatus = currentContactPermission;
       warningBannerNotifier.value = WarningContactsBannerState.hide;
       return;
@@ -145,7 +228,7 @@ mixin class ContactsViewControllerMixin {
     AppLifecycleState state, {
     required Client client,
   }) async {
-    if (!PlatformInfos.isMobile) {
+    if (!enablePhonebookLookup || !PlatformInfos.isMobile) {
       return;
     }
     Logs().i(
@@ -170,7 +253,7 @@ mixin class ContactsViewControllerMixin {
       }
 
       if (currentContactPermission != contactsPermissionStatus &&
-          currentContactPermission.isGranted) {
+          _canReadPhonebookContacts(currentContactPermission)) {
         contactsPermissionStatus = currentContactPermission;
         warningBannerNotifier.value = WarningContactsBannerState.hide;
         contactsManager.synchronizePhonebookContacts(withMxId: client.userID!);
@@ -185,12 +268,7 @@ mixin class ContactsViewControllerMixin {
     required MatrixLocalizations matrixLocalizations,
     bool forceRun = false,
   }) async {
-    if (PlatformInfos.isMobile &&
-        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
-      await displayContactPermissionDialog(context);
-    } else {
-      await _initWarningBanner();
-    }
+    await _initPhonebookPermission(context);
     _refreshAllContacts(
       context: context,
       client: client,
@@ -219,9 +297,7 @@ mixin class ContactsViewControllerMixin {
     await contactsManager.initialSynchronizeContacts(
       withMxId: client.userID!,
       isAvailableSupportPhonebookContacts:
-          PlatformInfos.isMobile &&
-          contactsPermissionStatus != null &&
-          contactsPermissionStatus == PermissionStatus.granted,
+          await _isPhonebookContactsAvailable(),
       forceRun: forceRun,
     );
   }
@@ -231,12 +307,7 @@ mixin class ContactsViewControllerMixin {
     required Client client,
     required MatrixLocalizations matrixLocalizations,
   }) async {
-    if (PlatformInfos.isMobile &&
-        !contactsManager.isDoNotShowWarningContactsDialogAgain) {
-      await displayContactPermissionDialog(context);
-    } else {
-      await _initWarningBanner();
-    }
+    await _initPhonebookPermission(context);
     _refreshAllContacts(
       context: context,
       client: client,
@@ -265,9 +336,32 @@ mixin class ContactsViewControllerMixin {
     await contactsManager.synchronizeContactsOnContactTab(
       withMxId: client.userID!,
       isAvailableSupportPhonebookContacts:
-          PlatformInfos.isMobile &&
-          contactsPermissionStatus != null &&
-          contactsPermissionStatus == PermissionStatus.granted,
+          await _isPhonebookContactsAvailable(),
+    );
+  }
+
+  Future<void> retrySynchronizeContactsOnContactTab({
+    required BuildContext context,
+    required Client client,
+    required MatrixLocalizations matrixLocalizations,
+  }) async {
+    await _initPhonebookPermission(context);
+
+    if (client.userID == null) {
+      return;
+    }
+
+    await contactsManager.cancelAllSubscriptions();
+    await contactsManager.reSyncContacts();
+    _refreshAllContacts(
+      context: context,
+      client: client,
+      matrixLocalizations: matrixLocalizations,
+    );
+    await contactsManager.synchronizeContactsOnContactTab(
+      withMxId: client.userID!,
+      isAvailableSupportPhonebookContacts:
+          await _isPhonebookContactsAvailable(),
     );
   }
 
@@ -299,7 +393,13 @@ mixin class ContactsViewControllerMixin {
   }) {
     final keyword = _debouncer.value.trim();
     _refreshContacts(keyword);
-    _refreshPhoneBookContacts(keyword);
+    if (showPhonebookContacts) {
+      _refreshPhoneBookContacts(keyword);
+    } else if (!presentationPhonebookContactNotifier.isDisposed) {
+      presentationPhonebookContactNotifier.value = const Right(
+        GetPhonebookContactsInitial(),
+      );
+    }
     if (enableRecentContacts) {
       _refreshRecentContacts(
         context: context,
@@ -380,102 +480,71 @@ mixin class ContactsViewControllerMixin {
 
   Future<void> _refreshPhoneBookContacts(String keyword) async {
     if (presentationPhonebookContactNotifier.isDisposed) return;
-    presentationPhonebookContactNotifier.value = contactsManager
-        .getPhonebookContactsNotifier()
-        .value
-        .fold(
-          (failure) {
-            if (failure is LookUpPhonebookContactPartialFailed) {
-              final filteredContacts = failure.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
+    presentationPhonebookContactNotifier
+        .value = contactsManager.getPhonebookContactsNotifier().value.fold(
+      (failure) {
+        if (failure is LookUpPhonebookContactPartialFailed) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
 
-            if (failure is GetPhonebookContactsFailure) {
-              final filteredContacts = failure.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
+        if (failure is GetPhonebookContactsFailure) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
 
-            if (failure is RequestTokenFailure) {
-              final filteredContacts = failure.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
+        if (failure is RequestTokenFailure) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
 
-            if (failure is RegisterTokenFailure) {
-              final filteredContacts = failure.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
+        if (failure is RegisterTokenFailure) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
 
-            return Left(failure);
-          },
-          (success) {
-            if (success is GetPhonebookContactsSuccess) {
-              final filteredContacts = success.contacts
-                  .searchContacts(keyword)
-                  .expand((contact) => contact.toPresentationContacts())
-                  .toList();
-              _refreshContacts(keyword);
-              if (filteredContacts.isEmpty) {
-                return Left(GetPresentationContactsEmpty(keyword: keyword));
-              } else {
-                return Right(
-                  GetPresentationContactsSuccess(
-                    contacts: filteredContacts,
-                    keyword: keyword,
-                  ),
-                );
-              }
-            }
-            return Right(success);
-          },
-        );
+        if (failure is GetHashDetailsFailure) {
+          return _mapPhonebookContactsToPresentation(failure.contacts, keyword);
+        }
+
+        return Left(failure);
+      },
+      (success) {
+        if (success is GetPhonebookContactsSuccess) {
+          final filteredContacts = success.contacts
+              .searchContacts(keyword)
+              .expand((contact) => contact.toPresentationContacts())
+              .toList();
+          _refreshContacts(keyword);
+          if (filteredContacts.isEmpty) {
+            return Left(GetPresentationContactsEmpty(keyword: keyword));
+          } else {
+            return Right(
+              GetPresentationContactsSuccess(
+                contacts: filteredContacts,
+                keyword: keyword,
+              ),
+            );
+          }
+        }
+        return Right(success);
+      },
+    );
+  }
+
+  Either<Failure, Success> _mapPhonebookContactsToPresentation(
+    List<contact_model.Contact> contacts,
+    String keyword,
+  ) {
+    final filteredContacts = contacts
+        .searchContacts(keyword)
+        .expand((contact) => contact.toPresentationContacts())
+        .toList();
+    if (filteredContacts.isEmpty) {
+      return Left(GetPresentationContactsEmpty(keyword: keyword));
+    }
+    return Right(
+      GetPresentationContactsSuccess(
+        contacts: filteredContacts,
+        keyword: keyword,
+      ),
+    );
   }
 
   Either<Failure, Success> _handleSearchExternalContact(
@@ -599,9 +668,13 @@ mixin class ContactsViewControllerMixin {
   Future<void> _handleRequestContactsPermission({
     required Client client,
   }) async {
+    if (!enablePhonebookLookup) {
+      return;
+    }
+
     final currentContactsPermissionStatus = await _permissionHandlerService
         .requestContactsPermissionActions();
-    if (currentContactsPermissionStatus == PermissionStatus.granted) {
+    if (_canReadPhonebookContacts(currentContactsPermissionStatus)) {
       contactsManager.synchronizePhonebookContacts(withMxId: client.userID!);
       warningBannerNotifier.value = WarningContactsBannerState.hide;
     } else {
@@ -635,6 +708,10 @@ mixin class ContactsViewControllerMixin {
   }
 
   List<String> _flatMatrixIdsFromPhonebookContacts() {
+    if (!showPhonebookContacts) {
+      return [];
+    }
+
     final phonebookContacts =
         contactsManager
             .getPhonebookContactsNotifier()

--- a/lib/presentation/mixins/wellknown_mixin.dart
+++ b/lib/presentation/mixins/wellknown_mixin.dart
@@ -1,4 +1,9 @@
+import 'dart:convert';
+
+import 'package:fluffychat/utils/custom_http_client.dart';
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:matrix/matrix.dart';
 
 mixin WellKnownMixin {
@@ -10,17 +15,55 @@ mixin WellKnownMixin {
       ValueNotifier(null);
 
   Future<void> getWellKnownInformation(Client client) async {
+    final homeserver = client.homeserver;
+    if (homeserver == null) {
+      return;
+    }
+    final result = await discoverFromHomeserver(homeserver);
+    if (result == null) return;
+    Logs().d('WellKnownMixin::getWellKnownInformation() well-known $result');
+    discoveryInformationNotifier.value = result;
+  }
+
+  static Future<DiscoveryInformation?> discoverFromHomeserver(
+    Uri homeserver, {
+    http.Client? httpClient,
+  }) async {
+    final client = httpClient ?? _createHttpClient();
     try {
-      final result = await client.getWellknown();
-      Logs().d('WellKnownMixin::getWellKnownInformation() well-known $result');
-      discoveryInformationNotifier.value = result;
-    } catch (e) {
-      Logs().e(
-        'WellKnownMixin::getWellKnownInformation() Error checking wellknown '
-        'status (keeping previous value): $e',
+      final response = await client.get(
+        Uri.https(homeserver.authority, '/.well-known/matrix/client'),
       );
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw FormatException(
+          'Well-known request failed with status ${response.statusCode}',
+        );
+      }
+      final discoveryJson = jsonDecode(utf8.decode(response.bodyBytes));
+      if (discoveryJson is! Map) {
+        throw const FormatException('Well-known response is not a JSON object');
+      }
+      return DiscoveryInformation.fromJson(
+        Map<String, Object?>.from(discoveryJson),
+      );
+    } catch (e, s) {
+      Logs().e(
+        'WellKnownMixin::discoverFromHomeserver() Error checking wellknown '
+        'status (keeping previous value): $e',
+        e,
+        s,
+      );
+      return null;
+    } finally {
+      if (httpClient == null) {
+        client.close();
+      }
     }
   }
+
+  static http.Client _createHttpClient() => PlatformInfos.isAndroid
+      ? CustomHttpClient.createHTTPClient()
+      : http.Client();
 
   bool supportInvitation() {
     final additionalProperties =

--- a/lib/presentation/mixins/wellknown_mixin.dart
+++ b/lib/presentation/mixins/wellknown_mixin.dart
@@ -1,9 +1,5 @@
-import 'dart:convert';
-
-import 'package:fluffychat/utils/custom_http_client.dart';
-import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/client_well_known_extension.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:matrix/matrix.dart';
 
 mixin WellKnownMixin {
@@ -15,55 +11,13 @@ mixin WellKnownMixin {
       ValueNotifier(null);
 
   Future<void> getWellKnownInformation(Client client) async {
-    final homeserver = client.homeserver;
-    if (homeserver == null) {
-      return;
-    }
-    final result = await discoverFromHomeserver(homeserver);
+    final result = await client.getWellKnownOrFallback(
+      fallback: discoveryInformationNotifier.value,
+    );
     if (result == null) return;
     Logs().d('WellKnownMixin::getWellKnownInformation() well-known $result');
     discoveryInformationNotifier.value = result;
   }
-
-  static Future<DiscoveryInformation?> discoverFromHomeserver(
-    Uri homeserver, {
-    http.Client? httpClient,
-  }) async {
-    final client = httpClient ?? _createHttpClient();
-    try {
-      final response = await client.get(
-        Uri.https(homeserver.authority, '/.well-known/matrix/client'),
-      );
-      if (response.statusCode < 200 || response.statusCode >= 300) {
-        throw FormatException(
-          'Well-known request failed with status ${response.statusCode}',
-        );
-      }
-      final discoveryJson = jsonDecode(utf8.decode(response.bodyBytes));
-      if (discoveryJson is! Map) {
-        throw const FormatException('Well-known response is not a JSON object');
-      }
-      return DiscoveryInformation.fromJson(
-        Map<String, Object?>.from(discoveryJson),
-      );
-    } catch (e, s) {
-      Logs().e(
-        'WellKnownMixin::discoverFromHomeserver() Error checking wellknown '
-        'status (keeping previous value): $e',
-        e,
-        s,
-      );
-      return null;
-    } finally {
-      if (httpClient == null) {
-        client.close();
-      }
-    }
-  }
-
-  static http.Client _createHttpClient() => PlatformInfos.isAndroid
-      ? CustomHttpClient.createHTTPClient()
-      : http.Client();
 
   bool supportInvitation() {
     final additionalProperties =

--- a/test/domain/contacts/contacts_manager_test.dart
+++ b/test/domain/contacts/contacts_manager_test.dart
@@ -4141,6 +4141,42 @@ void main() {
           ).called(2);
         },
       );
+      test('WHEN federation configuration lookup throws an unexpected error.\n'
+          'AND synchronizeContactsOnContactTab is called again.\n'
+          'THEN contact synchronization is retried.\n', () async {
+        when(mockGetTomContactsInteractor.execute()).thenAnswer(
+          (_) => Stream.fromIterable([
+            const Right(ContactsLoading()),
+            const Left(GetContactsIsEmpty()),
+          ]),
+        );
+
+        when(
+          mockFederationConfigurationsRepository.getFederationConfigurations(
+            mxId,
+          ),
+        ).thenThrow(Exception('Unexpected federation lookup error'));
+
+        contactsManager.synchronizeContactsOnContactTab(
+          isAvailableSupportPhonebookContacts: true,
+          withMxId: mxId,
+        );
+
+        await Future.delayed(const Duration(seconds: 1));
+
+        contactsManager.synchronizeContactsOnContactTab(
+          isAvailableSupportPhonebookContacts: true,
+          withMxId: mxId,
+        );
+
+        await Future.delayed(const Duration(seconds: 1));
+
+        verify(
+          mockFederationConfigurationsRepository.getFederationConfigurations(
+            mxId,
+          ),
+        ).called(2);
+      });
       test(
         '[Account-A] WHEN it is available get Phonebook contact.\n'
         '[Account-A] AND contactsNotifier return GetContactsIsEmpty with contacts is empty.\n'

--- a/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/federation_look_up_phonebook_contact_interactor_test.dart
@@ -189,7 +189,12 @@ void main() {
           interactor.execute(argument: testArgument),
           emitsInOrder([
             const Right(GetPhonebookContactsLoading()),
-            Left(GetHashDetailsFailure(exception: expectedException)),
+            Left(
+              GetHashDetailsFailure(
+                exception: expectedException,
+                contacts: testContacts,
+              ),
+            ),
           ]),
         );
       });
@@ -408,8 +413,11 @@ void main() {
           interactor.execute(argument: testArgument),
           emitsInOrder([
             const Right(GetPhonebookContactsLoading()),
-            const Left(
-              GetHashDetailsFailure(exception: 'Hash details is empty'),
+            Left(
+              GetHashDetailsFailure(
+                exception: 'Hash details is empty',
+                contacts: testContacts,
+              ),
             ),
           ]),
         );

--- a/test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart
+++ b/test/domain/usecase/contacts/twake_look_up_phonebook_contact_interactor_test.dart
@@ -591,7 +591,10 @@ void main() {
           emitsInOrder(<dynamic>[
             const Right<Failure, Success>(GetPhonebookContactsLoading()),
             Left<Failure, Success>(
-              GetHashDetailsFailure(exception: expectedException),
+              GetHashDetailsFailure(
+                exception: expectedException,
+                contacts: contacts,
+              ),
             ),
           ]),
         );

--- a/test/presentation/mixins/wellknown_mixin_test.dart
+++ b/test/presentation/mixins/wellknown_mixin_test.dart
@@ -1,6 +1,10 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:matrix/matrix.dart';
+import 'dart:convert';
+
 import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:matrix/matrix.dart';
 
 class DummyController with WellKnownMixin {}
 
@@ -100,6 +104,35 @@ void main() {
       );
 
       expect(controller.supportInvitation(), isFalse);
+    });
+
+    test('discoverFromHomeserver uses homeserver well-known URL', () async {
+      final requests = <Uri>[];
+      final httpClient = MockClient((request) async {
+        requests.add(request.url);
+        return http.Response.bytes(
+          utf8.encode(
+            jsonEncode({
+              'm.homeserver': {'base_url': 'https://matrix.domain.xyz'},
+              'app.twake.chat': {'enable_invitations': true},
+            }),
+          ),
+          200,
+        );
+      });
+
+      final result = await WellKnownMixin.discoverFromHomeserver(
+        Uri.parse('https://matrix.domain.xyz/some/path'),
+        httpClient: httpClient,
+      );
+
+      expect(requests, [
+        Uri.parse('https://matrix.domain.xyz/.well-known/matrix/client'),
+      ]);
+      expect(result, isNotNull);
+      expect(result!.additionalProperties['app.twake.chat'], {
+        'enable_invitations': true,
+      });
     });
   });
 }

--- a/test/presentation/mixins/wellknown_mixin_test.dart
+++ b/test/presentation/mixins/wellknown_mixin_test.dart
@@ -1,9 +1,5 @@
-import 'dart:convert';
-
 import 'package:fluffychat/presentation/mixins/wellknown_mixin.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart';
 import 'package:matrix/matrix.dart';
 
 class DummyController with WellKnownMixin {}
@@ -104,35 +100,6 @@ void main() {
       );
 
       expect(controller.supportInvitation(), isFalse);
-    });
-
-    test('discoverFromHomeserver uses homeserver well-known URL', () async {
-      final requests = <Uri>[];
-      final httpClient = MockClient((request) async {
-        requests.add(request.url);
-        return http.Response.bytes(
-          utf8.encode(
-            jsonEncode({
-              'm.homeserver': {'base_url': 'https://matrix.domain.xyz'},
-              'app.twake.chat': {'enable_invitations': true},
-            }),
-          ),
-          200,
-        );
-      });
-
-      final result = await WellKnownMixin.discoverFromHomeserver(
-        Uri.parse('https://matrix.domain.xyz/some/path'),
-        httpClient: httpClient,
-      );
-
-      expect(requests, [
-        Uri.parse('https://matrix.domain.xyz/.well-known/matrix/client'),
-      ]);
-      expect(result, isNotNull);
-      expect(result!.additionalProperties['app.twake.chat'], {
-        'enable_invitations': true,
-      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- Gate local contact display with the homeserver well-known invitation flag.
- Keep local contact lookup running independently from display visibility.
- Retry contact synchronization after well-known data becomes available.
- Avoid logging missing cached invitation status as an error because it is an expected state for contacts without stored invitations.

## Validation
- Tested on Mangue iOS.
- Verified the app starts past splash.
- Verified local contacts can be displayed when `enable_invitations` is enabled.
- Verified `InvitationStatusNotFound` no longer spams error logs.

On SaaS : 

https://github.com/user-attachments/assets/73ebae76-83da-40dd-9e05-7122a6bd8a6f

On LNG (invitations disabled) : 
<img width="660" height="1434" alt="IMG_6671" src="https://github.com/user-attachments/assets/6c6a9e1e-1f1e-471a-a5df-4df780dfde16" />



## Known follow-up
- Phonebook identity lookup can still fail with `401 M_SESSION_NOT_VALIDATED`; this is a separate token/session issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved well-known discovery using the current homeserver (with fallback) and refreshed invitation availability across contacts flows.
  * Added “keep alive” for the contacts tab and auto-retry when discovery data is missing.
  * Enabled phonebook results to participate in loading/search when available, with updated permission handling.

* **Bug Fixes**
  * Phonebook hash-details failures now retain discovered contacts for smoother recovery.
  * Avoided profile loading and tap actions for contacts with missing/empty Matrix IDs.
  * Reduced noisy error logging for expected “not found” cases.
  * Improved phonebook synchronization timing to prevent stuck syncing.

* **Tests**
  * Updated and added unit tests for the new failure payloads and sync retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->