### PR TITLE
Fix contact search E2E title query

### DIFF
--- a/integration_test/scenarios/contact_search_scenario.dart
+++ b/integration_test/scenarios/contact_search_scenario.dart
@@ -24,7 +24,6 @@ class ContactSearchScenario extends BaseTestScenario {
   static const _searchByMatrixAddress = String.fromEnvironment(
     'SearchByMatrixAddress',
   );
-  static const _searchByTitle = String.fromEnvironment('SearchByTitle');
   static const _currentAccount = String.fromEnvironment('CurrentAccount');
 
   @override
@@ -50,24 +49,6 @@ class ContactSearchScenario extends BaseTestScenario {
 
     final byAccount = await _expectSingleResult(s, _currentAccount);
     await _verifyOwnerAndEmail(s, byAccount, ownerVisible: true);
-
-    // Diacritic-insensitive: title with 'a' replaced by 'à' should still match.
-    final diacriticQuery = _searchByTitle.replaceAll('a', 'à');
-    s.softAssertEquals(
-      diacriticQuery != _searchByTitle,
-      true,
-      'SearchByTitle must contain "a" to verify diacritic-insensitive search',
-    );
-    final byTitleDiacritic = await _searchAndWait(
-      diacriticQuery,
-      expectResults: true,
-    );
-    s.softAssertEquals(
-      byTitleDiacritic.length == 1,
-      true,
-      'Search by $diacriticQuery expected 1 contact',
-    );
-    await _verifyOwnerAndEmail(s, byTitleDiacritic, ownerVisible: false);
 
     await _verifyContactListScreen(s);
 


### PR DESCRIPTION
## Summary
- Remove the invalid diacritic contact-name assertion from the cross-platform contact search E2E.
- Keep the scenario focused on seeded web fixtures: no-result state, Matrix-address lookup, current-account lookup, and contact screen chrome.

## Root cause
The web fixture only seeds Matrix IDs for this scenario. Exact Matrix-address lookup is fixture-backed, but local title lookup such as charlie or alice is not available in the contacts data used by the contacts tab. The attempted àlice variant was validated and still failed for the same reason.

## Diacritic follow-up
Diacritic-insensitive contact search is handled separately in #3246 with a deterministic contact fixture and a unit test.

## Validation
- flutter analyze integration_test/scenarios/contact_search_scenario.dart
- Patrol Web manual run for integration_test/tests/contact/contact_test.dart passed: https://github.com/linagora/twake-on-matrix/actions/runs/29003986364

## Local E2E note
Local Patrol Web could not start because Docker Desktop daemon was unavailable on this machine: docker info failed with missing /Users/clement/.docker/run/docker.sock.