### PR TITLE
fix: keep well-known discovery across restarts by re-fetching from th…

### DIFF
--- a/lib/utils/matrix_sdk_extensions/client_well_known_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/client_well_known_extension.dart
@@ -1,0 +1,34 @@
+import 'package:matrix/matrix.dart';
+// ignore: implementation_imports
+import 'package:matrix/src/utils/request_and_cache.dart';
+
+extension ClientWellKnownExtension on Client {
+  /// Fetches the discovery information (`/.well-known/matrix/client`) from
+  /// the homeserver host, returning [fallback] when it cannot be fetched.
+  Future<DiscoveryInformation?> getWellKnownOrFallback({
+    DiscoveryInformation? fallback,
+    Duration cacheLifetime = const Duration(minutes: 5),
+  }) async {
+    try {
+      return await requestAndCache<DiscoveryInformation>(
+        () => MatrixApi(
+          homeserver: homeserver,
+          httpClient: httpClient,
+        ).getWellknown(),
+        fromJson: DiscoveryInformation.fromJson,
+        toJson: (wellKnown) => wellKnown.toJson(),
+        cacheKey: 'well_known',
+        cacheLifetime: cacheLifetime,
+        throwOnUpdateFailure: false,
+      );
+    } catch (e) {
+      Logs().w(
+        'ClientWellKnownExtension::getWellKnownOrFallback: could not fetch '
+        'well-known from the homeserver host, keeping previous discovery '
+        'information',
+        e,
+      );
+      return fallback;
+    }
+  }
+}

--- a/lib/utils/matrix_sdk_extensions/client_well_known_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/client_well_known_extension.dart
@@ -3,8 +3,11 @@ import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/request_and_cache.dart';
 
 extension ClientWellKnownExtension on Client {
+  static const _cacheKey = 'well_known';
+
   /// Fetches the discovery information (`/.well-known/matrix/client`) from
   /// the homeserver host, returning [fallback] when it cannot be fetched.
+  /// A returned fallback is persisted so it survives the next restart.
   Future<DiscoveryInformation?> getWellKnownOrFallback({
     DiscoveryInformation? fallback,
     Duration cacheLifetime = const Duration(minutes: 5),
@@ -17,7 +20,7 @@ extension ClientWellKnownExtension on Client {
         ).getWellknown(),
         fromJson: DiscoveryInformation.fromJson,
         toJson: (wellKnown) => wellKnown.toJson(),
-        cacheKey: 'well_known',
+        cacheKey: _cacheKey,
         cacheLifetime: cacheLifetime,
         throwOnUpdateFailure: false,
       );
@@ -28,6 +31,18 @@ extension ClientWellKnownExtension on Client {
         'information',
         e,
       );
+      if (fallback != null && isLogged()) {
+        // Persist the fallback so it survives the next restart
+        try {
+          await database.cacheCustomObject(_cacheKey, fallback.toJson());
+        } catch (e) {
+          Logs().w(
+            'ClientWellKnownExtension::getWellKnownOrFallback: could not '
+            'persist the fallback well-known',
+            e,
+          );
+        }
+      }
       return fallback;
     }
   }

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1196,6 +1196,10 @@ class MatrixState extends State<Matrix>
 
     if (checkedSummary == null && discovery == null) return;
 
+    // The active client may have changed while awaiting: a late result must
+    // not overwrite the newer account's summary.
+    if (clientOrNull != newClient) return;
+
     loginHomeserverSummary = HomeserverSummary(
       discoveryInformation: discovery,
       versions:

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:fluffychat/config/go_routes/app_routes.dart';
-import 'package:fluffychat/utils/matrix_sdk_extensions/hive_collections_database.dart';
 import 'package:fluffychat/config/localizations/localization_service.dart';
 import 'package:fluffychat/data/model/federation_server/federation_configuration.dart';
 import 'package:fluffychat/data/model/federation_server/federation_server_information.dart';
@@ -42,6 +41,7 @@ import 'package:fluffychat/domain/repository/tom_configurations_repository.dart'
 import 'package:fluffychat/pages/chat_list/receive_sharing_intent_mixin.dart';
 import 'package:fluffychat/utils/client_manager.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/client_well_known_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/twake_snackbar.dart';
 import 'package:fluffychat/utils/uia_request_manager.dart';
@@ -1175,22 +1175,20 @@ class MatrixState extends State<Matrix>
       'Matrix::_getHomeserverInformation: client homeserver = ${newClient.homeserver}',
     );
     if (newClient.homeserver == null) return;
-    final db = newClient.database;
-    final previousDiscovery =
-        loginHomeserverSummary?.discoveryInformation ??
-        (db is HiveCollectionsDatabase ? await db.getWellKnown() : null);
+    final previousDiscovery = loginHomeserverSummary?.discoveryInformation;
     final newSummary = await newClient
         .checkHomeserver(newClient.homeserver!, checkWellKnown: false)
         .toHomeserverSummary();
-    if (newSummary.discoveryInformation == null && previousDiscovery != null) {
-      loginHomeserverSummary = HomeserverSummary(
-        discoveryInformation: previousDiscovery,
-        versions: newSummary.versions,
-        loginFlows: newSummary.loginFlows,
-      );
-    } else {
-      loginHomeserverSummary = newSummary;
-    }
+
+    final discovery = await newClient.getWellKnownOrFallback(
+      fallback: previousDiscovery,
+    );
+
+    loginHomeserverSummary = HomeserverSummary(
+      discoveryInformation: discovery,
+      versions: newSummary.versions,
+      loginFlows: newSummary.loginFlows,
+    );
     Logs().d(
       'Matrix::_getHomeserverInformation: appTwakeInformation ${loginHomeserverSummary?.appTwakeInformation}',
     );

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1175,19 +1175,35 @@ class MatrixState extends State<Matrix>
       'Matrix::_getHomeserverInformation: client homeserver = ${newClient.homeserver}',
     );
     if (newClient.homeserver == null) return;
-    final previousDiscovery = loginHomeserverSummary?.discoveryInformation;
-    final newSummary = await newClient
-        .checkHomeserver(newClient.homeserver!, checkWellKnown: false)
-        .toHomeserverSummary();
+    final previousSummary = loginHomeserverSummary;
+
+    HomeserverSummary? checkedSummary;
+    try {
+      checkedSummary = await newClient
+          .checkHomeserver(newClient.homeserver!, checkWellKnown: false)
+          .toHomeserverSummary();
+    } catch (e) {
+      Logs().w(
+        'Matrix::_getHomeserverInformation: homeserver unreachable, using '
+        'cached discovery information',
+        e,
+      );
+    }
 
     final discovery = await newClient.getWellKnownOrFallback(
-      fallback: previousDiscovery,
+      fallback: previousSummary?.discoveryInformation,
     );
+
+    if (checkedSummary == null && discovery == null) return;
 
     loginHomeserverSummary = HomeserverSummary(
       discoveryInformation: discovery,
-      versions: newSummary.versions,
-      loginFlows: newSummary.loginFlows,
+      versions:
+          checkedSummary?.versions ??
+          previousSummary?.versions ??
+          GetVersionsResponse(versions: []),
+      loginFlows:
+          checkedSummary?.loginFlows ?? previousSummary?.loginFlows ?? [],
     );
     Logs().d(
       'Matrix::_getHomeserverInformation: appTwakeInformation ${loginHomeserverSummary?.appTwakeInformation}',

--- a/test/fake_client.dart
+++ b/test/fake_client.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: depend_on_referenced_packages
 
+import 'package:http/http.dart' as http;
 import 'package:matrix/matrix.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vodozemac/vodozemac.dart' as vod;
@@ -69,13 +70,16 @@ class MockDatabase extends Mock implements DatabaseApi {
   }
 }
 
-Future<Client> getClient({DatabaseApi? database}) async {
+Future<Client> getClient({
+  DatabaseApi? database,
+  http.Client? httpClient,
+}) async {
   if (!vod.isInitialized()) {
     await vod.init(libraryPath: './vodozemac/debug/');
   }
   final client = Client(
     'testclient',
-    httpClient: FakeMatrixApi(),
+    httpClient: httpClient ?? FakeMatrixApi(),
     database: database ?? MockDatabase(),
   );
   await client.checkHomeserver(

--- a/test/utils/matrix_sdk_extensions/client_well_known_extension_test.dart
+++ b/test/utils/matrix_sdk_extensions/client_well_known_extension_test.dart
@@ -1,0 +1,154 @@
+import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
+import 'package:fluffychat/domain/model/homeserver_summary.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/client_well_known_extension.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:matrix/matrix.dart';
+
+import '../../fake_client.dart';
+
+/// Records every URI the client requests while delegating to [FakeMatrixApi],
+/// so tests can assert which host a request was sent to.
+class RecordingHttpClient extends http.BaseClient {
+  final List<Uri> requestedUris = [];
+  final http.Client _inner = FakeMatrixApi();
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    requestedUris.add(request.url);
+    return _inner.send(request);
+  }
+}
+
+/// Persists custom cache objects in memory so the SDK cache fallback path can
+/// be exercised.
+class CachingDatabase extends MockDatabase {
+  final Map<String, ({Map<String, Object?> content, DateTime savedAt})> cache =
+      {};
+
+  @override
+  Future<({Map<String, Object?> content, DateTime savedAt})?>
+  getCustomCacheObject(String key) async => cache[key];
+
+  @override
+  Future<void> cacheCustomObject(
+    String key,
+    Map<String, Object?> content, {
+    DateTime? savedAt,
+  }) async {
+    cache[key] = (content: content, savedAt: savedAt ?? DateTime.now());
+  }
+}
+
+const wellKnownPath = '/.well-known/matrix/client';
+
+Map<String, Object?> wellKnownWithLiveKit(dynamic req) => {
+  'm.homeserver': {'base_url': 'https://fakeserver.notexisting'},
+  'org.matrix.msc4143.rtc_foci': [
+    {'type': 'livekit', 'livekit_base_url': 'https://livekit.example.com/'},
+  ],
+};
+
+HomeserverSummary summaryOf(DiscoveryInformation? discovery) =>
+    HomeserverSummary(
+      discoveryInformation: discovery,
+      versions: GetVersionsResponse(versions: ['v1.11']),
+      loginFlows: [],
+    );
+
+void main() {
+  group('ClientWellKnownExtension::getWellKnownOrFallback', () {
+    late Client client;
+
+    tearDown(() async {
+      await client.dispose(closeDatabase: false);
+    });
+
+    test('exposes the livekit url from a freshly fetched well-known', () async {
+      client = await getClient();
+      final fakeApi = FakeMatrixApi.currentApi!;
+      fakeApi.api['GET']![wellKnownPath] = wellKnownWithLiveKit;
+
+      final discovery = await client.getWellKnownOrFallback();
+
+      // The fake user's domain (https://fakeserver) is not a known server of
+      // FakeMatrixApi: this only passes because the fetch targets the
+      // homeserver host, not userID.domain (the 404 source of #3050).
+      expect(
+        summaryOf(discovery).videoCallBaseUrl,
+        'https://livekit.example.com',
+      );
+    });
+
+    test('targets the homeserver host, never the MXID domain', () async {
+      final recorder = RecordingHttpClient();
+      client = await getClient(httpClient: recorder);
+      final fakeApi = FakeMatrixApi.currentApi!;
+      fakeApi.api['GET']![wellKnownPath] = wellKnownWithLiveKit;
+
+      final discovery = await client.getWellKnownOrFallback();
+      expect(discovery, isNotNull);
+
+      final uris = List.of(recorder.requestedUris);
+      final wellKnownUris = uris.where((uri) => uri.path == wellKnownPath);
+      expect(wellKnownUris, isNotEmpty);
+      expect(
+        wellKnownUris.every((uri) => uri.host == client.homeserver!.host),
+        isTrue,
+        reason: 'well-known must be fetched from the homeserver host',
+      );
+      // The logged-in user is @admin:fakeServer: no request may ever target
+      // their MXID domain (the 404 source of #3050).
+      expect(
+        uris.any((uri) => uri.host == 'fakeserver'),
+        isFalse,
+        reason: 'no request may target the MXID domain',
+      );
+    });
+
+    test(
+      'returns the fallback when the well-known cannot be fetched',
+      () async {
+        client = await getClient();
+        final fakeApi = FakeMatrixApi.currentApi!;
+        fakeApi.api['GET']!.remove(wellKnownPath);
+        final previous = DiscoveryInformation(
+          mHomeserver: HomeserverInformation(
+            baseUrl: Uri.parse('https://fakeserver.notexisting'),
+          ),
+        );
+
+        final discovery = await client.getWellKnownOrFallback(
+          fallback: previous,
+        );
+
+        expect(discovery, same(previous));
+      },
+    );
+
+    test('serves the persisted well-known when a later fetch fails', () async {
+      final database = CachingDatabase();
+      client = await getClient(database: database);
+      final fakeApi = FakeMatrixApi.currentApi!;
+      fakeApi.api['GET']![wellKnownPath] = wellKnownWithLiveKit;
+
+      await client.getWellKnownOrFallback();
+      expect(database.cache['well_known'], isNotNull);
+
+      // Simulate a restart after the cache lifetime with the server
+      // unreachable: the SDK must serve the persisted copy.
+      database.cache['well_known'] = (
+        content: database.cache['well_known']!.content,
+        savedAt: DateTime.now().subtract(const Duration(minutes: 10)),
+      );
+      fakeApi.api['GET']!.remove(wellKnownPath);
+
+      final discovery = await client.getWellKnownOrFallback();
+
+      expect(
+        summaryOf(discovery).videoCallBaseUrl,
+        'https://livekit.example.com',
+      );
+    });
+  });
+}

--- a/test/utils/matrix_sdk_extensions/client_well_known_extension_test.dart
+++ b/test/utils/matrix_sdk_extensions/client_well_known_extension_test.dart
@@ -126,6 +126,47 @@ void main() {
       },
     );
 
+    test('serves the persisted well-known without a network attempt when the '
+        'homeserver is unset', () async {
+      final database = CachingDatabase();
+      final recorder = RecordingHttpClient();
+      client = await getClient(database: database, httpClient: recorder);
+      FakeMatrixApi.currentApi!.api['GET']![wellKnownPath] =
+          wellKnownWithLiveKit;
+
+      // Seed the persisted copy with a successful fetch, then age it past
+      // the cache lifetime so freshness alone cannot serve the next call.
+      await client.getWellKnownOrFallback();
+      database.cache['well_known'] = (
+        content: database.cache['well_known']!.content,
+        savedAt: DateTime.now().subtract(const Duration(minutes: 10)),
+      );
+
+      // What checkHomeserver() leaves behind when the server is fully
+      // unreachable at startup.
+      final homeserver = client.homeserver;
+      client.homeserver = null;
+
+      final requestsBefore = recorder.requestedUris
+          .where((uri) => uri.path == wellKnownPath)
+          .length;
+      final discovery = await client.getWellKnownOrFallback();
+      final requestsAfter = recorder.requestedUris
+          .where((uri) => uri.path == wellKnownPath)
+          .length;
+      client.homeserver = homeserver;
+
+      expect(
+        summaryOf(discovery).videoCallBaseUrl,
+        'https://livekit.example.com',
+      );
+      expect(
+        requestsAfter,
+        requestsBefore,
+        reason: 'no network attempt may be made without a homeserver',
+      );
+    });
+
     test('serves the persisted well-known when a later fetch fails', () async {
       final database = CachingDatabase();
       client = await getClient(database: database);

--- a/test/utils/matrix_sdk_extensions/client_well_known_extension_test.dart
+++ b/test/utils/matrix_sdk_extensions/client_well_known_extension_test.dart
@@ -167,6 +167,67 @@ void main() {
       );
     });
 
+    test('persists the fallback so it survives a restart', () async {
+      final database = CachingDatabase();
+      client = await getClient(database: database);
+      FakeMatrixApi.currentApi!.api['GET']!.remove(wellKnownPath);
+
+      final previous = DiscoveryInformation.fromJson(
+        wellKnownWithLiveKit(null),
+      );
+
+      final discovery = await client.getWellKnownOrFallback(fallback: previous);
+
+      expect(discovery, same(previous));
+      expect(database.cache['well_known'], isNotNull);
+
+      // As after a restart: no in-memory fallback left and the endpoint is
+      // still down — the seeded copy must be served.
+      final restored = await client.getWellKnownOrFallback();
+      expect(
+        summaryOf(restored).videoCallBaseUrl,
+        'https://livekit.example.com',
+      );
+    });
+
+    test(
+      'does not overwrite a persisted well-known with the fallback',
+      () async {
+        final database = CachingDatabase();
+        client = await getClient(database: database);
+        final fakeApi = FakeMatrixApi.currentApi!;
+        fakeApi.api['GET']![wellKnownPath] = wellKnownWithLiveKit;
+
+        await client.getWellKnownOrFallback();
+
+        // Age the persisted copy so the next call attempts (and fails) a
+        // fetch instead of being served by freshness.
+        final agedSavedAt = DateTime.now().subtract(
+          const Duration(minutes: 10),
+        );
+        database.cache['well_known'] = (
+          content: database.cache['well_known']!.content,
+          savedAt: agedSavedAt,
+        );
+        fakeApi.api['GET']!.remove(wellKnownPath);
+
+        final other = DiscoveryInformation(
+          mHomeserver: HomeserverInformation(
+            baseUrl: Uri.parse('https://other.example.com'),
+          ),
+        );
+        final discovery = await client.getWellKnownOrFallback(fallback: other);
+
+        // The stale persisted copy wins over the in-memory fallback…
+        expect(
+          summaryOf(discovery).videoCallBaseUrl,
+          'https://livekit.example.com',
+        );
+        // …and remains untouched.
+        expect(database.cache['well_known']!.savedAt, agedSavedAt);
+      },
+    );
+
     test('serves the persisted well-known when a later fetch fails', () async {
       final database = CachingDatabase();
       client = await getClient(database: database);


### PR DESCRIPTION
## Root cause
The well-known is only fetched during login and kept in memory: any restart loses discovery informations, so well-known driven features (livekit call button for example) disappear until logout and login again, and well-known changes are not refreshed.

## Solution
Refetch the well-known on startup from the homeserver host and persist it through the SDK well_known cache served as offline fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved homeserver discovery using cached well-known information.
  * Added fallback handling when discovery services are unavailable.
  * Persisted discovery data can now be reused across app restarts.

* **Bug Fixes**
  * Prevented outdated homeserver checks from overwriting current connection state.
  * Improved recovery when homeserver checks fail by using available cached information.

* **Tests**
  * Added coverage for discovery requests, caching, fallback behavior, persistence, and correct homeserver targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->