### PR TITLE
TW-3220(ui): update bubble fonts

### DIFF
--- a/lib/pages/chat/events/button_content.dart
+++ b/lib/pages/chat/events/button_content.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/pages/chat/events/button_content_style.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 
 class ButtonContent extends StatelessWidget {
   final Function onTap;
@@ -46,9 +47,12 @@ class ButtonContent extends StatelessWidget {
                     title,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
-                    style: Theme.of(context).textTheme.bodyMedium!.copyWith(
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
+                    style: Theme.of(context)
+                        .extension<LinagoraTextThemeExtension>()!
+                        .bodyMedium4
+                        .copyWith(
+                          color: Theme.of(context).colorScheme.onSurface,
+                        ),
                   ),
                 ),
               ],

--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:flutter_matrix_html/flutter_html.dart';
+import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 import 'package:linkfy_text/linkfy_text.dart';
 import 'package:matrix/matrix.dart';
 import 'package:fluffychat/presentation/extensions/send_file_extension.dart';
@@ -69,11 +70,14 @@ class HtmlMessage extends StatelessWidget with LinkifyMixin {
     final effectiveDefaultTextStyle = ambientStyle.merge(defaultTextStyle);
     final effectiveLinkStyle = ambientStyle.merge(
       linkStyle ??
-          themeData.textTheme.bodyMedium?.copyWith(
-            color: themeData.colorScheme.secondary,
-            decoration: TextDecoration.underline,
-            decorationColor: themeData.colorScheme.secondary,
-          ),
+          themeData
+              .extension<LinagoraTextThemeExtension>()!
+              .bodyMedium4
+              .copyWith(
+                color: themeData.colorScheme.secondary,
+                decoration: TextDecoration.underline,
+                decorationColor: themeData.colorScheme.secondary,
+              ),
     );
     return Html(
       data: renderHtml,

--- a/lib/pages/chat/events/message_content_style.dart
+++ b/lib/pages/chat/events/message_content_style.dart
@@ -58,8 +58,6 @@ class MessageContentStyle {
         : bubbleImageWidget;
   }
 
-  static const double letterSpacingMessageContent = -0.15;
-
   static const double videoCenterButtonSize = 56;
 
   static const double iconInsideVideoButtonSize = 48;
@@ -85,7 +83,7 @@ class MessageContentStyle {
   static TextStyle? linkStyleMessageContent(BuildContext context) =>
       Theme.of(context)
           .extension<LinagoraTextThemeExtension>()!
-          .bodyMedium3
+          .bodyMedium4
           .copyWith(color: Theme.of(context).colorScheme.secondary);
 
   static const blurhashSize = 32;

--- a/lib/pages/chat/events/reply_content_style.dart
+++ b/lib/pages/chat/events/reply_content_style.dart
@@ -50,7 +50,9 @@ class ReplyContentStyle {
   }
 
   static TextStyle? replyBodyTextStyle(BuildContext context) {
-    return Theme.of(context).textTheme.bodyMedium?.copyWith(
+    return Theme.of(
+      context,
+    ).extension<LinagoraTextThemeExtension>()!.bodyMedium4.copyWith(
       color: LinagoraRefColors.material().neutral[50],
       overflow: TextOverflow.ellipsis,
     );

--- a/lib/pages/chat/events/text_message_retry_button.dart
+++ b/lib/pages/chat/events/text_message_retry_button.dart
@@ -23,8 +23,6 @@ class TextMessageRetryButton extends StatelessWidget {
         child: Text(
           L10n.of(context)!.tapToRetry,
           style: Theme.of(context).textTheme.labelMedium?.copyWith(
-            fontSize: 12,
-            height: 16 / 12,
             color: LinagoraSysColors.material().primary,
           ),
         ),

--- a/lib/pages/chat/events/video_call_content.dart
+++ b/lib/pages/chat/events/video_call_content.dart
@@ -24,47 +24,39 @@ class VideoCallContent extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Padding(
-            padding: const EdgeInsets.only(left: LinagoraSpacing.base),
-            child: Text(
-              l10n.videoCallStartedTitle,
-              style: theme.textTheme.bodyLarge?.copyWith(
-                color: theme.colorScheme.onSurface,
-              ),
-            ),
+          Text(
+            l10n.videoCallStartedTitle,
+            style: theme
+                .extension<LinagoraTextThemeExtension>()!
+                .bodyMedium4
+                .copyWith(color: theme.colorScheme.onSurface),
           ),
           const SizedBox(height: LinagoraSpacing.base),
-          Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: LinagoraSpacing.base,
-            ),
-            child: OverflowBar(
-              spacing: LinagoraSpacing.base,
-              overflowSpacing: LinagoraSpacing.base,
-              overflowAlignment: OverflowBarAlignment.start,
-              children: [
-                LinagoraButton(
-                  label: l10n.videoCallCopyLink,
-                  icon: Icons.open_in_new,
-                  size: buttonSize,
-                  variant: LinagoraButtonVariant.outlined,
-                  onPressed: () async {
-                    await TwakeClipboard.instance.copyText(callUrl);
-                    if (context.mounted) {
-                      TwakeSnackBar.show(context, l10n.copiedToClipboard);
-                    }
-                  },
-                ),
-                LinagoraButton(
-                  label: l10n.videoCallJoinCall,
-                  icon: Icons.videocam_outlined,
-                  size: buttonSize,
-                  variant: LinagoraButtonVariant.filled,
-                  onPressed: () =>
-                      UrlLauncher(context, url: callUrl).launchUrl(),
-                ),
-              ],
-            ),
+          OverflowBar(
+            spacing: LinagoraSpacing.base,
+            overflowSpacing: LinagoraSpacing.base,
+            overflowAlignment: OverflowBarAlignment.start,
+            children: [
+              LinagoraButton(
+                label: l10n.videoCallCopyLink,
+                icon: Icons.open_in_new,
+                size: buttonSize,
+                variant: LinagoraButtonVariant.outlined,
+                onPressed: () async {
+                  await TwakeClipboard.instance.copyText(callUrl);
+                  if (context.mounted) {
+                    TwakeSnackBar.show(context, l10n.copiedToClipboard);
+                  }
+                },
+              ),
+              LinagoraButton(
+                label: l10n.videoCallJoinCall,
+                icon: Icons.videocam_outlined,
+                size: buttonSize,
+                variant: LinagoraButtonVariant.filled,
+                onPressed: () => UrlLauncher(context, url: callUrl).launchUrl(),
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/pages/chat/input_bar/input_bar_style.dart
+++ b/lib/pages/chat/input_bar/input_bar_style.dart
@@ -15,7 +15,7 @@ class InputBarStyle {
   static TextStyle getTypeAheadTextStyle(BuildContext context) =>
       Theme.of(
         context,
-      ).extension<LinagoraTextThemeExtension>()!.bodyMedium3.copyWith(
+      ).extension<LinagoraTextThemeExtension>()!.bodyMedium4.copyWith(
         color: Theme.of(context).brightness == Brightness.light
             ? Colors.black
             : Colors.white,

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -331,7 +331,7 @@ extension LocalizedBody on Event {
 
     return Theme.of(
       context,
-    ).extension<LinagoraTextThemeExtension>()!.bodyMedium3.copyWith(
+    ).extension<LinagoraTextThemeExtension>()!.bodyMedium4.copyWith(
       color: redacted
           ? LinagoraRefColors.material().tertiary[30]
           : Theme.of(context).colorScheme.onSurface,

--- a/lib/widgets/file_widget/message_file_tile_style.dart
+++ b/lib/widgets/file_widget/message_file_tile_style.dart
@@ -1,4 +1,7 @@
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:linagora_design_flutter/style/linagora_text_theme.dart';
 
 import 'file_tile_widget_style.dart';
 
@@ -18,11 +21,16 @@ class MessageFileTileStyle extends FileTileWidgetStyle {
   EdgeInsets get paddingFileTileAll =>
       const EdgeInsets.only(left: 8.0, right: 16.0, top: 4.0, bottom: 4.0);
 
+  /// Figma "Bubble message / Files": body/medium on mobile, body/medium2
+  /// (semibold) on desktop.
   @override
   TextStyle? textStyle(BuildContext context) {
-    return Theme.of(context).textTheme.titleSmall?.copyWith(
-      color: Theme.of(context).colorScheme.onSurface,
-    );
+    final theme = Theme.of(context);
+    final themeExtension = theme.extension<LinagoraTextThemeExtension>()!;
+    final style = getIt.get<ResponsiveUtils>().isMobile(context)
+        ? theme.textTheme.bodyMedium
+        : themeExtension.bodyMedium2;
+    return style?.copyWith(color: Theme.of(context).colorScheme.onSurface);
   }
 
   @override

--- a/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
+++ b/lib/widgets/twake_components/twake_preview_link/twake_link_preview_item.dart
@@ -270,7 +270,7 @@ class LinkPreviewBuilder extends StatelessWidget {
                     urlPreviewPresentation.title ?? '',
                     style: Theme.of(context)
                         .extension<LinagoraTextThemeExtension>()!
-                        .bodyMedium2
+                        .titleSmall2
                         .copyWith(
                           color: Theme.of(context).colorScheme.onSurfaceVariant,
                         ),
@@ -284,9 +284,12 @@ class LinkPreviewBuilder extends StatelessWidget {
                   child: Text(
                     key: LinkPreviewBuilder.subtitleKey,
                     urlPreviewPresentation.description ?? '',
-                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      color: LinagoraRefColors.material().tertiary[20],
-                    ),
+                    style: Theme.of(context)
+                        .extension<LinagoraTextThemeExtension>()!
+                        .titleSmall2
+                        .copyWith(
+                          color: LinagoraRefColors.material().tertiary[20],
+                        ),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -962,7 +962,7 @@ packages:
     description:
       path: "."
       ref: master
-      resolved-ref: a90cccaf48322f4ebd3b46d84a1ca0a4dd994bda
+      resolved-ref: acb3bbcf8ea9e6663342b67769197849789a0214
       url: "https://github.com/linagora/emoji_mart.git"
     source: git
     version: "1.0.2"
@@ -1858,11 +1858,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "feature/web-link-generator"
-      resolved-ref: "9642eeb246b09fb2fc30b4dd4477feb3640e4ca1"
-      url: "git@github.com:linagora/linagora-design-flutter.git"
+      ref: "v0.2.2"
+      resolved-ref: "993f9300943636307a13834ab27c300a268082c8"
+      url: "https://github.com/linagora/linagora-design-flutter.git"
     source: git
-    version: "0.2.0"
+    version: "0.2.1"
   linkfy_text:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   linagora_design_flutter:
     git:
       url: https://github.com/linagora/linagora-design-flutter.git
-      ref:  v0.2.0
+      ref:  v0.2.2
   flutter_matrix_html:
     git:
       url: https://github.com/linagora/flutter_matrix_html.git
@@ -345,12 +345,6 @@ dependency_overrides:
     git:
       url: https://github.com/linagora/overflow_view.git
       ref: master
-
-  # TODO: Remove when https://github.com/linagora/linagora-design-flutter/pull/67 is merged
-  linagora_design_flutter:
-    git:
-      url: git@github.com:linagora/linagora-design-flutter.git
-      ref: feature/web-link-generator
 
 cider:
   link_template:

--- a/test/pages/chat/events/message/message_content_builder_mixin_test.dart
+++ b/test/pages/chat/events/message/message_content_builder_mixin_test.dart
@@ -306,10 +306,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with filename -> Done",
+                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js -> Done",
               "format": "org.matrix.custom.html",
               "formatted_body":
-                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with filename -&gt; Done</p>",
+                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js -&gt; Done</p>",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',
@@ -400,10 +400,10 @@ Future<void> main() async {
             content: {
               "msgtype": "m.text",
               "body":
-                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js to support download with filename -> Done",
+                  "#2730 Fallback value for Always read receipt settings is false -> Done\n\n#2628 Disable view PDF file in mobile -> Done\n\n#2726 Remove logo in printed email -> Done\n\n#2737 View PDF in js -> Done",
               "format": "org.matrix.custom.html",
               "formatted_body":
-                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js to support download with filename -&gt; Done</p>",
+                  "<p>#2730 Fallback value for Always read receipt settings is false -&gt; Done</p><br/><p>#2628 Disable view PDF file in mobile -&gt; Done</p><br/><p>#2726 Remove logo in printed email -&gt; Done</p><br/><p>#2737 View PDF in js -&gt; Done</p>",
             },
             type: 'm.room.message',
             eventId: '\$143273582443PhrSn:example.org',


### PR DESCRIPTION
## Ticket
Implements #3220
Fixes #3260

## Changes
Aligns message-bubble typography with the Figma design system
## Demo
<img width="3650" height="2186" alt="image" src="https://github.com/user-attachments/assets/8c157ad8-f3fc-4b53-92fa-f69b20fecc04" />
<img width="200" alt="Capture d’écran 2026-07-28 à 10 07 43" src="https://github.com/user-attachments/assets/85a88afb-69ab-4b82-bf03-0eabcd97a873" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chat, message, link preview, file, reply, and input text styling to use the latest design-system typography.
  * Improved responsive typography for file tiles across mobile and larger screens.
  * Refined video call and retry-message presentation by simplifying inherited text styling and layout spacing.

* **Chores**
  * Updated the design-system package to version 0.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->