### PR TITLE
fix: backfill limited timelines before first sync

### DIFF
--- a/lib/utils/matrix_sdk_extensions/twake_client.dart
+++ b/lib/utils/matrix_sdk_extensions/twake_client.dart
@@ -56,7 +56,7 @@ class TwakeClient extends Client {
     super.roomPreviewLastEvents,
     super.pinUnreadRooms,
     super.pinInvitedRooms,
-    super.requestHistoryOnLimitedTimeline,
+    super.requestHistoryOnLimitedTimeline = true,
     super.supportedLoginTypes,
     super.mxidLocalPartFallback,
     super.formatLocalpart,

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1369,7 +1369,6 @@ class MatrixState extends State<Matrix>
         state != AppLifecycleState.paused;
     client.backgroundSync = foreground;
     client.syncPresence = foreground ? null : PresenceType.unavailable;
-    client.requestHistoryOnLimitedTimeline = true;
     backgroundPush?.clearAllNotifications();
   }
 

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1369,7 +1369,7 @@ class MatrixState extends State<Matrix>
         state != AppLifecycleState.paused;
     client.backgroundSync = foreground;
     client.syncPresence = foreground ? null : PresenceType.unavailable;
-    client.requestHistoryOnLimitedTimeline = !foreground;
+    client.requestHistoryOnLimitedTimeline = true;
     backgroundPush?.clearAllNotifications();
   }
 

--- a/test/utils/matrix_sdk_extensions/twake_client_test.dart
+++ b/test/utils/matrix_sdk_extensions/twake_client_test.dart
@@ -1,0 +1,12 @@
+import 'package:fluffychat/utils/matrix_sdk_extensions/twake_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../fake_client.dart';
+
+void main() {
+  test('enables limited timeline history backfill before initialization', () {
+    final client = TwakeClient('testclient', database: MockDatabase());
+
+    expect(client.requestHistoryOnLimitedTimeline, isTrue);
+  });
+}


### PR DESCRIPTION
## Ticket
Fixes #3209

## Root cause
`requestHistoryOnLimitedTimeline` was disabled before the first sync and on foreground resumes. A limited sync could clear cached events without backfilling history.

## Solution
- Enable limited-timeline backfill by default in `TwakeClient`, before `Client.init()`.
- Remove lifecycle reassignment so cold starts, foreground resumes, and web focus share the same behavior.
- Add a constructor regression test.

## Impact
Limited timelines recover missing history automatically. The SDK may request up to 30 events for each limited room.

## Tests
- `flutter test test/utils/matrix_sdk_extensions/twake_client_test.dart`
- `flutter analyze lib/utils/matrix_sdk_extensions/twake_client.dart lib/widgets/matrix.dart test/utils/matrix_sdk_extensions/twake_client_test.dart`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved limited timeline history request behavior when the app transitions between foreground and background, ensuring the client consistently enables limited history fetching.
- **Tests**
  - Added a Flutter test to verify the client has limited timeline history enabled when instantiated in a test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->