### PR TITLE
TW-3277: Ensure TextField mounts after tapping search icon in ContactsSelectionView

### DIFF
--- a/integration_test/robots/new_chat_robot.dart
+++ b/integration_test/robots/new_chat_robot.dart
@@ -48,11 +48,14 @@ class NewChatRobot extends CoreRobot {
 
   Future<void> clickOnNewGroupChatIcon() async {
     await getNewGroupChatIcon().tap();
-    // The add-members screen (`ContactsSelectionView`) opens directly in search
-    // mode (`openSearchBar()` in its initState), so the standalone search icon
-    // is gone and the search `TextField` is shown inline. Wait for that field
-    // instead of the removed `Icons.search` affordance.
-    await $.waitUntilVisible($(ContactsSelectionView).$(TextField).first);
+    // The add-members screen (`ContactsSelectionView`) mounts its `TextField`
+    // only after `openSearchBar()` runs, which is wired to the search icon's
+    // `onTap` (see `SearchableAppBar`) — it is never triggered automatically.
+    // Tap the icon first, then wait for the field it reveals.
+    final contactsSelectionView = $(ContactsSelectionView);
+    await $.waitUntilVisible(contactsSelectionView);
+    await contactsSelectionView.$(find.byIcon(Icons.search)).first.tap();
+    await $.waitUntilVisible(contactsSelectionView.$(TextField).first);
   }
 
   List<TwakeListItemRobot> getListOfAccount() {


### PR DESCRIPTION
## Ticket
**Related issue**

- #3277

## Before

```

Update available! 4.3.1 → 4.5.1

Check the compatibility table at: https://patrol.leancode.co/documentation/compatibility-table


Building Flutter web app...
Web server started at: http://localhost:49539
Running Playwright tests against: http://localhost:49539
Installing Node.js dependencies...
Node.js dependencies installed successfully.
Installing Playwright dependencies...
🧪 tests.chat.create_new_group_chat_test create a new group chat
        ⏳   1. [36mwaitUntilVisible[0m widgets with type "ChatList".
[A[K        ✅   1. [36mwaitUntilVisible[0m widgets with type "ChatList".
        ⏳   2. [33mtap[0m widgets with type "TwakeNavigationIcon" (ignoring all but index 1).
[A[K        ✅   2. [33mtap[0m widgets with type "TwakeNavigationIcon" (ignoring all but index 1).
        ⏳   3. [33mtap[0m widgets with type "TwakeFloatingActionButton".
[A[K        ✅   3. [33mtap[0m widgets with type "TwakeFloatingActionButton".
        ⏳   4. [36mwaitUntilVisible[0m widgets with text "New Group Chat".
[A[K        ✅   4. [36mwaitUntilVisible[0m widgets with text "New Group Chat".
        ⏳   5. [33mtap[0m widgets with type "InkWell" that are ancestors of widgets with text "New Group Chat".
[A[K        ✅   5. [33mtap[0m widgets with type "InkWell" that are ancestors of widgets with text "New Group Chat".
        ⏳   6. [36mwaitUntilVisible[0m widgets with type "TextField" descending from widgets with type "ContactsSelectionView".
[A[K        ❌   6. [36mwaitUntilVisible[0m widgets with type "TextField" descending from widgets with type "ContactsSelectionView".
❌ create a new group chat [90m(/tests/chat/create_new_group_chat_test.dart)[0m [90m(4s)[0m
[31m══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════[0m
[31mThe following StateError was thrown running a test:[0m
[31mBad state: No element[0m
[31m[0m
[31mWhen the exception was thrown, this was the stack:[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 274:3        throw_[0m
[31mdart-sdk/lib/core/iterable.dart 663:7                                              get first[0m
[31mpackage:flutter_test/src/finders.dart 1332:27                                      <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 924:37                [_resumeBody][0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 952:19                moveNext[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 1279:20  next[0m
[31mpackage:flutter_test/src/finders.dart 1428:53                                      <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 924:37                [_resumeBody][0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 952:19                moveNext[0m
[31mdart-sdk/lib/core/iterable.dart 560:33                                             get isEmpty[0m
[31mpackage:patrol_finders/src/custom_finders/patrol_tester.dart 572:35                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 623:19                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 648:23                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 542:3                 _asyncStartSync[0m
[31mpackage:patrol_finders/src/custom_finders/patrol_tester.dart 584:11                <fn>[0m
[31mpackage:patrol_finders/src/custom_finders/patrol_tester.dart 168:36                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 623:19                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 648:23                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 542:3                 _asyncStartSync[0m
[31mpackage:patrol_finders/src/custom_finders/patrol_tester.dart 145:13                wrapWithPatrolLog[0m
[31mpackage:patrol_finders/src/custom_finders/patrol_tester.dart 563:13                <fn>[0m
[31mdart-sdk/lib/async/zone.dart 1525:13                                               _rootRun[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 118:77   tear[0m
[31mdart-sdk/lib/async/zone.dart 1422:19                                               run[0m
[31mpackage:flutter_test/src/test_async_utils.dart 74:35                               guard[0m
[31mpackage:patrol_finders/src/custom_finders/patrol_tester.dart 562:27                waitUntilVisible[0m
[31mintegration_test/robots/new_chat_robot.dart 55:13                                  <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 623:19                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 648:23                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 594:19                <fn>[0m
[31mdart-sdk/lib/async/zone.dart 1538:47                                               _rootRunUnary[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 118:77   tear[0m
[31mdart-sdk/lib/async/zone.dart 1429:19                                               runUnary[0m
[31mdart-sdk/lib/async/future_impl.dart 222:18                                         handleValue[0m
[31mdart-sdk/lib/async/future_impl.dart 948:44                                         handleValueCallback[0m
[31mdart-sdk/lib/async/future_impl.dart 977:13                                         _propagateToListeners[0m
[31mdart-sdk/lib/async/future_impl.dart 720:5                                          [_completeWithValue][0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 504:7                 complete[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 571:12                _asyncReturn[0m
[31mpackage:patrol_finders/src/custom_finders/patrol_finder.dart 207:3                 <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 623:19                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 648:23                <fn>[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 594:19                <fn>[0m
[31mdart-sdk/lib/async/zone.dart 1538:47                                               _rootRunUnary[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 118:77   tear[0m
[31mdart-sdk/lib/async/zone.dart 1429:19                                               runUnary[0m
[31mdart-sdk/lib/async/future_impl.dart 222:18                                         handleValue[0m
[31mdart-sdk/lib/async/future_impl.dart 948:44                                         handleValueCallback[0m
[31mdart-sdk/lib/async/future_impl.dart 977:13                                         _propagateToListeners[0m
[31mdart-sdk/lib/async/future_impl.dart 720:5                                          [_completeWithValue][0m
[31mdart-sdk/lib/async/future_impl.dart 804:7                                          <fn>[0m
[31mdart-sdk/lib/async/zone.dart 1525:13                                               _rootRun[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 118:77   tear[0m
[31mdart-sdk/lib/async/zone.dart 1422:19                                               run[0m
[31mdart-sdk/lib/async/zone.dart 1321:7                                                runGuarded[0m
[31mdart-sdk/lib/async/zone.dart 1362:23                                               <fn>[0m
[31mdart-sdk/lib/async/schedule_microtask.dart 40:34                                   _microtaskLoop[0m
[31mdart-sdk/lib/async/schedule_microtask.dart 49:5                                    _startMicrotaskLoop[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/operations.dart 118:77   tear[0m
[31mdart-sdk/lib/_internal/js_dev_runtime/patch/async_patch.dart 188:69                <fn>[0m
[31m[0m
[31mThe test description was:[0m
[31m  create a new group chat[0m
[31m═════════════════════════════════════════════════════════════════[0m
[31m[0m

[1mTest summary:[0m
📝 Total: 1
✅ Successful: 0
❌ Failed: 1
  - create a new group chat [90m(/tests/chat/create_new_group_chat_test.dart)[0m
⏩ Skipped: 0
📊 Report: /Users/huy.nguyenquang/Documents/Linagora/twake-on-matrix/playwright-report
⏱️  Duration: 21s

Some tests failed.
See the logs above to learn what happened. Also consider running with --verbose. If the logs still aren't useful, then it's a bug - please report it.

```

## After 

```

Update available! 4.3.1 → 4.5.1

Check the compatibility table at: https://patrol.leancode.co/documentation/compatibility-table


Building Flutter web app...
Web server started at: http://localhost:53408
Running Playwright tests against: http://localhost:53408
Installing Node.js dependencies...
Node.js dependencies installed successfully.
Installing Playwright dependencies...
🧪 tests.chat.create_new_group_chat_test create a new group chat
        ⏳   1. [36mwaitUntilVisible[0m widgets with type "ChatList".
[A[K        ✅   1. [36mwaitUntilVisible[0m widgets with type "ChatList".
        ⏳   2. [33mtap[0m widgets with type "TwakeNavigationIcon" (ignoring all but index 1).
[A[K        ✅   2. [33mtap[0m widgets with type "TwakeNavigationIcon" (ignoring all but index 1).
        ⏳   3. [33mtap[0m widgets with type "TwakeFloatingActionButton".
[A[K        ✅   3. [33mtap[0m widgets with type "TwakeFloatingActionButton".
        ⏳   4. [36mwaitUntilVisible[0m widgets with text "New Group Chat".
[A[K        ✅   4. [36mwaitUntilVisible[0m widgets with text "New Group Chat".
        ⏳   5. [33mtap[0m widgets with type "InkWell" that are ancestors of widgets with text "New Group Chat".
[A[K        ✅   5. [33mtap[0m widgets with type "InkWell" that are ancestors of widgets with text "New Group Chat".
        ⏳   6. [36mwaitUntilVisible[0m widgets with type "ContactsSelectionView".
[A[K        ✅   6. [36mwaitUntilVisible[0m widgets with type "ContactsSelectionView".
        ⏳   7. [33mtap[0m widgets with icon "IconData(U+0E567)" descending from widgets with type "ContactsSelectionView".
[A[K        ✅   7. [33mtap[0m widgets with icon "IconData(U+0E567)" descending from widgets with type "ContactsSelectionView".
        ⏳   8. [36mwaitUntilVisible[0m widgets with type "TextField" descending from widgets with type "ContactsSelectionView".
[A[K        ✅   8. [36mwaitUntilVisible[0m widgets with type "TextField" descending from widgets with type "ContactsSelectionView".
        ⏳   9. [33mtap[0m widgets with type "TextField".
[A[K        ✅   9. [33mtap[0m widgets with type "TextField".
        ⏳  10. [35menterText[0m "@" widgets with type "TextField".
[A[K        ✅  10. [35menterText[0m "@" widgets with type "TextField".
        ⏳  11. [35menterText[0m "@charlie:localhost" widgets with type "TextField".
[A[K        ✅  11. [35menterText[0m "@charlie:localhost" widgets with type "TextField".
        ⏳  12. [33mtap[0m widgets with type "Checkbox" descending from widgets with type "ContactItem" (ignoring all but index 0).
[A[K        ✅  12. [33mtap[0m widgets with type "Checkbox" descending from widgets with type "ContactItem" (ignoring all but index 0).
        ⏳  13. [33mtap[0m widgets with type "TwakeFloatingActionButton" (ignoring all but last).
[A[K        ✅  13. [33mtap[0m widgets with type "TwakeFloatingActionButton" (ignoring all but last).
        ⏳  14. [36mwaitUntilVisible[0m widgets with type "NewGroupChatInfoView".
[A[K        ✅  14. [36mwaitUntilVisible[0m widgets with type "NewGroupChatInfoView".
        ⏳  15. [35menterText[0m widgets with type "TextField" (ignoring all but last).
[A[K        ✅  15. [35menterText[0m widgets with type "TextField" (ignoring all but last).
        ⏳  16. [33mtap[0m widgets with type "TwakeFloatingActionButton" (ignoring all but last).
[A[K        ✅  16. [33mtap[0m widgets with type "TwakeFloatingActionButton" (ignoring all but last).
        ⏳  17. [36mwaitUntilVisible[0m widgets with type "ChatView".
[A[K        ✅  17. [36mwaitUntilVisible[0m widgets with type "ChatView".
        ⏳  18. [36mwaitUntilVisible[0m widgets with type "ChatEventList".
[A[K        ✅  18. [36mwaitUntilVisible[0m widgets with type "ChatEventList".
[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K[A[K✅ create a new group chat [90m(/tests/chat/create_new_group_chat_test.dart)[0m [90m(18s)[0m

[1mTest summary:[0m
📝 Total: 1
✅ Successful: 1
❌ Failed: 0
⏩ Skipped: 0
📊 Report: /Users/huy.nguyenquang/Documents/Linagora/twake-on-matrix/playwright-report
⏱️  Duration: 30s


```

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS: