### PR TITLE
TW-3240(fix): keep message composer bar height

### DIFF
--- a/lib/pages/chat/chat_input_row.dart
+++ b/lib/pages/chat/chat_input_row.dart
@@ -26,6 +26,7 @@ import 'package:social_media_recorder/screen/social_media_recorder.dart';
 import 'chat.dart';
 import 'chat_actions.dart';
 import 'input_bar/input_bar.dart';
+import 'input_bar/input_bar_style.dart';
 
 class ChatInputRow extends StatelessWidget {
   final ChatController controller;
@@ -282,7 +283,8 @@ class ChatInputRow extends StatelessWidget {
                               }
                             },
                             encode: AudioEncoderType.AAC,
-                            fullRecordPackageHeight: 50,
+                            fullRecordPackageHeight:
+                                ChatInputRowStyle.chatInputRowHeight,
                             initRecordPackageWidth: 50,
                             cancelTextBackGroundColor: Colors.transparent,
                             cancelText: L10n.of(context)!.cancel,
@@ -489,7 +491,7 @@ class ChatInputRow extends StatelessWidget {
         hintText: L10n.of(context)!.message,
         isDense: true,
         hintMaxLines: 1,
-        hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+        hintStyle: InputBarStyle.getTypeAheadTextStyle(context).copyWith(
           color: controller.responsive.isMobile(context)
               ? LinagoraRefColors.material().tertiary[50]
               : LinagoraRefColors.material().tertiary[30],

--- a/lib/pages/chat/chat_input_row_style.dart
+++ b/lib/pages/chat/chat_input_row_style.dart
@@ -1,14 +1,15 @@
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/spacings/linagora_spacing.dart';
 
 class ChatInputRowStyle {
   static final ResponsiveUtils responsiveUtils = getIt.get<ResponsiveUtils>();
 
   static const double chatInputRowWidth = 52.0;
-  static const double chatInputRowHeight = 40.0;
+  static const double chatInputRowHeight = LinagoraSpacing.base * 5;
   static const EdgeInsets chatInputRowPaddingMobile = EdgeInsets.only(
-    left: 8.0,
+    left: LinagoraSpacing.base,
   );
   static const BorderRadius chatInputRowBorderRadius = BorderRadius.all(
     Radius.circular(25),
@@ -26,8 +27,8 @@ class ChatInputRowStyle {
 
   static EdgeInsetsDirectional contentPadding(BuildContext context) =>
       EdgeInsetsDirectional.only(
-        top: responsiveUtils.isMobile(context) ? 7 : 10,
-        bottom: responsiveUtils.isMobile(context) ? 7 : 10,
+        top: responsiveUtils.isMobile(context) ? 7 : 12,
+        bottom: responsiveUtils.isMobile(context) ? 7 : 12,
       );
 
   static const double inputComposerOpacity = 0.38;

--- a/lib/pages/chat_draft/draft_chat_input_row.dart
+++ b/lib/pages/chat_draft/draft_chat_input_row.dart
@@ -242,7 +242,7 @@ class DraftChatInputRow extends StatelessWidget {
                 sendVoiceMessageAction?.call(file, time, waveFrom);
               },
               encode: AudioEncoderType.AAC,
-              fullRecordPackageHeight: 50,
+              fullRecordPackageHeight: ChatInputRowStyle.chatInputRowHeight,
               initRecordPackageWidth: 50,
               cancelTextBackGroundColor: Colors.transparent,
               cancelText: L10n.of(context)!.cancel,

--- a/lib/pages/chat_draft/draft_chat_view_style.dart
+++ b/lib/pages/chat_draft/draft_chat_view_style.dart
@@ -1,6 +1,7 @@
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/pages/chat/chat_input_row_style.dart';
+import 'package:fluffychat/pages/chat/input_bar/input_bar_style.dart';
 import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
@@ -22,7 +23,7 @@ class DraftChatViewStyle {
         isDense: true,
         hintMaxLines: 1,
         contentPadding: ChatInputRowStyle.contentPadding(context),
-        hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+        hintStyle: InputBarStyle.getTypeAheadTextStyle(context).copyWith(
           color: responsive.isMobile(context)
               ? LinagoraRefColors.material().tertiary[50]
               : LinagoraRefColors.material().tertiary[30],


### PR DESCRIPTION
## Ticket
Fixes #3240

## Root cause
- When empty, the mic overlay forced the bar size to 50px but on first input key the bar drop to 40px
- Hint used `bodyLarge` while typed text uses `bodyMedium3`

## Solution
- Mic overlay height now follows `chatInputRowHeight`
- Hint reuses the typed-text style (`getTypeAheadTextStyle`)

## Test recommendations
- Type the first char, then clear it the bar height must not change. Voice recording should also still looks good.
- Hint matches the typed text size, text stays vertically centered
- Please test both an existing chat and a new draft

## Demo

### Before

https://github.com/user-attachments/assets/ba72c52a-a901-43ff-b90d-9c9cebb0a777


### After

https://github.com/user-attachments/assets/7133b8ba-4ec1-4b75-9651-cf0236f1bfb5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved consistency of chat input field text styling across standard and draft chats.
  - Updated chat input spacing and sizing for more consistent responsive layouts on mobile and larger screens.
  - Aligned audio recording controls with the chat input height for a smoother interface.
  - Refined input hint appearance and responsive color treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->