### PR TITLE
TW-3254: remove duplicate search bar opening when adding a member to group chat

### DIFF
--- a/lib/pages/new_group/contacts_selection.dart
+++ b/lib/pages/new_group/contacts_selection.dart
@@ -46,7 +46,6 @@ abstract class ContactsSelectionController<T extends StatefulWidget>
           client: client,
           matrixLocalizations: MatrixLocals(L10n.of(context)!),
         );
-        openSearchBar();
       }
     });
     super.initState();


### PR DESCRIPTION

## Ticket
**Related issue**

- #3254 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:

https://github.com/user-attachments/assets/fc84506a-7b54-4031-af34-bff2d1f2de53



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact selection initialization by reliably setting up lifecycle monitoring, address book updates, and the initial contact fetch.
  * Removed the automatic opening of the search bar when entering contact selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->