### PR TITLE
fix(ci): address PR #3279 review feedback

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -247,8 +247,8 @@ jobs:
     steps:
       - name: Validate FTL bucket name
         run: |
-          if [[ "${{ env.FTL_RESULTS_BUCKET }}" == _* ]]; then
-            echo "ERROR: FTL_RESULTS_BUCKET='${{ env.FTL_RESULTS_BUCKET }}' — GOOGLE_CLOUD_PROJECT_ID secret is missing or empty."
+          if [[ "$FTL_RESULTS_BUCKET" == _* ]]; then
+            echo "ERROR: FTL_RESULTS_BUCKET='$FTL_RESULTS_BUCKET' — GOOGLE_CLOUD_PROJECT_ID secret is missing or empty."
             exit 1
           fi
 
@@ -283,14 +283,14 @@ jobs:
             --timeout 30m \
             --use-orchestrator \
             --environment-variables clearPackageData=true \
-            --results-bucket "${{ env.FTL_RESULTS_BUCKET }}" \
+            --results-bucket "$FTL_RESULTS_BUCKET" \
             --results-dir "$PERF_RUN_ID"
 
       # gcloud storage (not gsutil): gsutil often ignores WIF/ADC and hits 401 Anonymous.
       - name: Download logcat from GCS
         if: always() && env.PERF_RUN_ID != ''
         run: |
-          GCS_PATH="gs://${{ env.FTL_RESULTS_BUCKET }}/$PERF_RUN_ID"
+          GCS_PATH="gs://$FTL_RESULTS_BUCKET/$PERF_RUN_ID"
           mkdir -p ./perf_gcs_results
           gcloud storage cp -r "${GCS_PATH}/*" ./perf_gcs_results/ \
             || { echo "ERROR: gcloud storage failed to download results from $GCS_PATH"; exit 1; }
@@ -331,8 +331,8 @@ jobs:
     steps:
       - name: Validate FTL bucket name
         run: |
-          if [[ "${{ env.FTL_RESULTS_BUCKET }}" == _* ]]; then
-            echo "ERROR: FTL_RESULTS_BUCKET='${{ env.FTL_RESULTS_BUCKET }}' — GOOGLE_CLOUD_PROJECT_ID secret is missing or empty."
+          if [[ "$FTL_RESULTS_BUCKET" == _* ]]; then
+            echo "ERROR: FTL_RESULTS_BUCKET='$FTL_RESULTS_BUCKET' — GOOGLE_CLOUD_PROJECT_ID secret is missing or empty."
             exit 1
           fi
 
@@ -364,14 +364,14 @@ jobs:
             --timeout 30m \
             --use-orchestrator \
             --environment-variables clearPackageData=true \
-            --results-bucket "${{ env.FTL_RESULTS_BUCKET }}" \
+            --results-bucket "$FTL_RESULTS_BUCKET" \
             --results-dir "$PERF_RUN_ID"
 
       # gcloud storage (not gsutil): gsutil often ignores WIF/ADC and hits 401 Anonymous.
       - name: Download logcat from GCS
         if: always() && env.PERF_RUN_ID != ''
         run: |
-          GCS_PATH="gs://${{ env.FTL_RESULTS_BUCKET }}/$PERF_RUN_ID"
+          GCS_PATH="gs://$FTL_RESULTS_BUCKET/$PERF_RUN_ID"
           mkdir -p ./perf_gcs_results
           gcloud storage cp -r "${GCS_PATH}/*" ./perf_gcs_results/ \
             || { echo "ERROR: gcloud storage failed to download results from $GCS_PATH"; exit 1; }

--- a/scripts/provision-perf-rooms.sh
+++ b/scripts/provision-perf-rooms.sh
@@ -6,8 +6,8 @@
 #   ScrollRoom1 — image-heavy room for the 30s scroll scenario
 #   ScrollRoom2 — second image-heavy room
 #
-# Idempotent: existing rooms (matched by name) are reused, only missing
-# messages/images are topped up.
+# Idempotent: existing rooms (matched by name) are reused unchanged; newly
+# created rooms are seeded once.
 #
 # Usage: ./scripts/provision-perf-rooms.sh [env-file]
 #   env-file defaults to integration_test/.env.local.do-not-commit
@@ -33,7 +33,7 @@ PASSWORD="$(get PASSWORD)"
 
 log() { echo "[perf-provision] $*" >&2; }
 
-api() { # api METHOD PATH [DATA] — retries on 429/5xx with backoff
+api() { # api METHOD PATH [DATA] — retries network errors, 429s, and 5xx
   local method="$1" path="$2" data="${3:-}"
   local attempt=1 max=6 wait=5
   while true; do
@@ -48,11 +48,11 @@ api() { # api METHOD PATH [DATA] — retries on 429/5xx with backoff
     fi
     code=$(printf '%s' "$out" | tail -n1)
     out=$(printf '%s' "$out" | sed '$d')
-    if [ "$code" -lt 400 ] 2>/dev/null; then
+    if [ "$code" -ge 200 ] 2>/dev/null && [ "$code" -lt 400 ] 2>/dev/null; then
       printf '%s' "$out"
       return 0
     fi
-    if { [ "$code" = "429" ] || [ "$code" -ge 500 ] 2>/dev/null; } && [ $attempt -lt $max ]; then
+    if { [ "$code" = "000" ] || [ "$code" = "429" ] || [ "$code" -ge 500 ] 2>/dev/null; } && [ $attempt -lt $max ]; then
       log "HTTP $code on $method $path — retry $attempt/$max in ${wait}s"
       sleep "$wait"
       wait=$((wait * 2))
@@ -72,9 +72,10 @@ for attempt in 1 2 3 4 5; do
     -d "$(jq -nc --arg u "$USER_NAME" --arg p "$PASSWORD" \
           '{type:"m.login.password", identifier:{type:"m.id.user", user:$u}, password:$p}')" \
     || true)
-  TOKEN=$(printf '%s' "$RESP" | jq -r '.access_token // empty')
+  TOKEN=$(printf '%s' "$RESP" | jq -r '.access_token // empty' 2>/dev/null || true)
   if [ -n "$TOKEN" ]; then break; fi
-  log "Login attempt $attempt failed ($(printf '%s' "$RESP" | jq -r '.errcode // "?"')) — waiting..."
+  LOGIN_ERROR=$(printf '%s' "$RESP" | jq -r '.errcode // "?"' 2>/dev/null || printf 'invalid_json')
+  log "Login attempt $attempt failed ($LOGIN_ERROR) — waiting..."
   sleep $((attempt * 15))
 done
 [ -n "$TOKEN" ] || { echo "ERROR: login failed"; exit 1; }
@@ -163,15 +164,26 @@ seed_room() { # seed_room ROOM_ID LABEL
   rm -rf "$tmpdir"
 }
 
+NAV_ROOM_EXISTED=$(find_room_by_name "$NAV_ROOM_NAME")
+SCROLL1_ROOM_EXISTED=$(find_room_by_name "$SCROLL_ROOM_1_NAME")
+SCROLL2_ROOM_EXISTED=$(find_room_by_name "$SCROLL_ROOM_2_NAME")
+
 NAV_ID=$(ensure_room "$NAV_ROOM_NAME")
 SCROLL1_ID=$(ensure_room "$SCROLL_ROOM_1_NAME")
 SCROLL2_ID=$(ensure_room "$SCROLL_ROOM_2_NAME")
 
-# Nav room only needs to exist and open quickly — a few messages are enough.
-send_text "$NAV_ID" "nav fixture message" || true
+if [ -z "$NAV_ROOM_EXISTED" ]; then
+  # Nav room only needs to exist and open quickly — a few messages are enough.
+  send_text "$NAV_ID" "nav fixture message" || true
+fi
 
-seed_room "$SCROLL1_ID" "$SCROLL_ROOM_1_NAME"
-seed_room "$SCROLL2_ID" "$SCROLL_ROOM_2_NAME"
+if [ -z "$SCROLL1_ROOM_EXISTED" ]; then
+  seed_room "$SCROLL1_ID" "$SCROLL_ROOM_1_NAME"
+fi
+
+if [ -z "$SCROLL2_ROOM_EXISTED" ]; then
+  seed_room "$SCROLL2_ID" "$SCROLL_ROOM_2_NAME"
+fi
 
 log "Done. Add these to INTEGRATION_TEST_ENV_BASE64:"
 cat <<EOF

--- a/scripts/tests/test_provision_perf_rooms.py
+++ b/scripts/tests/test_provision_perf_rooms.py
@@ -26,69 +26,87 @@ class MatrixState:
         self.sent_messages = 0
 
 
-def handler_for(state):
-    class MatrixHandler(BaseHTTPRequestHandler):
-        def log_message(self, _format, *_args):
+class MatrixHandler(BaseHTTPRequestHandler):
+    state = None
+
+    def log_message(self, _format, *_args):
+        return
+
+    def send_json(self, payload, status=200):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        self.handle_get()
+
+    def do_POST(self):
+        self.handle_post()
+
+    def do_PUT(self):
+        self.handle_put()
+
+    def handle_get(self):
+        if self.path == "/_matrix/client/v3/joined_rooms":
+            self.state.joined_rooms_requests += 1
+            self.send_json({"joined_rooms": list(self.state.room_names)})
             return
 
-        def send_json(self, payload, status=200):
-            body = json.dumps(payload).encode()
-            self.send_response(status)
-            self.send_header("Content-Type", "application/json")
-            self.send_header("Content-Length", str(len(body)))
+        prefix = "/_matrix/client/v3/rooms/"
+        suffix = "/state/m.room.name"
+        if self.path.startswith(prefix) and self.path.endswith(suffix):
+            room_id = unquote(self.path[len(prefix) : -len(suffix)])
+            self.send_json({"name": self.state.room_names[room_id]})
+            return
+
+        self.send_error(404)
+
+    def handle_post(self):
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length)
+
+        if self.path == "/_matrix/client/v3/login":
+            self.handle_login()
+            return
+
+        if self.path == "/_matrix/client/v3/createRoom":
+            self.handle_create_room(body)
+            return
+
+        self.send_error(404)
+
+    def handle_login(self):
+        self.state.login_attempts += 1
+        if self.state.invalid_login_once and self.state.login_attempts == 1:
+            malformed = b"<html>Bad gateway</html>"
+            self.send_response(502)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(malformed)))
             self.end_headers()
-            self.wfile.write(body)
+            self.wfile.write(malformed)
+            return
+        self.send_json({"access_token": "test-token"})
 
-        def do_GET(self):
-            if self.path == "/_matrix/client/v3/joined_rooms":
-                state.joined_rooms_requests += 1
-                self.send_json({"joined_rooms": list(state.room_names)})
-                return
+    def handle_create_room(self, body):
+        room_name = json.loads(body)["name"]
+        room_id = f"!created{len(self.state.created_room_names)}:test"
+        self.state.created_room_names.append(room_name)
+        self.state.room_names[room_id] = room_name
+        self.send_json({"room_id": room_id})
 
-            prefix = "/_matrix/client/v3/rooms/"
-            suffix = "/state/m.room.name"
-            if self.path.startswith(prefix) and self.path.endswith(suffix):
-                room_id = unquote(self.path[len(prefix) : -len(suffix)])
-                self.send_json({"name": state.room_names[room_id]})
-                return
+    def handle_put(self):
+        if "/send/m.room.message/" in self.path:
+            self.state.sent_messages += 1
+            self.send_json({"event_id": f"$event{self.state.sent_messages}"})
+            return
+        self.send_error(404)
 
-            self.send_error(404)
 
-        def do_POST(self):
-            content_length = int(self.headers.get("Content-Length", "0"))
-            body = self.rfile.read(content_length)
-
-            if self.path == "/_matrix/client/v3/login":
-                state.login_attempts += 1
-                if state.invalid_login_once and state.login_attempts == 1:
-                    malformed = b"<html>Bad gateway</html>"
-                    self.send_response(502)
-                    self.send_header("Content-Type", "text/html")
-                    self.send_header("Content-Length", str(len(malformed)))
-                    self.end_headers()
-                    self.wfile.write(malformed)
-                    return
-                self.send_json({"access_token": "test-token"})
-                return
-
-            if self.path == "/_matrix/client/v3/createRoom":
-                room_name = json.loads(body)["name"]
-                room_id = f"!created{len(state.created_room_names)}:test"
-                state.created_room_names.append(room_name)
-                state.room_names[room_id] = room_name
-                self.send_json({"room_id": room_id})
-                return
-
-            self.send_error(404)
-
-        def do_PUT(self):
-            if "/send/m.room.message/" in self.path:
-                state.sent_messages += 1
-                self.send_json({"event_id": f"$event{state.sent_messages}"})
-                return
-            self.send_error(404)
-
-    return MatrixHandler
+def handler_for(state):
+    return type("BoundMatrixHandler", (MatrixHandler,), {"state": state})
 
 
 class ProvisionPerfRoomsTest(unittest.TestCase):

--- a/scripts/tests/test_provision_perf_rooms.py
+++ b/scripts/tests/test_provision_perf_rooms.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "provision-perf-rooms.sh"
+
+
+class MatrixState:
+    def __init__(self, existing_rooms, invalid_login_once=False):
+        self.room_names = dict(existing_rooms)
+        self.invalid_login_once = invalid_login_once
+        self.login_attempts = 0
+        self.joined_rooms_requests = 0
+        self.created_room_names = []
+        self.sent_messages = 0
+
+
+def handler_for(state):
+    class MatrixHandler(BaseHTTPRequestHandler):
+        def log_message(self, _format, *_args):
+            return
+
+        def send_json(self, payload, status=200):
+            body = json.dumps(payload).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path == "/_matrix/client/v3/joined_rooms":
+                state.joined_rooms_requests += 1
+                self.send_json({"joined_rooms": list(state.room_names)})
+                return
+
+            prefix = "/_matrix/client/v3/rooms/"
+            suffix = "/state/m.room.name"
+            if self.path.startswith(prefix) and self.path.endswith(suffix):
+                room_id = unquote(self.path[len(prefix) : -len(suffix)])
+                self.send_json({"name": state.room_names[room_id]})
+                return
+
+            self.send_error(404)
+
+        def do_POST(self):
+            content_length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(content_length)
+
+            if self.path == "/_matrix/client/v3/login":
+                state.login_attempts += 1
+                if state.invalid_login_once and state.login_attempts == 1:
+                    malformed = b"<html>Bad gateway</html>"
+                    self.send_response(502)
+                    self.send_header("Content-Type", "text/html")
+                    self.send_header("Content-Length", str(len(malformed)))
+                    self.end_headers()
+                    self.wfile.write(malformed)
+                    return
+                self.send_json({"access_token": "test-token"})
+                return
+
+            if self.path == "/_matrix/client/v3/createRoom":
+                room_name = json.loads(body)["name"]
+                room_id = f"!created{len(state.created_room_names)}:test"
+                state.created_room_names.append(room_name)
+                state.room_names[room_id] = room_name
+                self.send_json({"room_id": room_id})
+                return
+
+            self.send_error(404)
+
+        def do_PUT(self):
+            if "/send/m.room.message/" in self.path:
+                state.sent_messages += 1
+                self.send_json({"event_id": f"$event{state.sent_messages}"})
+                return
+            self.send_error(404)
+
+    return MatrixHandler
+
+
+class ProvisionPerfRoomsTest(unittest.TestCase):
+    def run_script(self, state, fail_joined_rooms_once=False):
+        server = ThreadingHTTPServer(("127.0.0.1", 0), handler_for(state))
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                temp_path = Path(temp_dir)
+                env_file = temp_path / "integration.env"
+                env_file.write_text(
+                    "\n".join(
+                        [
+                            f"SERVER_URL=http://127.0.0.1:{server.server_port}",
+                            "USERNAME=test-user",
+                            "PASSWORD=test-password",
+                        ]
+                    )
+                    + "\n"
+                )
+
+                fake_bin = temp_path / "bin"
+                fake_bin.mkdir()
+                real_curl = shutil.which("curl")
+                self.assertIsNotNone(real_curl)
+                curl_wrapper = fake_bin / "curl"
+                curl_wrapper.write_text(
+                    "#!/usr/bin/env bash\n"
+                    'if [[ "${FAIL_JOINED_ROOMS_ONCE:-}" == "1" '
+                    '&& "$*" == *"/joined_rooms"* '
+                    '&& ! -e "$CURL_FAILURE_MARKER" ]]; then\n'
+                    '  touch "$CURL_FAILURE_MARKER"\n'
+                    "  printf '\\n000'\n"
+                    "  exit 7\n"
+                    "fi\n"
+                    f"exec {shlex.quote(real_curl)} \"$@\"\n"
+                )
+                curl_wrapper.chmod(0o755)
+
+                sleep_wrapper = fake_bin / "sleep"
+                sleep_wrapper.write_text("#!/usr/bin/env bash\nexit 0\n")
+                sleep_wrapper.chmod(0o755)
+
+                env = os.environ.copy()
+                env.update(
+                    {
+                        "PATH": f"{fake_bin}:{env['PATH']}",
+                        "TEXT_MSG_COUNT": "1",
+                        "IMAGE_COUNT": "0",
+                        "FAIL_JOINED_ROOMS_ONCE": (
+                            "1" if fail_joined_rooms_once else "0"
+                        ),
+                        "CURL_FAILURE_MARKER": str(temp_path / "curl-failed"),
+                    }
+                )
+                return subprocess.run(
+                    ["bash", str(SCRIPT_PATH), str(env_file)],
+                    check=False,
+                    capture_output=True,
+                    env=env,
+                    text=True,
+                    timeout=10,
+                )
+        finally:
+            server.shutdown()
+            server.server_close()
+            server_thread.join()
+
+    def test_existing_rooms_survive_transient_failures_without_reseeding(self):
+        state = MatrixState(
+            {
+                "!nav:test": "PerfNav",
+                "!scroll-a:test": "PerfScrollA",
+                "!scroll-b:test": "PerfScrollB",
+            },
+            invalid_login_once=True,
+        )
+
+        result = self.run_script(state, fail_joined_rooms_once=True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(state.login_attempts, 2)
+        self.assertEqual(state.joined_rooms_requests, 1)
+        self.assertEqual(state.created_room_names, [])
+        self.assertEqual(state.sent_messages, 0)
+        self.assertIn("invalid_json", result.stderr)
+        self.assertIn("HTTP 000", result.stderr)
+
+    def test_new_rooms_are_created_and_seeded_once(self):
+        state = MatrixState({})
+
+        result = self.run_script(state)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertCountEqual(
+            state.created_room_names,
+            ["PerfNav", "PerfScrollA", "PerfScrollB"],
+        )
+        self.assertEqual(state.sent_messages, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Follow up on actionable review feedback left on #3279 after it was merged.

- treat curl network status 000 as retryable and only accept HTTP 2xx/3xx responses
- keep login retries alive when the endpoint returns malformed or non-JSON content
- avoid reseeding pre-existing performance rooms
- use the native FTL_RESULTS_BUCKET shell variable in workflow steps
- add local integration coverage for transient failures, existing rooms, and first-time room creation

## Validation

- python3 scripts/tests/test_provision_perf_rooms.py
- bash -n scripts/provision-perf-rooms.sh
- shellcheck scripts/provision-perf-rooms.sh
- actionlint .github/workflows/integration-tests.yaml
- git diff --check

Related: #3279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved performance test result handling for consistent bucket usage, including validation, result upload settings, and log artifact download.
  - Made performance room provisioning more reliable and idempotent: existing rooms are reused without reseeding.
  - Enhanced transient failure handling with bounded retries and more robust login token/error reporting.

- **Tests**
  - Added integration-style tests covering room reuse under transient failures and correct one-time creation/seeding when rooms are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->