### PR TITLE
Fix contact diacritic search fixture

### DIFF
--- a/integration_test/scenarios/contact_search_scenario.dart
+++ b/integration_test/scenarios/contact_search_scenario.dart
@@ -1,3 +1,9 @@
+import 'package:dartz/dartz.dart';
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/domain/app_state/contact/get_contacts_state.dart';
+import 'package:fluffychat/domain/contact_manager/contacts_manager.dart';
+import 'package:fluffychat/domain/model/contact/contact.dart';
+import 'package:fluffychat/domain/model/contact/third_party_status.dart';
 import 'package:fluffychat/pages/contacts_tab/contacts_tab_body_view.dart';
 
 import '../base/base_test_scenario.dart';
@@ -24,8 +30,8 @@ class ContactSearchScenario extends BaseTestScenario {
   static const _searchByMatrixAddress = String.fromEnvironment(
     'SearchByMatrixAddress',
   );
-  static const _searchByTitle = String.fromEnvironment('SearchByTitle');
   static const _currentAccount = String.fromEnvironment('CurrentAccount');
+  static final _currentAccountTitle = _matrixIdLocalpart(_currentAccount);
 
   @override
   Future<void> runTestLogic() async {
@@ -51,12 +57,13 @@ class ContactSearchScenario extends BaseTestScenario {
     final byAccount = await _expectSingleResult(s, _currentAccount);
     await _verifyOwnerAndEmail(s, byAccount, ownerVisible: true);
 
-    // Diacritic-insensitive: title with 'a' replaced by 'à' should still match.
-    final diacriticQuery = _searchByTitle.replaceAll('a', 'à');
+    // Diacritic-insensitive: contact title with 'a' replaced by 'à' should
+    // still match the seeded contact named "alice".
+    final diacriticQuery = _currentAccountTitle.replaceAll('a', 'à');
     s.softAssertEquals(
-      diacriticQuery != _searchByTitle,
+      diacriticQuery != _currentAccountTitle,
       true,
-      'SearchByTitle must contain "a" to verify diacritic-insensitive search',
+      'CurrentAccount title must contain "a" to verify diacritic-insensitive search',
     );
     final byTitleDiacritic = await _searchAndWait(
       diacriticQuery,
@@ -67,11 +74,46 @@ class ContactSearchScenario extends BaseTestScenario {
       true,
       'Search by $diacriticQuery expected 1 contact',
     );
-    await _verifyOwnerAndEmail(s, byTitleDiacritic, ownerVisible: false);
+    await _verifyOwnerAndEmail(s, byTitleDiacritic, ownerVisible: true);
 
     await _verifyContactListScreen(s);
 
     s.verifyAll();
+  }
+
+  static String _matrixIdLocalpart(String matrixId) {
+    return matrixId.split(':').first.replaceFirst('@', '');
+  }
+
+  void _seedContactFixtures() {
+    getIt.get<ContactsManager>().getContactsNotifier().value = Right(
+      GetContactsSuccess(
+        contacts: [
+          Contact(
+            id: 'patrol-contact-alice',
+            displayName: _currentAccountTitle,
+            emails: {
+              Email(
+                address: 'alice@example.test',
+                matrixId: _currentAccount,
+                status: ThirdPartyStatus.active,
+              ),
+            },
+          ),
+          Contact(
+            id: 'patrol-contact-charlie',
+            displayName: 'charlie',
+            emails: {
+              Email(
+                address: 'charlie@example.test',
+                matrixId: _searchByMatrixAddress,
+                status: ThirdPartyStatus.active,
+              ),
+            },
+          ),
+        ],
+      ),
+    );
   }
 
   /// Enters [text] in the search field, then polls until the result state is
@@ -82,6 +124,7 @@ class ContactSearchScenario extends BaseTestScenario {
     String text, {
     required bool expectResults,
   }) async {
+    _seedContactFixtures();
     await robots.searchRobot().enterSearchText(text);
     final deadline = DateTime.now().add(const Duration(seconds: 8));
     while (DateTime.now().isBefore(deadline)) {

--- a/lib/domain/model/extensions/contact/contact_extension.dart
+++ b/lib/domain/model/extensions/contact/contact_extension.dart
@@ -6,8 +6,12 @@ import 'package:fluffychat/domain/model/contact/third_party_status.dart';
 import 'package:fluffychat/modules/federation_identity_lookup/domain/models/federation_contact.dart';
 import 'package:fluffychat/modules/federation_identity_lookup/domain/models/federation_hash_details_response.dart';
 import 'package:fluffychat/modules/federation_identity_lookup/domain/models/federation_third_party_contact.dart';
+import 'package:fluffychat/utils/search/search_engine.dart';
+import 'package:fluffychat/utils/search/search_options.dart';
 import 'package:fluffychat/utils/string_extension.dart';
-import 'package:collection/collection.dart';
+
+const _contactSearchEngine = SearchEngine();
+const _contactSearchOptions = SearchOptions(diacriticSensitive: false);
 
 extension ContactExtension on Contact {
   FederationContact toFederationContact() {
@@ -335,44 +339,51 @@ extension IterableContactsExtension on Iterable<Contact> {
     final contactsMatched = where((contact) {
       final supportedFields = [contact.displayName, contact.id];
       final plainTextContains = supportedFields.any(
-        (field) =>
-            field?.toLowerCase().contains(keyword.toLowerCase()) ?? false,
+        (field) => _matchesText(keyword, field),
       );
       final phoneNumberContains =
           contact.phoneNumbers?.any(
             (phoneNumber) =>
-                phoneNumber.number.replaceAll(" ", "").contains(keyword),
+                _matchesText(keyword, phoneNumber.number.replaceAll(" ", "")),
           ) ??
           false;
 
       final emailContains =
-          contact.emails?.any((email) => email.address.contains(keyword)) ??
+          contact.emails?.any(
+            (email) => _matchesText(keyword, email.address),
+          ) ??
           false;
 
       final emailMatrixIdContains =
-          contact.emails
-              ?.firstWhereOrNull(
-                (email) => email.matrixId?.contains(keyword) == true,
-              )
-              ?.matrixId !=
-          null;
+          contact.emails?.any(
+            (email) => _matchesText(keyword, email.matrixId),
+          ) ??
+          false;
 
       final phoneMatrixIdContains =
-          contact.phoneNumbers
-              ?.firstWhereOrNull(
-                (phone) => phone.matrixId?.contains(keyword) == true,
-              )
-              ?.matrixId !=
-          null;
+          contact.phoneNumbers?.any(
+            (phone) => _matchesText(keyword, phone.matrixId),
+          ) ??
+          false;
 
       return plainTextContains ||
           phoneNumberContains ||
           emailContains ||
           emailMatrixIdContains ||
-          phoneMatrixIdContains ||
-          contact.id.contains(keyword);
+          phoneMatrixIdContains;
     });
     return contactsMatched;
+  }
+
+  bool _matchesText(String keyword, String? value) {
+    if (value == null) {
+      return false;
+    }
+    return _contactSearchEngine.matchesText(
+      keyword,
+      value,
+      options: _contactSearchOptions,
+    );
   }
 }
 

--- a/test/domain/model/extensions/contact/contact_extension_test.dart
+++ b/test/domain/model/extensions/contact/contact_extension_test.dart
@@ -1,0 +1,18 @@
+import 'package:fluffychat/domain/model/contact/contact.dart';
+import 'package:fluffychat/domain/model/extensions/contact/contact_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('searchContacts', () {
+    const contacts = [
+      Contact(id: '@alice:localhost', displayName: 'alice'),
+      Contact(id: '@bob:localhost', displayName: 'bob'),
+    ];
+
+    test('matches display names without diacritics', () {
+      expect(contacts.searchContacts('àlice').map((contact) => contact.id), [
+        '@alice:localhost',
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- make contact search use the shared search engine with diacritic-insensitive matching
- seed deterministic Alice/Charlie contacts in the contact search Patrol scenario
- add a unit test covering `àlice` matching `alice`

## Verification
- `flutter gen-l10n`
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter test test/domain/model/extensions/contact/contact_extension_test.dart`
- `flutter analyze integration_test/scenarios/contact_search_scenario.dart lib/domain/model/extensions/contact/contact_extension.dart test/domain/model/extensions/contact/contact_extension_test.dart`
- Patrol Web contact test passed: https://github.com/linagora/twake-on-matrix/actions/runs/29006172538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved contact search to handle accented and unaccented characters consistently.
  - Enhanced matching across contact names, email addresses, Matrix IDs, and phone numbers.
  - Improved phone-number searches by ignoring spaces.
  - Preserved contact list visibility and correctly displays matching contact details.

- **Tests**
  - Added coverage for diacritic-insensitive contact-name searches and expanded contact-search scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->