### PR TITLE
Enable web E2E on PR creation

### DIFF
--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -7,18 +7,9 @@ on:
   # on the default branch, so this activates once merged.
   schedule:
     - cron: "0 2 * * *"
-  # PR trigger disabled until all web integration tests are green.
-  # Re-enable the `pull_request` block below once SSH git deps are
-  # migrated to HTTPS and the test suite is stable.
-  #
-  # pull_request:
-  #   branches: [main]
-  #   paths:
-  #     - "lib/**"
-  #     - "integration_test/**"
-  #     - "pubspec.yaml"
-  #     - "pubspec.lock"
-  #     - ".github/workflows/patrol-web-integration-test.yaml"
+  pull_request:
+    types: [opened]
+    branches: [main]
   workflow_dispatch:
     inputs:
       patrol_test_target:

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: "0 2 * * *"
   pull_request:
-    types: [opened]
+    types: [opened, synchronize, reopened]
     branches: [main]
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- Enable the Patrol Web Integration Tests workflow when a pull request is opened against `main`.
- Keep mobile E2E workflows unchanged.

## Temporary base
This PR is temporarily based on #3245 so CI runs with the contact search E2E fix.
After #3245 is merged, retarget this PR back to `main`.

## Why
Web E2E should run when a PR is created, while mobile E2E will move to a nightly trigger later.

## Validation
- Parsed `.github/workflows/patrol-web-integration-test.yaml` as YAML.
- Verified the diff only changes the web E2E workflow trigger.

https://github.com/linagora/twake-on-matrix/actions/runs/29741851303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled an additional pull request trigger for the web integration test workflow, so checks can start automatically when a pull request is opened, synchronized, or reopened (targeting `main`).
  * Kept the existing scheduled and manual run options unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->