### PR TITLE
Stabilize chat group reply E2E visibility

### DIFF
--- a/integration_test/scenarios/chat_group_scenario.dart
+++ b/integration_test/scenarios/chat_group_scenario.dart
@@ -49,7 +49,16 @@ Future<(String, String)> _prepareTwoMessages(BaseTestScenario scenario) async {
 }
 
 Future<void> _waitShown(BaseTestScenario scenario, String message) async {
-  final finder = await scenario.robots.chatGroupDetailRobot().getText(message);
+  final chatGroupDetailRobot = scenario.robots.chatGroupDetailRobot();
+  final finder = await chatGroupDetailRobot.getText(message);
+  await scenario.$.waitUntilExists(
+    finder,
+    timeout: const Duration(seconds: 60),
+  );
+  // On web the timeline can build a newly sent message just outside the
+  // hit-testable viewport. Move to the live edge after the event exists so the
+  // visibility assertion cannot stall on an off-screen MessageContent.
+  await chatGroupDetailRobot.scrollToLiveBottom();
   await scenario.$.waitUntilVisible(
     finder,
     timeout: const Duration(seconds: 60),


### PR DESCRIPTION
## Summary

- wait for newly sent chat-group messages to exist before asserting visibility
- scroll the timeline to its live bottom before requiring the message to be hit-testable

```
Total: 5
Successful: 5
Failed: 0
Skipped: 0
Duration: 4m 22s
```

## Root cause

Patrol could find the newly sent reply's `MessageContent` in the widget tree while it remained just outside the hit-testable web viewport. The visibility wait then timed out after 60 seconds.

## Validation

- `fvm flutter analyze --no-pub integration_test/scenarios/chat_group_scenario.dart`
- Patrol Web `integration_test/tests/chat/chat_group_test.dart` against a fresh local Synapse: 5/5 passed
- repeated the full Patrol Web suite against another fresh Synapse: 5/5 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved chat scenario validation by scrolling to the latest messages before checking their visibility.
  * Added a confirmation step to ensure message text is available before performing visibility assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->