### PR TITLE
TW-3222(fix): recover jump to message on kept alive off-screen rows

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -79,6 +79,7 @@ import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:fluffychat/utils/room_draft_storage.dart';
 import 'package:fluffychat/utils/room_status_extension.dart';
+import 'package:fluffychat/utils/scroll_controller_extension.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action.dart';
 import 'package:fluffychat/widgets/context_menu/context_menu_action_item_widget.dart';
@@ -1546,7 +1547,8 @@ class ChatController extends State<Chat>
     final targetEventId = timeline!.events[targetIndex].eventId;
     final itemContext = GlobalObjectKey(targetEventId).currentContext;
 
-    if (itemContext != null) {
+    if (itemContext != null &&
+        scrollController.hasFiniteViewportPosition(itemContext)) {
       await _centerAndHighlightMessage(
         itemContext: itemContext,
         targetIndex: targetIndex,
@@ -1609,7 +1611,8 @@ class ChatController extends State<Chat>
 
       // Check if widget rendered during the wait
       final recheckContext = GlobalObjectKey(targetEventId).currentContext;
-      if (recheckContext != null) {
+      if (recheckContext != null &&
+          scrollController.hasFiniteViewportPosition(recheckContext)) {
         Logs().d(
           'Chat::_scrollToMessageWithEventId(): Widget rendered after $attempts frames',
         );
@@ -1655,6 +1658,9 @@ class ChatController extends State<Chat>
     final scrollAdjustment =
         itemPosition.dy - (viewportHeight / 2) + (itemHeight / 2);
     final targetOffset = scrollController.offset + scrollAdjustment;
+
+    // localToGlobal yields NaN for mounted but off-screen rows.
+    if (!targetOffset.isFinite) return;
 
     // Calculate duration based on distance and adaptive speed
     final distance = scrollAdjustment.abs();
@@ -2111,11 +2117,14 @@ class ChatController extends State<Chat>
     return null;
   }
 
-  /// Checks if a message at [index] is currently rendered.
+  /// Checks if a message at [index] is rendered with a usable position.
   bool _isMessageRendered(int index) {
     if (index < 0 || index >= timeline!.events.length) return false;
-    final key = GlobalObjectKey(timeline!.events[index].eventId);
-    return key.currentContext != null;
+    final itemContext = GlobalObjectKey(
+      timeline!.events[index].eventId,
+    ).currentContext;
+    return itemContext != null &&
+        scrollController.hasFiniteViewportPosition(itemContext);
   }
 
   void forgetRoom() async {

--- a/lib/utils/scroll_controller_extension.dart
+++ b/lib/utils/scroll_controller_extension.dart
@@ -22,4 +22,14 @@ extension ScrollControllerExtension on ScrollController {
       }
     });
   }
+
+  /// Whether [itemContext]'s row has a finite position in this controller's viewport.
+  bool hasFiniteViewportPosition(BuildContext itemContext) {
+    if (!hasClients) return false;
+    final itemBox = itemContext.findRenderObject() as RenderBox?;
+    final scrollBox =
+        position.context.notificationContext?.findRenderObject() as RenderBox?;
+    if (itemBox == null || scrollBox == null) return false;
+    return itemBox.localToGlobal(Offset.zero, ancestor: scrollBox).dy.isFinite;
+  }
 }


### PR DESCRIPTION
## Ticket
Fixes #3222

## Root cause
Tapping a reply quote sometimes don't jump to the source message (with an `Unsupported operation: NaN` in console). This is happening because the jump path treats `GlobalObjectKey(eventId).currentContext != null` as "the row is rendered". But in a lazy sliver a row can be mounted but kept alive off the screen, and in this case `localToGlobal` returns `NaN` which absorb the jump. This is why this issue is not happening every time. (only when the target is kept-alive but off the screen)

## Solution
- Add hasFiniteViewportPosition that verify row is mounted and positioned on the screen.
- Gate the jump paths with it
- Guard centerRenderedMessage against a non-finite offset as a crash net

## Test recommendations
Please help me test by trying to jump to old or recent messages, with or without link.
If you have an issue, please compare with main to know if it's a regression related to this PR or a pre-existing bug.

## Demos
### Before

https://github.com/user-attachments/assets/e1fbf733-f690-4439-b001-04e105b0ee87


### After

https://github.com/user-attachments/assets/c6f1d1b9-da1a-41fc-a6a4-f918f3d14f99

## More info

While looking at the issue I think some part of the pre-existing code can be improved so I created a follow up issue here #3243  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message navigation so jumping to a message no longer tries to center or highlight items that are not yet usable on screen.
  * Made message scrolling more reliable by ignoring non-finite positions, reducing cases where “scroll to message” could fail or behave unexpectedly.
  * Updated message availability checks so the app waits for a message to be truly ready before attempting to focus it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->