### PR TITLE
chore: bump version to v2.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.23.3] - 2026-07-10
+### Fixed
+- #3251: Keep well-known discovery across restarts by re-fetching host
+
 ## [2.23.1] - 2026-07-09
 ### Added
 - #3232: Add Riverpod 3 setup

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: fluffychat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.23.1+2330
+version: 2.23.3+2330
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
## [2.23.3] - 2026-07-10
### Fixed
- #3251: Keep well-known discovery across restarts by re-fetching host

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discovery reliability across app restarts by re-fetching the host when needed.

* **Chores**
  * Updated the app version to 2.23.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->