### PR TITLE
TW-3269: Preload message alignment setting on web to improve UI consistency

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -1515,15 +1515,6 @@ class MatrixState extends State<Matrix>
               AppConfig.experimentalVoip,
             )
             .then((value) => AppConfig.experimentalVoip = value),
-        store
-            .getItemBool(
-              SettingKeys.enableRightAndLeftMessageAlignmentOnWeb,
-              AppConfig.enableRightAndLeftMessageAlignmentOnWeb,
-            )
-            .then(
-              (value) =>
-                  AppConfig.enableRightAndLeftMessageAlignmentOnWeb = value,
-            ),
       ]);
     } catch (e, s) {
       Logs().wtf('MatrixState::initSettings: error', e, s);

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -443,6 +443,7 @@ class MatrixState extends State<Matrix>
   @override
   void initState() {
     super.initState();
+    _preloadMessageAlignmentSetting();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       WidgetsBinding.instance.addObserver(this);
       if (PlatformInfos.isWeb) {
@@ -1435,6 +1436,28 @@ class MatrixState extends State<Matrix>
     client.backgroundSync = foreground;
     client.syncPresence = foreground ? null : PresenceType.unavailable;
     backgroundPush?.clearAllNotifications();
+  }
+
+  void _preloadMessageAlignmentSetting() {
+    store
+        .getItemBool(
+          SettingKeys.enableRightAndLeftMessageAlignmentOnWeb,
+          AppConfig.enableRightAndLeftMessageAlignmentOnWeb,
+        )
+        .then((value) {
+          if (!mounted ||
+              AppConfig.enableRightAndLeftMessageAlignmentOnWeb == value) {
+            return;
+          }
+          // The flag is a plain static that nothing listens to, so a rebuild
+          // has to be requested explicitly for already-mounted descendants.
+          setState(() {
+            AppConfig.enableRightAndLeftMessageAlignmentOnWeb = value;
+          });
+        })
+        .catchError((Object e, StackTrace s) {
+          Logs().w('MatrixState::_preloadMessageAlignmentSetting: error', e, s);
+        });
   }
 
   Future<void> initSettings() async {


### PR DESCRIPTION
## Ticket
**Related issue**

- #3269 

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/aa8cb5d8-2df7-40c3-afb8-1532c9c74da7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior by loading the saved “right-to-left message alignment” preference earlier, before the interface finishes initializing.
  * The message alignment setting on web now updates immediately to match the stored preference when it differs from the current configuration.
  * Preference load or update failures are handled safely and logged, preventing the app from breaking during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->