### PR TITLE
fix: make video call button react to well-known updates

### DIFF
--- a/integration_test/base/web_test_main.dart
+++ b/integration_test/base/web_test_main.dart
@@ -28,6 +28,7 @@ import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/utils/logging/init_matrix_logger.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart' show ProviderScope;
 import 'package:go_router/go_router.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:matrix/matrix.dart';
@@ -96,5 +97,5 @@ Future<void> main() async {
   // calls `widget.clients.add(...)` on a successful login, which would throw
   // on a const list. Held in a `final` so the analyzer doesn't suggest const.
   final clients = <Client>[];
-  runApp(TwakeApp(clients: clients));
+  runApp(ProviderScope(child: TwakeApp(clients: clients)));
 }

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -16,7 +16,6 @@ import 'package:fluffychat/domain/app_state/room/report_content_state.dart';
 import 'package:fluffychat/domain/model/chat/message_report_reason.dart';
 import 'package:fluffychat/domain/model/contact/contact.dart';
 import 'package:fluffychat/domain/model/extensions/contact/contact_extension.dart';
-import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
 import 'package:fluffychat/domain/model/file_info/file_info.dart';
 import 'package:fluffychat/domain/model/room/room_extension.dart';
 import 'package:fluffychat/domain/usecase/reactions/get_recent_reactions_interactor.dart';
@@ -2365,9 +2364,8 @@ class ChatController extends State<Chat>
       room?.canSendDefaultMessages == true &&
       room?.membership == Membership.join;
 
-  bool get canStartVideoCall =>
-      canSendMessages &&
-      Matrix.of(context).loginHomeserverSummary?.videoCallBaseUrl != null;
+  bool canStartVideoCall(String? videoCallBaseUrl) =>
+      canSendMessages && videoCallBaseUrl != null;
 
   void onPhoneButtonTap() async {
     // VoIP required Android SDK 21

--- a/lib/pages/chat/chat_video_call_button.dart
+++ b/lib/pages/chat/chat_video_call_button.dart
@@ -1,0 +1,36 @@
+import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
+import 'package:fluffychat/pages/chat/chat.dart';
+import 'package:fluffychat/providers/login_homeserver_summary_provider.dart';
+import 'package:fluffychat/utils/voip/video_call_helper.dart';
+import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+
+class ChatVideoCallButton extends ConsumerWidget {
+  final ChatController controller;
+
+  const ChatVideoCallButton(this.controller, {super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final videoCallBaseUrl = ref.watch(
+      loginHomeserverSummaryProvider.select(
+        (summary) => summary?.videoCallBaseUrl,
+      ),
+    );
+    if (!controller.canStartVideoCall(videoCallBaseUrl)) {
+      return const SizedBox.shrink();
+    }
+    return TwakeIconButton(
+      icon: Icons.videocam_outlined,
+      tooltip: L10n.of(context)!.startVideoCall,
+      onTap: () => VideoCallHelper.start(
+        room: controller.room,
+        startedTitle: L10n.of(context)!.videoCallStartedTitle,
+        baseUrl: videoCallBaseUrl,
+      ),
+      preferBelow: false,
+    );
+  }
+}

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -1,20 +1,17 @@
-import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
 import 'package:fluffychat/pages/chat/chat.dart';
 import 'package:fluffychat/widgets/twake_components/unread_count_badge.dart';
 import 'package:fluffychat/pages/chat/chat_app_bar_title.dart';
 import 'package:fluffychat/pages/chat/chat_invitation_body.dart';
+import 'package:fluffychat/pages/chat/chat_video_call_button.dart';
 import 'package:fluffychat/pages/chat/chat_view_body.dart';
 import 'package:fluffychat/pages/chat/chat_view_style.dart';
 import 'package:fluffychat/pages/chat/events/message_content_mixin.dart';
-import 'package:fluffychat/providers/login_homeserver_summary_provider.dart';
-import 'package:fluffychat/utils/voip/video_call_helper.dart';
 import 'package:fluffychat/presentation/mixins/audio_mixin.dart';
 import 'package:fluffychat/resource/image_paths.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:linagora_design_flutter/colors/linagora_state_layer.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
@@ -164,32 +161,7 @@ class ChatView extends StatelessWidget with MessageContentMixin {
                             onPressed: controller.toggleSearch,
                             icon: const Icon(Icons.search),
                           ),
-                          Consumer(
-                            builder: (context, ref, __) {
-                              final videoCallBaseUrl = ref.watch(
-                                loginHomeserverSummaryProvider.select(
-                                  (summary) => summary?.videoCallBaseUrl,
-                                ),
-                              );
-                              if (!controller.canStartVideoCall(
-                                videoCallBaseUrl,
-                              )) {
-                                return const SizedBox.shrink();
-                              }
-                              return TwakeIconButton(
-                                icon: Icons.videocam_outlined,
-                                tooltip: L10n.of(context)!.startVideoCall,
-                                onTap: () => VideoCallHelper.start(
-                                  room: controller.room,
-                                  startedTitle: L10n.of(
-                                    context,
-                                  )!.videoCallStartedTitle,
-                                  baseUrl: videoCallBaseUrl,
-                                ),
-                                preferBelow: false,
-                              );
-                            },
-                          ),
+                          ChatVideoCallButton(controller),
                           if (controller.hasActionAppBarMenu)
                             Builder(
                               builder: (context) => TwakeIconButton(

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -6,6 +6,7 @@ import 'package:fluffychat/pages/chat/chat_invitation_body.dart';
 import 'package:fluffychat/pages/chat/chat_view_body.dart';
 import 'package:fluffychat/pages/chat/chat_view_style.dart';
 import 'package:fluffychat/pages/chat/events/message_content_mixin.dart';
+import 'package:fluffychat/providers/login_homeserver_summary_provider.dart';
 import 'package:fluffychat/utils/voip/video_call_helper.dart';
 import 'package:fluffychat/presentation/mixins/audio_mixin.dart';
 import 'package:fluffychat/resource/image_paths.dart';
@@ -13,6 +14,7 @@ import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/twake_components/twake_icon_button.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:linagora_design_flutter/colors/linagora_state_layer.dart';
 import 'package:linagora_design_flutter/colors/linagora_sys_colors.dart';
@@ -162,21 +164,32 @@ class ChatView extends StatelessWidget with MessageContentMixin {
                             onPressed: controller.toggleSearch,
                             icon: const Icon(Icons.search),
                           ),
-                          if (controller.canStartVideoCall)
-                            TwakeIconButton(
-                              icon: Icons.videocam_outlined,
-                              tooltip: L10n.of(context)!.startVideoCall,
-                              onTap: () => VideoCallHelper.start(
-                                room: controller.room,
-                                startedTitle: L10n.of(
-                                  context,
-                                )!.videoCallStartedTitle,
-                                baseUrl: Matrix.of(
-                                  context,
-                                ).loginHomeserverSummary?.videoCallBaseUrl,
-                              ),
-                              preferBelow: false,
-                            ),
+                          Consumer(
+                            builder: (context, ref, __) {
+                              final videoCallBaseUrl = ref.watch(
+                                loginHomeserverSummaryProvider.select(
+                                  (summary) => summary?.videoCallBaseUrl,
+                                ),
+                              );
+                              if (!controller.canStartVideoCall(
+                                videoCallBaseUrl,
+                              )) {
+                                return const SizedBox.shrink();
+                              }
+                              return TwakeIconButton(
+                                icon: Icons.videocam_outlined,
+                                tooltip: L10n.of(context)!.startVideoCall,
+                                onTap: () => VideoCallHelper.start(
+                                  room: controller.room,
+                                  startedTitle: L10n.of(
+                                    context,
+                                  )!.videoCallStartedTitle,
+                                  baseUrl: videoCallBaseUrl,
+                                ),
+                                preferBelow: false,
+                              );
+                            },
+                          ),
                           if (controller.hasActionAppBarMenu)
                             Builder(
                               builder: (context) => TwakeIconButton(

--- a/lib/pages/chat/events/message/message_content_builder.dart
+++ b/lib/pages/chat/events/message/message_content_builder.dart
@@ -2,20 +2,21 @@ import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions
 import 'package:fluffychat/pages/chat/events/message/message_content_builder_mixin.dart';
 import 'package:fluffychat/pages/chat/events/message/message_style.dart';
 import 'package:fluffychat/pages/chat/events/message_time.dart';
+import 'package:fluffychat/providers/login_homeserver_summary_provider.dart';
 import 'package:fluffychat/utils/voip/video_call_helper.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/pages/chat/optional_padding.dart';
 import 'package:fluffychat/pages/chat/optional_selection_container_disabled.dart';
 import 'package:fluffychat/pages/chat/optional_stack.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:fluffychat/pages/chat/events/message/reply_content_widget.dart';
 import 'package:fluffychat/pages/chat/events/message_content.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 import 'message.dart';
 
-class MessageContentBuilder extends StatelessWidget
+class MessageContentBuilder extends ConsumerWidget
     with MessageContentBuilderMixin {
   final Event event;
   final Timeline timeline;
@@ -37,7 +38,7 @@ class MessageContentBuilder extends StatelessWidget
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return LayoutBuilder(
       builder: (context, constraints) {
         // TODO: change to colorSurface when its approved
@@ -64,9 +65,11 @@ class MessageContentBuilder extends StatelessWidget
         final isNeedAddNewLine = sizeMessageBubble?.isNeedAddNewLine ?? false;
         final isTextMessageError =
             event.status.isError && event.messageType == MessageTypes.Text;
-        final videoCallBaseUrl = Matrix.of(
-          context,
-        ).loginHomeserverSummary?.videoCallBaseUrl;
+        final videoCallBaseUrl = ref.watch(
+          loginHomeserverSummaryProvider.select(
+            (summary) => summary?.videoCallBaseUrl,
+          ),
+        );
 
         return OptionalPadding(
           padding: const EdgeInsets.only(bottom: 8),
@@ -95,6 +98,7 @@ class MessageContentBuilder extends StatelessWidget
                   children: [
                     MessageContent(
                       displayEvent,
+                      videoCallBaseUrl: videoCallBaseUrl,
                       textColor: textColor,
                       textWidth: stepWidth,
                       endOfBubbleWidget: Padding(

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -34,9 +34,7 @@ import 'map_bubble.dart';
 import 'message_download_content.dart';
 import 'sticker.dart';
 import 'video_call_content.dart';
-import 'package:fluffychat/domain/model/extensions/homeserver_summary_extensions.dart';
 import 'package:fluffychat/utils/voip/video_call_helper.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 
 class MessageContent extends StatelessWidget
     with HandleDownloadAndPreviewFileMixin {
@@ -48,10 +46,12 @@ class MessageContent extends StatelessWidget
   final bool ownMessage;
   final Timeline timeline;
   final double? textWidth;
+  final String? videoCallBaseUrl;
 
   const MessageContent(
     this.event, {
     super.key,
+    required this.videoCallBaseUrl,
     required this.textColor,
     required this.endOfBubbleWidget,
     this.onTapPreview,
@@ -303,7 +303,7 @@ class MessageContent extends StatelessWidget
           case MessageTypes.Emote:
             final videoCallUrl = VideoCallHelper.extractUrl(
               event,
-              Matrix.of(context).loginHomeserverSummary?.videoCallBaseUrl,
+              videoCallBaseUrl,
             );
             if (videoCallUrl != null) {
               return VideoCallContent(callUrl: videoCallUrl);

--- a/lib/providers/login_homeserver_summary_provider.dart
+++ b/lib/providers/login_homeserver_summary_provider.dart
@@ -1,0 +1,11 @@
+import 'package:fluffychat/domain/model/homeserver_summary.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+part 'login_homeserver_summary_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class LoginHomeserverSummary extends _$LoginHomeserverSummary {
+  @override
+  HomeserverSummary? build() => null;
+
+  void set(HomeserverSummary? summary) => state = summary;
+}

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -39,6 +39,7 @@ import 'package:fluffychat/domain/model/tom_server_information.dart';
 import 'package:fluffychat/domain/repository/multiple_account/multiple_account_repository.dart';
 import 'package:fluffychat/domain/repository/tom_configurations_repository.dart';
 import 'package:fluffychat/pages/chat_list/receive_sharing_intent_mixin.dart';
+import 'package:fluffychat/providers/login_homeserver_summary_provider.dart';
 import 'package:fluffychat/utils/client_manager.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/client_well_known_extension.dart';
@@ -52,6 +53,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_app_lock/flutter_app_lock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart'
+    show ConsumerState, ConsumerStatefulWidget;
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:future_loading_dialog/future_loading_dialog.dart';
@@ -74,7 +77,7 @@ import '../utils/web_push/web_push.dart';
 import '../utils/famedlysdk_store.dart';
 import 'local_notifications_extension.dart';
 
-class Matrix extends StatefulWidget {
+class Matrix extends ConsumerStatefulWidget {
   final Widget? child;
 
   final List<Client> clients;
@@ -98,7 +101,7 @@ class Matrix extends StatefulWidget {
   static MatrixState read(BuildContext context) => context.read<MatrixState>();
 }
 
-class MatrixState extends State<Matrix>
+class MatrixState extends ConsumerState<Matrix>
     with
         WidgetsBindingObserver,
         ReceiveSharingIntentMixin,
@@ -118,7 +121,11 @@ class MatrixState extends State<Matrix>
   int _activeClient = -1;
   String? activeBundle;
   Store store = Store();
-  HomeserverSummary? loginHomeserverSummary;
+  HomeserverSummary? get loginHomeserverSummary =>
+      ref.read(loginHomeserverSummaryProvider);
+
+  set loginHomeserverSummary(HomeserverSummary? summary) =>
+      ref.read(loginHomeserverSummaryProvider.notifier).set(summary);
   String? _authUrl;
   XFile? loginAvatar;
   String? loginUsername;

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -121,6 +121,7 @@ class MatrixState extends ConsumerState<Matrix>
   int _activeClient = -1;
   String? activeBundle;
   Store store = Store();
+  // TODO: [transitional] migrate call sites to loginHomeserverSummaryProvider and remove this getter/setter.
   HomeserverSummary? get loginHomeserverSummary =>
       ref.read(loginHomeserverSummaryProvider);
 

--- a/test/providers/login_homeserver_summary_provider_test.dart
+++ b/test/providers/login_homeserver_summary_provider_test.dart
@@ -5,16 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:matrix/matrix.dart';
 
 void main() {
-  late ProviderContainer container;
-
-  setUp(() {
-    container = ProviderContainer();
-  });
-
-  tearDown(() {
-    container.dispose();
-  });
-
   HomeserverSummary buildSummary() => HomeserverSummary(
     discoveryInformation: DiscoveryInformation(
       mHomeserver: HomeserverInformation(
@@ -26,10 +16,13 @@ void main() {
   );
 
   test('starts with no summary', () {
+    final container = ProviderContainer.test();
+
     expect(container.read(loginHomeserverSummaryProvider), isNull);
   });
 
   test('set publishes the summary to watchers', () {
+    final container = ProviderContainer.test();
     final seen = <HomeserverSummary?>[];
     container.listen(
       loginHomeserverSummaryProvider,
@@ -44,6 +37,7 @@ void main() {
   });
 
   test('summary survives without listeners (keepAlive)', () async {
+    final container = ProviderContainer.test();
     final summary = buildSummary();
     container.read(loginHomeserverSummaryProvider.notifier).set(summary);
 

--- a/test/providers/login_homeserver_summary_provider_test.dart
+++ b/test/providers/login_homeserver_summary_provider_test.dart
@@ -1,0 +1,55 @@
+import 'package:fluffychat/domain/model/homeserver_summary.dart';
+import 'package:fluffychat/providers/login_homeserver_summary_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer();
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  HomeserverSummary buildSummary() => HomeserverSummary(
+    discoveryInformation: DiscoveryInformation(
+      mHomeserver: HomeserverInformation(
+        baseUrl: Uri.parse('https://matrix.example.com'),
+      ),
+    ),
+    versions: GetVersionsResponse(versions: ['v1.11']),
+    loginFlows: [],
+  );
+
+  test('starts with no summary', () {
+    expect(container.read(loginHomeserverSummaryProvider), isNull);
+  });
+
+  test('set publishes the summary to watchers', () {
+    final seen = <HomeserverSummary?>[];
+    container.listen(
+      loginHomeserverSummaryProvider,
+      (_, next) => seen.add(next),
+      fireImmediately: true,
+    );
+    final summary = buildSummary();
+
+    container.read(loginHomeserverSummaryProvider.notifier).set(summary);
+
+    expect(seen, [null, summary]);
+  });
+
+  test('summary survives without listeners (keepAlive)', () async {
+    final summary = buildSummary();
+    container.read(loginHomeserverSummaryProvider.notifier).set(summary);
+
+    // Let any pending autoDispose cleanup run; keepAlive must prevent it.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(loginHomeserverSummaryProvider), same(summary));
+  });
+}


### PR DESCRIPTION
## Ticket
Fixes #3265 (front-end part, not deployment issue)

## Root cause
loginHomeserverSummary is a plain field on "MatrixState" fetched (or served from cache) but nothing rebuilds the chat app bar when fetched, so after a reload the call button only shows up after a rebuild (ex: room switch, new message, ...).

## Solution
Keep the summary in a Riverpod provider and watch it from the app bar, so the button appears as soon as discovery arrives. `MatrixState` keeps a getter/setter so legacy call sites don't change

## Demo

https://github.com/user-attachments/assets/b9b2e67d-1504-4886-8864-a98841708d73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated chat video-call button and centralized the start-video-call action.
  * Video-call UI now appears only when chat messaging is allowed and the active server supports video calls.

* **Bug Fixes**
  * Video-call link handling and availability now consistently follow the active server’s configuration across chat UI and message rendering.

* **Refactor**
  * Moved homeserver discovery and video-call base URL lookup to Riverpod-backed state, reducing reliance on context-based access.

* **Tests**
  * Added Riverpod tests to verify homeserver summary provider initialization, updates, and keep-alive behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->