### PR TITLE
feat(ci): track nightly Patrol Web performance

### DIFF
--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -299,10 +299,10 @@ jobs:
             --dart-define=User2MaxtrixAddress="$MemberMatrixID" \
             --dart-define=ForwardReceiver1Name="$ForwardReceiver1Name" \
             --dart-define=ForwardReceiver2Name="$ForwardReceiver2Name" \
-            2>&1 | tee /tmp/patrol-web-perf.log
+            2>&1 | tee patrol-web-perf.log
 
-          if ! grep -qE '^❌ Failed: 0$' /tmp/patrol-web-perf.log \
-            || grep -qE '^📝 Total: 0$' /tmp/patrol-web-perf.log; then
+          if ! grep -qE '^❌ Failed: 0$' patrol-web-perf.log \
+            || grep -qE '^📝 Total: 0$' patrol-web-perf.log; then
             echo "::error::Patrol Web performance scenario failed"
             exit 1
           fi
@@ -311,7 +311,7 @@ jobs:
         run: |
           python3 scripts/perf/compute_median.py \
             --include-values \
-            /tmp/patrol-web-perf.log \
+            patrol-web-perf.log \
             perf_web.json
           python3 - <<'PY'
           import json
@@ -332,7 +332,7 @@ jobs:
         with:
           name: perf-web-${{ github.run_id }}
           path: |
-            /tmp/patrol-web-perf.log
+            patrol-web-perf.log
             perf_web.json
           retention-days: 90
           if-no-files-found: error

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -16,6 +16,16 @@ on:
         description: "Optional path to a single Patrol integration test Dart file. Leave empty to run the whole suite."
         required: false
         default: ""
+      run_web_perf:
+        description: "Run the Web performance benchmark after the functional E2E jobs."
+        type: boolean
+        required: false
+        default: false
+      publish_web_perf_history:
+        description: "Publish the Web point to Pages (main or the temporary feature preview only)."
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   # Lists the Patrol test files to run (the single given target, or every
@@ -200,3 +210,228 @@ jobs:
       - name: Tear down Synapse
         if: always()
         run: docker rm -f synapse || true
+
+  web-perf:
+    name: Web performance (3 repetitions)
+    needs: patrol-web
+    if: >-
+      ${{
+        github.event_name == 'schedule' ||
+        (github.event_name == 'workflow_dispatch' && inputs.run_web_perf)
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      FLUTTER_VERSION: "3.38.9"
+      PATROL_CLI_VERSION: "4.3.1"
+      SYNAPSE_URL: http://127.0.0.1
+      SERVER_NAME: localhost
+      LANG: en_US.UTF-8
+      LANGUAGE: en_US:en
+      LC_ALL: en_US.UTF-8
+      GIT_TERMINAL_PROMPT: "0"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      - name: Start Synapse (Docker)
+        run: ./scripts/integration-server-synapse.sh
+
+      - name: Provision performance fixture
+        env:
+          PERF_MESSAGE_COUNT: "120"
+        run: |
+          ./scripts/integration-test-provision-synapse.sh > .env.patrol-web
+          cut -d= -f1 .env.patrol-web
+
+      - name: Install dependencies
+        run: |
+          flutter pub get
+          dart run build_runner build --delete-conflicting-outputs
+          dart pub global activate patrol_cli ${{ env.PATROL_CLI_VERSION }}
+
+      - name: Run Patrol Web benchmark
+        timeout-minutes: 20
+        run: |
+          set -a
+          # shellcheck disable=SC1091
+          . ./.env.patrol-web
+          set +a
+
+          patrol test \
+            --device chrome \
+            --profile \
+            --web-headless=true \
+            --web-workers 1 \
+            --web-retries 0 \
+            --web-timeout 600000 \
+            --web-viewport '{"width":1440,"height":900}' \
+            --web-locale en-US \
+            --web-timezone Europe/Paris \
+            --web-browser-args '["--enable-precise-memory-info"]' \
+            --verbose \
+            --target integration_test/performance/web_perf_test.dart \
+            --dart-define=PATROL_WEB=true \
+            --dart-define=MATRIX_URL="$MATRIX_URL" \
+            --dart-define=SERVER_URL="$SERVER_URL" \
+            --dart-define=USERNAME="$TEST_USERNAME" \
+            --dart-define=PASSWORD="$TEST_PASSWORD" \
+            --dart-define=Receiver="$Receiver" \
+            --dart-define=ReceiverPass="$ReceiverPass" \
+            --dart-define=CurrentAccount="$CurrentAccount" \
+            --dart-define=MemberMatrixID="$MemberMatrixID" \
+            --dart-define=SearchByMatrixAddress="$SearchByMatrixAddress" \
+            --dart-define=SearchByTitle="$SearchByTitle" \
+            --dart-define=TitleOfGroupTest="$TitleOfGroupTest" \
+            --dart-define=GroupTest="$SearchByTitle" \
+            --dart-define=GroupID="$GroupID" \
+            --dart-define=User2MaxtrixAddress="$MemberMatrixID" \
+            --dart-define=ForwardReceiver1Name="$ForwardReceiver1Name" \
+            --dart-define=ForwardReceiver2Name="$ForwardReceiver2Name" \
+            2>&1 | tee /tmp/patrol-web-perf.log
+
+          if ! grep -qE '^❌ Failed: 0$' /tmp/patrol-web-perf.log \
+            || grep -qE '^📝 Total: 0$' /tmp/patrol-web-perf.log; then
+            echo "::error::Patrol Web performance scenario failed"
+            exit 1
+          fi
+
+      - name: Aggregate and validate three repetitions
+        run: |
+          python3 scripts/perf/compute_median.py \
+            --include-values \
+            /tmp/patrol-web-perf.log \
+            perf_web.json
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          from scripts.perf.update_web_history import validate_checkpoints
+
+          checkpoints = json.loads(Path("perf_web.json").read_text())
+          validate_checkpoints(checkpoints)
+          if len(checkpoints) != 2:
+              raise SystemExit(
+                  f"Expected 2 Web checkpoints, found {len(checkpoints)}"
+              )
+          print("Validated two checkpoints with three repetitions each.")
+          PY
+
+      - name: Upload Web performance results
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-web-${{ github.run_id }}
+          path: |
+            /tmp/patrol-web-perf.log
+            perf_web.json
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Tear down Synapse
+        if: always()
+        run: docker rm -f synapse || true
+
+  publish-web-perf:
+    name: Publish Web performance history
+    needs: web-perf
+    if: >-
+      ${{
+        always() &&
+        needs.web-perf.result == 'success' &&
+        (
+          (github.event_name == 'schedule' && github.ref == 'refs/heads/main') ||
+          (
+            github.event_name == 'workflow_dispatch' &&
+            inputs.publish_web_perf_history &&
+            (
+              github.ref == 'refs/heads/main' ||
+              github.ref == 'refs/heads/feat/patrol-web-performance-pages'
+            )
+          )
+        )
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: gh-pages-writes
+      cancel-in-progress: false
+    env:
+      DESTINATION_DIR: >-
+        ${{
+          github.ref == 'refs/heads/main' &&
+          'performance' ||
+          'performance-previews/feat-patrol-web-performance-pages'
+        }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download Web performance results
+        uses: actions/download-artifact@v4
+        with:
+          name: perf-web-${{ github.run_id }}
+          path: perf-results/
+
+      - name: Checkout existing GitHub Pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: existing-pages
+          persist-credentials: false
+
+      - name: Rebuild dashboard and update Web history
+        run: |
+          mkdir -p performance-site/data/web
+          if [ -d "existing-pages/$DESTINATION_DIR" ]; then
+            cp -R "existing-pages/$DESTINATION_DIR/." performance-site/
+          fi
+          cp -R scripts/perf/dashboard/. performance-site/
+
+          python3 scripts/perf/update_web_history.py \
+            --web perf-results/perf_web.json \
+            --log perf-results/patrol-web-perf.log \
+            --data-directory performance-site/data/web \
+            --date "$(date -u +%F)" \
+            --generated-at "$(date -u +%FT%TZ)" \
+            --repository "$GITHUB_REPOSITORY" \
+            --sha "$GITHUB_SHA" \
+            --run-id "$GITHUB_RUN_ID" \
+            --flutter-version "3.38.9" \
+            --patrol-version "4.3.1" \
+            --runner-image "${ImageOS:-ubuntu}-${ImageVersion:-unknown}"
+
+      - name: Publish dashboard
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: performance-site
+          destination_dir: ${{ env.DESTINATION_DIR }}
+          keep_files: true
+
+      - name: Add dashboard link to summary
+        env:
+          DASHBOARD_URL: >-
+            https://linagora.github.io/twake-on-matrix/${{ env.DESTINATION_DIR }}/
+        run: |
+          {
+            echo "## Patrol Web performance"
+            echo
+            echo "Published the median of 3 Chrome profile repetitions."
+            echo
+            echo "[$DASHBOARD_URL]($DASHBOARD_URL)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/integration_test/base/test_base.dart
+++ b/integration_test/base/test_base.dart
@@ -26,6 +26,10 @@ class TestBase {
     // harness lacks). Such tests are skipped on web instead of failing the
     // suite, and run unchanged on mobile.
     bool mobileOnly = false,
+    // Marks a test that is intentionally web-only. It is not registered on
+    // mobile, which prevents dedicated browser benchmarks from accidentally
+    // entering Android or iOS suites.
+    bool webOnly = false,
   }) {
     // On web a `mobileOnly` test must not be REGISTERED at all (not merely
     // skipped). Patrol web's Playwright runner boots the Flutter app
@@ -37,6 +41,7 @@ class TestBase {
     // `__patrol__getTests()`, so Playwright never boots a page for it.
     // Mobile is unaffected (`kIsWeb` is false), so coverage is preserved.
     if (kIsWeb && mobileOnly) return;
+    if (!kIsWeb && webOnly) return;
 
     const testTimeoutMs = int.fromEnvironment(
       'GLOBAL_TEST_TIMEOUT_MS',

--- a/integration_test/base/web_perf_collector.dart
+++ b/integration_test/base/web_perf_collector.dart
@@ -1,0 +1,2 @@
+export 'web_perf_collector_stub.dart'
+    if (dart.library.js_interop) 'web_perf_collector_web.dart';

--- a/integration_test/base/web_perf_collector_stub.dart
+++ b/integration_test/base/web_perf_collector_stub.dart
@@ -1,0 +1,14 @@
+/// Non-web safeguard for the browser-only performance collector.
+class WebPerfCollector {
+  WebPerfCollector(String scenario);
+
+  void start() => throw UnsupportedError('WebPerfCollector requires a browser');
+
+  void checkpoint(String label, {Map<String, dynamic> extra = const {}}) =>
+      throw UnsupportedError('WebPerfCollector requires a browser');
+
+  void stop() => throw UnsupportedError('WebPerfCollector requires a browser');
+
+  Future<void> flush() =>
+      throw UnsupportedError('WebPerfCollector requires a browser');
+}

--- a/integration_test/base/web_perf_collector_stub.dart
+++ b/integration_test/base/web_perf_collector_stub.dart
@@ -9,6 +9,6 @@ class WebPerfCollector {
 
   void stop() => throw UnsupportedError('WebPerfCollector requires a browser');
 
-  Future<void> flush() =>
+  Future<void> flush([void Function(String)? logger]) =>
       throw UnsupportedError('WebPerfCollector requires a browser');
 }

--- a/integration_test/base/web_perf_collector_web.dart
+++ b/integration_test/base/web_perf_collector_web.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+
+import 'package:web/web.dart' as web;
+
+import 'web_perf_metrics.dart';
+
+bool _environmentEmitted = false;
+
+/// Collects browser frame cadence, long tasks and optional Chrome JS heap.
+class WebPerfCollector {
+  WebPerfCollector(this.scenario)
+    : _runId = DateTime.now().microsecondsSinceEpoch.toString();
+
+  final String scenario;
+  final String _runId;
+  final List<double> _frameTimestampsMs = [];
+  final List<double> _longTaskDurationsMs = [];
+  final List<String> _pending = [];
+
+  JSFunction? _frameCallback;
+  web.PerformanceObserver? _longTaskObserver;
+  int? _frameHandle;
+  int _sequence = 0;
+  bool _active = false;
+
+  /// Starts an isolated browser measurement window.
+  void start() {
+    if (_active) {
+      throw StateError('WebPerfCollector is already active');
+    }
+    _frameTimestampsMs.clear();
+    _longTaskDurationsMs.clear();
+    _active = true;
+    _startLongTaskObserver();
+    _frameCallback = ((double timestamp) {
+      if (!_active) return;
+      _frameTimestampsMs.add(timestamp);
+      _frameHandle = web.window.requestAnimationFrame(_frameCallback!);
+    }).toJS;
+    _frameHandle = web.window.requestAnimationFrame(_frameCallback!);
+  }
+
+  /// Captures the current measurement window as one PERF_METRIC checkpoint.
+  void checkpoint(String label, {Map<String, dynamic> extra = const {}}) {
+    _drainLongTasks();
+    final metrics = <String, dynamic>{
+      ...computeWebPerfMetrics(
+        frameTimestampsMs: List<double>.from(_frameTimestampsMs),
+        longTaskDurationsMs: List<double>.from(_longTaskDurationsMs),
+        jsHeapUsedBytes: _readJsHeapUsedBytes(),
+      ),
+      ...extra,
+    };
+    final values = metrics.entries
+        .map((entry) => '${entry.key}=${entry.value}')
+        .join(' | ');
+    _pending.add(
+      'PERF_METRIC | $scenario | $label'
+      ' | run=$_runId | seq=${_sequence++}'
+      ' | ts=${DateTime.now().millisecondsSinceEpoch}'
+      ' | $values',
+    );
+    _frameTimestampsMs.clear();
+    _longTaskDurationsMs.clear();
+  }
+
+  /// Stops requestAnimationFrame sampling and long-task observation.
+  void stop() {
+    _active = false;
+    final frameHandle = _frameHandle;
+    if (frameHandle != null) {
+      web.window.cancelAnimationFrame(frameHandle);
+    }
+    _frameHandle = null;
+    _drainLongTasks();
+    _longTaskObserver?.disconnect();
+    _longTaskObserver = null;
+  }
+
+  /// Emits environment metadata once and flushes queued metric lines.
+  Future<void> flush() async {
+    if (!_environmentEmitted) {
+      _environmentEmitted = true;
+      // ignore: avoid_print
+      print('PERF_WEB_ENV | ${jsonEncode(_browserEnvironment())}');
+    }
+    for (final line in _pending) {
+      // ignore: avoid_print
+      print(line);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    _pending.clear();
+  }
+
+  void _startLongTaskObserver() {
+    final supportsLongTasks = web.PerformanceObserver.supportedEntryTypes.toDart
+        .any((entryType) => entryType.toDart == 'longtask');
+    if (!supportsLongTasks) return;
+
+    _longTaskObserver = web.PerformanceObserver(
+      ((
+            web.PerformanceObserverEntryList entries,
+            web.PerformanceObserver observer,
+          ) {
+            _appendLongTasks(entries.getEntries());
+          })
+          .toJS,
+    );
+    _longTaskObserver!.observe(
+      web.PerformanceObserverInit(entryTypes: <JSString>['longtask'.toJS].toJS),
+    );
+  }
+
+  void _drainLongTasks() {
+    final observer = _longTaskObserver;
+    if (observer != null) {
+      _appendLongTasks(observer.takeRecords());
+    }
+  }
+
+  void _appendLongTasks(web.PerformanceEntryList entries) {
+    for (final entry in entries.toDart) {
+      if (entry.duration >= 50) {
+        _longTaskDurationsMs.add(entry.duration);
+      }
+    }
+  }
+
+  double? _readJsHeapUsedBytes() {
+    final memory = web.window.performance.getProperty<JSObject?>('memory'.toJS);
+    final usedHeap = memory?.getProperty<JSNumber?>('usedJSHeapSize'.toJS);
+    return usedHeap?.toDartDouble;
+  }
+
+  Map<String, dynamic> _browserEnvironment() => {
+    'user_agent': web.window.navigator.userAgent,
+    'viewport': {
+      'width': web.window.innerWidth,
+      'height': web.window.innerHeight,
+      'device_pixel_ratio': web.window.devicePixelRatio,
+    },
+    'renderer': web.document.querySelector('canvas') == null ? 'dom' : 'canvas',
+  };
+}

--- a/integration_test/base/web_perf_collector_web.dart
+++ b/integration_test/base/web_perf_collector_web.dart
@@ -148,6 +148,15 @@ class WebPerfCollector {
       'height': web.window.innerHeight,
       'device_pixel_ratio': web.window.devicePixelRatio,
     },
-    'renderer': web.document.querySelector('canvas') == null ? 'dom' : 'canvas',
+    'renderer': _usesCanvasRenderer() ? 'canvas' : 'dom',
   };
+
+  bool _usesCanvasRenderer() {
+    if (web.document.querySelector('canvas') != null) return true;
+    return web.document
+            .querySelector('flt-glass-pane')
+            ?.shadowRoot
+            ?.querySelector('canvas') !=
+        null;
+  }
 }

--- a/integration_test/base/web_perf_collector_web.dart
+++ b/integration_test/base/web_perf_collector_web.dart
@@ -80,15 +80,22 @@ class WebPerfCollector {
   }
 
   /// Emits environment metadata once and flushes queued metric lines.
-  Future<void> flush() async {
+  Future<void> flush([void Function(String)? logger]) async {
+    void emit(String line) {
+      if (logger != null) {
+        logger(line);
+      } else {
+        // ignore: avoid_print
+        print(line);
+      }
+    }
+
     if (!_environmentEmitted) {
       _environmentEmitted = true;
-      // ignore: avoid_print
-      print('PERF_WEB_ENV | ${jsonEncode(_browserEnvironment())}');
+      emit('PERF_WEB_ENV | ${jsonEncode(_browserEnvironment())}');
     }
     for (final line in _pending) {
-      // ignore: avoid_print
-      print(line);
+      emit(line);
       await Future<void>.delayed(const Duration(milliseconds: 50));
     }
     _pending.clear();

--- a/integration_test/base/web_perf_metrics.dart
+++ b/integration_test/base/web_perf_metrics.dart
@@ -1,0 +1,76 @@
+const _slowFrameMultiplier = 1.5;
+
+/// Computes browser frame and long-task metrics from a measured interaction.
+///
+/// [frameTimestampsMs] contains consecutive requestAnimationFrame timestamps.
+/// The median interval is used as the local refresh-rate baseline so headless
+/// runners are not incorrectly judged against an assumed 60 Hz display.
+Map<String, dynamic> computeWebPerfMetrics({
+  required List<double> frameTimestampsMs,
+  List<double> longTaskDurationsMs = const [],
+  double? jsHeapUsedBytes,
+}) {
+  final intervals = <double>[];
+  for (var index = 1; index < frameTimestampsMs.length; index++) {
+    final interval = frameTimestampsMs[index] - frameTimestampsMs[index - 1];
+    if (interval > 0) intervals.add(interval);
+  }
+  intervals.sort();
+
+  final expectedInterval = _median(intervals) ?? 0;
+  final slowFrameThreshold = expectedInterval * _slowFrameMultiplier;
+  final slowFrameCount = intervals
+      .where((interval) => interval > slowFrameThreshold)
+      .length;
+  final frameWindow = frameTimestampsMs.length >= 2
+      ? frameTimestampsMs.last - frameTimestampsMs.first
+      : 0.0;
+  final fps = frameWindow > 0 ? intervals.length * 1000 / frameWindow : 0.0;
+  final longTaskTotal = longTaskDurationsMs.fold<double>(
+    0,
+    (total, duration) => total + duration,
+  );
+
+  final metrics = <String, dynamic>{
+    'frame_count': frameTimestampsMs.length,
+    'frame_window_ms': _rounded(frameWindow),
+    'expected_frame_interval_ms': _rounded(expectedInterval),
+    'frame_interval_p50_ms': _rounded(_percentile(intervals, 50)),
+    'frame_interval_p95_ms': _rounded(_percentile(intervals, 95)),
+    'frame_interval_p99_ms': _rounded(_percentile(intervals, 99)),
+    'fps': _rounded(fps),
+    'slow_frame_count': slowFrameCount,
+    'slow_frame_rate': intervals.isEmpty
+        ? 0.0
+        : _rounded(slowFrameCount / intervals.length),
+    'long_task_count': longTaskDurationsMs.length,
+    'long_task_total_ms': _rounded(longTaskTotal),
+    'long_task_max_ms': _rounded(
+      longTaskDurationsMs.isEmpty
+          ? 0
+          : longTaskDurationsMs.reduce(
+              (left, right) => left > right ? left : right,
+            ),
+    ),
+  };
+  if (jsHeapUsedBytes != null) {
+    metrics['js_heap_used_bytes'] = _rounded(jsHeapUsedBytes);
+  }
+  return metrics;
+}
+
+double _percentile(List<double> sorted, int percentile) {
+  if (sorted.isEmpty) return 0;
+  final index = ((percentile / 100) * (sorted.length - 1)).round();
+  return sorted[index];
+}
+
+double? _median(List<double> sorted) {
+  if (sorted.isEmpty) return null;
+  final middle = sorted.length ~/ 2;
+  return sorted.length.isOdd
+      ? sorted[middle]
+      : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+double _rounded(num value) => double.parse(value.toStringAsFixed(3));

--- a/integration_test/performance/web_perf_test.dart
+++ b/integration_test/performance/web_perf_test.dart
@@ -1,0 +1,80 @@
+import 'package:fluffychat/pages/chat/chat_event_list.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:patrol/patrol.dart';
+
+import '../base/base_test_scenario.dart';
+import '../base/test_base.dart';
+import '../base/web_perf_collector.dart';
+import '../robots/chat_group_detail_robot.dart';
+import '../robots/home_robot.dart';
+
+const _roomTitle = String.fromEnvironment(
+  'SearchByTitle',
+  defaultValue: 'TEST_GROUP',
+);
+const _repetitions = 3;
+
+void main() {
+  TestBase().runPatrolTest(
+    description: 'Web performance: navigation and continuous room scroll',
+    webOnly: true,
+    scenarioBuilder: ($, robots) => WebPerfScenario($, robots),
+  );
+}
+
+/// Runs deterministic browser interactions after a short cache warm-up.
+class WebPerfScenario extends BaseTestScenario {
+  WebPerfScenario(super.$, super.robots);
+
+  @override
+  Future<void> runTestLogic() async {
+    await _warmUp($);
+    for (var repetition = 0; repetition < _repetitions; repetition++) {
+      await _measureNavigation($);
+      await _measureRoomScroll($);
+      await ChatGroupDetailRobot($).clickOnBackIcon();
+      await $.pumpAndTrySettle();
+    }
+  }
+}
+
+Future<void> _warmUp(PatrolIntegrationTester $) async {
+  for (var iteration = 0; iteration < 2; iteration++) {
+    final chatList = await HomeRobot($).gotoChatListScreen();
+    await chatList.openChatByTitle(_roomTitle);
+    await ChatGroupDetailRobot($).clickOnBackIcon();
+    await $.pumpAndTrySettle();
+  }
+}
+
+Future<void> _measureNavigation(PatrolIntegrationTester $) async {
+  final chatList = await HomeRobot($).gotoChatListScreen();
+  final collector = WebPerfCollector('web_navigation');
+  final stopwatch = Stopwatch()..start();
+  collector.start();
+
+  await chatList.openChatByTitle(_roomTitle);
+  stopwatch.stop();
+  collector.stop();
+  collector.checkpoint(
+    'room_opened',
+    extra: {'transition_ms': stopwatch.elapsedMicroseconds / 1000},
+  );
+  await collector.flush();
+}
+
+Future<void> _measureRoomScroll(PatrolIntegrationTester $) async {
+  final collector = WebPerfCollector('web_room_scroll');
+  final scrollable = find.byType(ChatEventList);
+  collector.start();
+
+  for (var step = 0; step < 60; step++) {
+    final direction = step < 30 ? 180.0 : -180.0;
+    await $.tester.drag(scrollable, Offset(0, direction));
+    await $.pump(const Duration(milliseconds: 80));
+  }
+
+  collector.stop();
+  collector.checkpoint('scroll_completed');
+  await collector.flush();
+}

--- a/integration_test/performance/web_perf_test.dart
+++ b/integration_test/performance/web_perf_test.dart
@@ -15,8 +15,8 @@ const _roomTitle = String.fromEnvironment(
 );
 const _repetitions = 3;
 const _scrollDuration = Duration(seconds: 6);
-const _scrollFrameInterval = Duration(milliseconds: 16);
-const _scrollDistancePerFrame = 12.0;
+const _scrollInputInterval = Duration(milliseconds: 100);
+const _scrollDistancePerEvent = 60.0;
 
 void main() {
   TestBase().runPatrolTest(
@@ -71,17 +71,17 @@ Future<void> _measureRoomScroll(PatrolIntegrationTester $) async {
   final collector = WebPerfCollector('web_room_scroll');
   final scrollable = find.byType(ChatEventList);
   final scrollSteps =
-      _scrollDuration.inMilliseconds ~/ _scrollFrameInterval.inMilliseconds;
+      _scrollDuration.inMilliseconds ~/ _scrollInputInterval.inMilliseconds;
   final scrollPosition = $.tester.getCenter(scrollable);
   collector.start();
 
   for (var step = 0; step < scrollSteps; step++) {
     final direction = step < scrollSteps ~/ 2 ? 1.0 : -1.0;
-    await Future<void>.delayed(_scrollFrameInterval);
+    await Future<void>.delayed(_scrollInputInterval);
     await $.tester.sendEventToBinding(
       PointerScrollEvent(
         position: scrollPosition,
-        scrollDelta: Offset(0, direction * _scrollDistancePerFrame),
+        scrollDelta: Offset(0, direction * _scrollDistancePerEvent),
       ),
     );
   }

--- a/integration_test/performance/web_perf_test.dart
+++ b/integration_test/performance/web_perf_test.dart
@@ -60,7 +60,7 @@ Future<void> _measureNavigation(PatrolIntegrationTester $) async {
     'room_opened',
     extra: {'transition_ms': stopwatch.elapsedMicroseconds / 1000},
   );
-  await collector.flush();
+  await collector.flush($.log);
 }
 
 Future<void> _measureRoomScroll(PatrolIntegrationTester $) async {
@@ -76,5 +76,5 @@ Future<void> _measureRoomScroll(PatrolIntegrationTester $) async {
 
   collector.stop();
   collector.checkpoint('scroll_completed');
-  await collector.flush();
+  await collector.flush($.log);
 }

--- a/integration_test/performance/web_perf_test.dart
+++ b/integration_test/performance/web_perf_test.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/pages/chat/chat_event_list.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:patrol/patrol.dart';
 
@@ -13,6 +14,9 @@ const _roomTitle = String.fromEnvironment(
   defaultValue: 'TEST_GROUP',
 );
 const _repetitions = 3;
+const _scrollDuration = Duration(seconds: 6);
+const _scrollFrameInterval = Duration(milliseconds: 16);
+const _scrollDistancePerFrame = 12.0;
 
 void main() {
   TestBase().runPatrolTest(
@@ -66,12 +70,20 @@ Future<void> _measureNavigation(PatrolIntegrationTester $) async {
 Future<void> _measureRoomScroll(PatrolIntegrationTester $) async {
   final collector = WebPerfCollector('web_room_scroll');
   final scrollable = find.byType(ChatEventList);
+  final scrollSteps =
+      _scrollDuration.inMilliseconds ~/ _scrollFrameInterval.inMilliseconds;
+  final scrollPosition = $.tester.getCenter(scrollable);
   collector.start();
 
-  for (var step = 0; step < 60; step++) {
-    final direction = step < 30 ? 180.0 : -180.0;
-    await $.tester.drag(scrollable, Offset(0, direction));
-    await $.pump(const Duration(milliseconds: 80));
+  for (var step = 0; step < scrollSteps; step++) {
+    final direction = step < scrollSteps ~/ 2 ? 1.0 : -1.0;
+    await Future<void>.delayed(_scrollFrameInterval);
+    await $.tester.sendEventToBinding(
+      PointerScrollEvent(
+        position: scrollPosition,
+        scrollDelta: Offset(0, direction * _scrollDistancePerFrame),
+      ),
+    );
   }
 
   collector.stop();

--- a/scripts/integration-test-provision-synapse.sh
+++ b/scripts/integration-test-provision-synapse.sh
@@ -23,6 +23,12 @@ USER3="${USER3:-charlie}"
 PASSWORD3="${PASSWORD3:-charliepassword}"
 ROOM_NAME="${ROOM_NAME:-TEST_GROUP}"
 READY_TIMEOUT="${READY_TIMEOUT:-60}"
+PERF_MESSAGE_COUNT="${PERF_MESSAGE_COUNT:-0}"
+
+if ! [[ "$PERF_MESSAGE_COUNT" =~ ^[0-9]+$ ]]; then
+  echo "PERF_MESSAGE_COUNT must be a non-negative integer" >&2
+  exit 1
+fi
 
 log() { echo "[provision] $*" >&2; }
 
@@ -177,6 +183,15 @@ log "Seeding test messages..."
 send_message "$TOKEN1" "$ROOM_ID" "Hello from $USER1"
 send_message "$TOKEN2" "$ROOM_ID" "Reply from $USER2"
 send_message "$TOKEN1" "$ROOM_ID" "Follow-up from $USER1"
+if [ "$PERF_MESSAGE_COUNT" -gt 0 ]; then
+  log "Seeding $PERF_MESSAGE_COUNT additional performance messages..."
+  for ((message_index = 1; message_index <= PERF_MESSAGE_COUNT; message_index++)); do
+    send_message \
+      "$TOKEN1" \
+      "$ROOM_ID" \
+      "Performance fixture message $message_index — deterministic scroll content"
+  done
+fi
 
 # Forward-test receiver rooms — distinct destinations $USER1 can forward to.
 # Non-overlapping names: a textContaining finder on "Receiver Group" would also

--- a/scripts/perf/compute_median.py
+++ b/scripts/perf/compute_median.py
@@ -5,7 +5,7 @@ groups values by (scenario, label, metric_key), and outputs a JSON file
 containing the median value of each metric across all runs.
 
 Usage:
-    python3 compute_median.py logcat1.txt logcat2.txt logcat3.txt output.json
+    python3 compute_median.py [--include-values] logcat1.txt logcat2.txt logcat3.txt output.json
 """
 import json
 import re
@@ -84,6 +84,8 @@ def _aggregate_groups(
 
 def _build_checkpoints(
     groups: dict[tuple, list[float]],
+    *,
+    include_values: bool = False,
 ) -> tuple[list[dict], dict[tuple, dict[str, int]]]:
     """Compute medians and variance indicators for each (scenario, label) checkpoint.
 
@@ -107,6 +109,8 @@ def _build_checkpoints(
         )
         cp['sample_count'] = min(cp['sample_count'], len(values))
         cp[key] = statistics.median(values)
+        if include_values:
+            cp[f'{key}_values'] = values
         if len(values) >= 2:
             cp[f'{key}_stddev'] = round(statistics.stdev(values), 2)
             cp[f'{key}_range'] = round(max(values) - min(values), 2)
@@ -144,9 +148,17 @@ def _emit_warnings(
         )
 
 
-def compute_median(logcat_files: list[str], output_file: str) -> None:
+def compute_median(
+    logcat_files: list[str],
+    output_file: str,
+    *,
+    include_values: bool = False,
+) -> None:
     groups, total_lines = _aggregate_groups(logcat_files)
-    output, cp_key_counts = _build_checkpoints(groups)
+    output, cp_key_counts = _build_checkpoints(
+        groups,
+        include_values=include_values,
+    )
     output.sort(key=lambda x: (x['scenario'], x.get('seq', 0)))
 
     with open(output_file, 'w') as fh:
@@ -161,7 +173,19 @@ def compute_median(logcat_files: list[str], output_file: str) -> None:
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 3:
-        print("Usage: compute_median.py <logcat1> [logcat2 ...] <output.json>")
+    arguments = sys.argv[1:]
+    include_values = False
+    if '--include-values' in arguments:
+        arguments.remove('--include-values')
+        include_values = True
+    if len(arguments) < 2:
+        print(
+            "Usage: compute_median.py [--include-values]"
+            " <logcat1> [logcat2 ...] <output.json>"
+        )
         sys.exit(1)
-    compute_median(sys.argv[1:-1], sys.argv[-1])
+    compute_median(
+        arguments[:-1],
+        arguments[-1],
+        include_values=include_values,
+    )

--- a/scripts/perf/compute_median.py
+++ b/scripts/perf/compute_median.py
@@ -66,48 +66,53 @@ def _entry_metrics(entry: dict) -> Iterator[tuple[str, str, str, float]]:
 
 def _aggregate_groups(
     logcat_files: list[str],
-) -> tuple[dict[tuple, list[float]], int]:
+) -> tuple[dict[tuple, list[float]], dict[tuple, int], int]:
     """Parse all logcat files and collect numeric values grouped by (scenario, label, key).
 
-    Returns (groups, total_parsed_lines).
+    Returns (groups, checkpoint_counts, total_parsed_lines).
+
+    A checkpoint can legitimately omit frame-derived metrics when no frame is
+    rendered during its measurement window. Count PERF_METRIC lines separately
+    so sample_count represents completed runs rather than the least common
+    optional metric.
     """
     groups: dict[tuple, list[float]] = defaultdict(list)
+    checkpoint_counts: dict[tuple, int] = defaultdict(int)
     total_lines = 0
     for f in logcat_files:
         entries = parse_logcat(f)
         total_lines += len(entries)
         for entry in entries:
+            checkpoint_counts[(entry['scenario'], entry['label'])] += 1
             for scenario, label, k, v in _entry_metrics(entry):
                 groups[(scenario, label, k)].append(v)
-    return groups, total_lines
+    return groups, checkpoint_counts, total_lines
 
 
 def _build_checkpoints(
     groups: dict[tuple, list[float]],
+    checkpoint_counts: dict[tuple, int],
     *,
     include_values: bool = False,
-) -> tuple[list[dict], dict[tuple, dict[str, int]]]:
+) -> list[dict]:
     """Compute medians and variance indicators for each (scenario, label) checkpoint.
 
-    Returns (checkpoints_list, cp_key_counts) where cp_key_counts is used to
-    detect partial runs (diverging sample counts across metric keys).
-
-    Invariant: each PERF_METRIC line emits *all* metrics for a checkpoint in one
-    shot, so all metric keys for a given (scenario, label) should share the same
-    len(values) across runs. sample_count takes the min as a safety net for partial
-    runs (logcat truncated or timeout mid-flush).
+    Optional frame metrics may have fewer values than checkpoint occurrences.
+    The checkpoint sample count therefore comes from PERF_METRIC line
+    occurrences, while each aggregate uses the values available for that metric.
     """
     checkpoints: dict[tuple, dict] = {}
-    cp_key_counts: dict[tuple, dict[str, int]] = defaultdict(dict)
 
     for (scenario, label, key), values in groups.items():
         cp_key = (scenario, label)
-        cp_key_counts[cp_key][key] = len(values)
         cp = checkpoints.setdefault(
             cp_key,
-            {'scenario': scenario, 'label': label, 'sample_count': len(values)},
+            {
+                'scenario': scenario,
+                'label': label,
+                'sample_count': checkpoint_counts[cp_key],
+            },
         )
-        cp['sample_count'] = min(cp['sample_count'], len(values))
         cp[key] = statistics.median(values)
         if include_values:
             cp[f'{key}_values'] = values
@@ -115,24 +120,11 @@ def _build_checkpoints(
             cp[f'{key}_stddev'] = round(statistics.stdev(values), 2)
             cp[f'{key}_range'] = round(max(values) - min(values), 2)
 
-    return list(checkpoints.values()), cp_key_counts
+    return list(checkpoints.values())
 
 
-def _emit_warnings(
-    output: list[dict],
-    cp_key_counts: dict[tuple, dict[str, int]],
-) -> None:
-    """Print warnings to stderr for partial runs and low sample counts."""
-    # Warn when metric counts diverge within a checkpoint — signals a partial run.
-    for cp_key, key_counts in cp_key_counts.items():
-        if len(set(key_counts.values())) > 1:
-            scenario, label = cp_key
-            print(
-                f"WARNING: partial run detected — metric sample counts diverge for"
-                f" {scenario}/{label}: { {k: v for k, v in key_counts.items()} }",
-                file=sys.stderr,
-            )
-
+def _emit_warnings(output: list[dict]) -> None:
+    """Print warnings for checkpoints missing from one or more expected runs."""
     # Warn when fewer than 3 samples: median is a single value, not a real median.
     low_sample_cps = [
         f"{cp['scenario']}/{cp['label']}"
@@ -154,9 +146,10 @@ def compute_median(
     *,
     include_values: bool = False,
 ) -> None:
-    groups, total_lines = _aggregate_groups(logcat_files)
-    output, cp_key_counts = _build_checkpoints(
+    groups, checkpoint_counts, total_lines = _aggregate_groups(logcat_files)
+    output = _build_checkpoints(
         groups,
+        checkpoint_counts,
         include_values=include_values,
     )
     output.sort(key=lambda x: (x['scenario'], x.get('seq', 0)))
@@ -164,7 +157,7 @@ def compute_median(
     with open(output_file, 'w') as fh:
         json.dump(output, fh, indent=2)
 
-    _emit_warnings(output, cp_key_counts)
+    _emit_warnings(output)
 
     print(
         f"Parsed {total_lines} PERF_METRIC lines from {len(logcat_files)} run(s)."

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -175,7 +175,7 @@
     "platform-eyebrow", "web-diagnostic", "value-long-task",
     "footer-source", "workflow-link",
     "source-rss", "source-fps", "source-jank", "source-transition",
-    "title-rss", "description-rss", "title-fps",
+    "title-rss", "description-rss", "title-fps", "description-fps",
     "title-jank", "description-jank", "title-transition",
     ...Object.values(ANDROID_METRICS).flatMap(metric => [metric.valueElement, metric.metaElement]),
   ];
@@ -717,6 +717,10 @@
     elements["description-rss"].textContent = web
       ? "Mémoire du moteur JavaScript exposée par Chrome ; elle n’est jamais comparée à la RAM Android."
       : "Une hausse continue après plusieurs cycles peut révéler une fuite mémoire.";
+    elements["title-fps"].textContent = web ? "Fluidité Chrome CI" : "Fluidité mesurée";
+    elements["description-fps"].textContent = web
+      ? "Cadence requestAnimationFrame du Chrome headless CI : utile pour suivre les régressions, pas comme FPS utilisateur."
+      : "Frames rendues par seconde entre le premier et le dernier signal vertical observé.";
     elements["title-jank"].textContent = web ? "Frames lentes" : "Frames saccadées";
     elements["description-jank"].textContent = web
       ? "Part des intervalles requestAnimationFrame supérieurs à 1,5 fois la cadence médiane."

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -715,6 +715,9 @@
     elements["status-meta"].textContent = state.platform === "web"
       ? "Chrome headless · GitHub runner · médiane de 3 répétitions"
       : `Mise à jour ${state.index.updated_at || state.records.at(-1).generated_at}`;
+    elements["inspection-title"].textContent = "Cliquez sur un point du graphique";
+    elements["inspection-values"].innerHTML = `
+      <p>Les valeurs exactes, le commit, le run Actions et la comparaison apparaîtront ici.</p>`;
   }
 
   function clearRenderedData(message) {

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -14,6 +14,8 @@
     isMetricApplicable,
     isProfileRecord,
     maximumMarkerDelta,
+    metricSelection,
+    normalizeHealthIndex,
     platformDataPaths,
     shouldFallbackToWeb,
   } = globalThis.PerfMetrics;
@@ -91,6 +93,8 @@
     js_heap_used_bytes: {
       label: "Mémoire JavaScript",
       source: "web",
+      scenario: "web_room_scroll",
+      checkpoint: "scroll_completed",
       color: "#b8f34b",
       lowerIsBetter: true,
       format: value => `${(value / 1048576).toFixed(1)} Mio`,
@@ -99,12 +103,15 @@
       metaElement: "meta-rss",
     },
     fps: {
-      label: "FPS navigateur",
+      label: "Indice de fluidité CI",
       source: "web",
       color: "#65d9d2",
       lowerIsBetter: false,
       continuousOnly: true,
-      format: value => `${value.toFixed(1)} FPS`,
+      scenario: "web_room_scroll",
+      checkpoint: "scroll_completed",
+      displayAsIndex: true,
+      format: value => `Indice ${value.toFixed(0)}`,
       read: checkpointValue => hasEnoughWebFrames(checkpointValue) &&
         checkpointValue.fps > 0
         ? checkpointValue.fps
@@ -115,6 +122,8 @@
     slow_frame_rate: {
       label: "Frames lentes",
       source: "web",
+      scenario: "web_room_scroll",
+      checkpoint: "scroll_completed",
       color: "#ffb548",
       lowerIsBetter: true,
       format: value => `${(value * 100).toFixed(1)} %`,
@@ -125,8 +134,10 @@
       metaElement: "meta-jank",
     },
     transition_ms: {
-      label: "Temps d’ouverture",
+      label: "transition_ms",
       source: "web",
+      scenario: "web_navigation",
+      checkpoint: "room_opened",
       color: "#78a9ff",
       lowerIsBetter: true,
       format: value => `${value.toFixed(0)} ms`,
@@ -168,6 +179,7 @@
 
   const elementIds = [
     "platform-select", "range-select", "scenario-select", "checkpoint-select",
+    "filter-scenario", "filter-checkpoint",
     "latest-date", "latest-sha", "history-depth",
     "status-light", "status-label", "status-meta",
     "overall-status", "overall-detail", "verdict",
@@ -175,7 +187,8 @@
     "platform-eyebrow", "web-diagnostic", "value-long-task",
     "footer-source", "workflow-link",
     "source-rss", "source-fps", "source-jank", "source-transition",
-    "title-rss", "description-rss", "title-fps", "description-fps",
+    "title-rss", "description-rss", "metric-icon-fps",
+    "title-fps", "description-fps",
     "title-jank", "description-jank", "title-transition",
     ...Object.values(ANDROID_METRICS).flatMap(metric => [metric.valueElement, metric.metaElement]),
   ];
@@ -235,8 +248,11 @@
 
   function metricValue(record, metric, scenario, label) {
     if (!isProfileRecord(record)) return null;
-    if (!isMetricApplicable(metric, scenario)) return null;
-    return metric.read(checkpoint(record, metric.source, scenario, label));
+    const selection = metricSelection(metric, scenario, label);
+    if (!isMetricApplicable(metric, selection.scenario)) return null;
+    return metric.read(
+      checkpoint(record, metric.source, selection.scenario, selection.label)
+    );
   }
 
   function scenarioLabel(value) {
@@ -311,16 +327,6 @@
     return visibleDays.map(day => byDay.get(day) || { severity: "missing", delta: null });
   }
 
-  function normalize(values, lowerIsBetter) {
-    const reference = values.find(value => value != null && value > 0);
-    if (reference == null) return values.map(() => null);
-    return values.map(value => {
-      if (value == null || value <= 0) return null;
-      const index = lowerIsBetter ? (reference / value) * 100 : (value / reference) * 100;
-      return Number(index.toFixed(1));
-    });
-  }
-
   function pointColors(markers, normalColor) {
     return markers.map(marker => {
       if (marker.severity === "critical") return "#ff6257";
@@ -337,7 +343,7 @@
     const markers = markersFor(metric, selection.scenario, selection.label, days);
     return {
       label: metric.label,
-      data: normalize(realValues, metric.lowerIsBetter),
+      data: normalizeHealthIndex(realValues, metric.lowerIsBetter),
       realValues,
       markers,
       metricKey,
@@ -380,6 +386,9 @@
               const metric = METRICS[context.dataset.metricKey];
               const realValue = context.dataset.realValues[context.dataIndex];
               if (realValue == null) return `${metric.label} : non mesuré`;
+              if (metric.displayAsIndex) {
+                return `${metric.label} : ${metric.format(context.raw)}`;
+              }
               return `${metric.label} : ${metric.format(realValue)} · indice ${context.raw}`;
             },
             afterBody: contexts => {
@@ -459,7 +468,8 @@
 
   function metricValueCopy(metricKey, metric, value, context) {
     if (value != null) return metric.format(value);
-    if (!isMetricApplicable(metric, context.scenario)) {
+    const selection = metricSelection(metric, context.scenario, context.label);
+    if (!isMetricApplicable(metric, selection.scenario)) {
       return "Non applicable";
     }
     if (
@@ -475,14 +485,34 @@
     return "Non mesuré";
   }
 
-  function metricMetaCopy(metricKey, context, marker) {
+  function displayedMetricValue(record, metric, scenario, label) {
+    const rawValue = metricValue(record, metric, scenario, label);
+    if (!metric.displayAsIndex) return rawValue;
+    const values = state.records.map(
+      item => metricValue(item, metric, scenario, label)
+    );
+    const indexes = normalizeHealthIndex(values, metric.lowerIsBetter);
+    return indexes[state.records.indexOf(record)] ?? null;
+  }
+
+  function metricMetaCopy(metricKey, metric, context, marker) {
     if (state.platform === "web") {
       if (["fps", "slow_frame_rate"].includes(metricKey)) {
+        const selection = metricSelection(
+          metric,
+          context.scenario,
+          context.label
+        );
         return webFrameSampleCopy(
-          context.selectedCheckpoint,
+          checkpoint(
+            context.latest,
+            metric.source,
+            selection.scenario,
+            selection.label
+          ),
           metricKey,
           marker,
-          context.scenario
+          selection.scenario
         );
       }
       return severityCopy(marker);
@@ -514,7 +544,7 @@
     }
 
     const marker = context.latestMarkers[metricKey];
-    const value = metricValue(
+    const value = displayedMetricValue(
       context.latest,
       metric,
       context.scenario,
@@ -527,7 +557,7 @@
       ["fps", "jank_rate", "slow_frame_rate"].includes(metricKey);
     valueElement.classList.toggle("insufficient", isMissingFrameMetric);
     valueElement.textContent = metricValueCopy(metricKey, metric, value, context);
-    metaElement.textContent = metricMetaCopy(metricKey, context, marker);
+    metaElement.textContent = metricMetaCopy(metricKey, metric, context, marker);
   }
 
   function updateMetricCards(latest, scenario, label, latestMarkers) {
@@ -587,7 +617,12 @@
 
   function inspectionValue(record, metric, selection) {
     if (!isProfileRecord(record)) return "Non comparable · ancien APK debug";
-    const value = metricValue(record, metric, selection.scenario, selection.label);
+    const value = displayedMetricValue(
+      record,
+      metric,
+      selection.scenario,
+      selection.label
+    );
     if (value != null) return metric.format(value);
     if (metric.source !== "physical") return "Non mesuré";
     if (selection.metricKey === "fps" && !selection.scenario.includes("scroll")) {
@@ -709,22 +744,32 @@
       ? "médiane · 3 répétitions Chrome"
       : "médiane · 3 appareils virtuels";
     elements["source-fps"].textContent = web
+      ? "indice relatif · 3 répétitions Chrome"
+      : "1 téléphone physique";
+    elements["source-jank"].textContent = web
       ? "médiane · 3 répétitions Chrome"
       : "1 téléphone physique";
-    elements["source-jank"].textContent = elements["source-fps"].textContent;
-    elements["source-transition"].textContent = elements["source-fps"].textContent;
+    elements["source-transition"].textContent = web
+      ? "médiane · 3 répétitions Chrome"
+      : "1 téléphone physique";
     elements["title-rss"].textContent = web ? "Mémoire JavaScript" : "Mémoire utilisée";
     elements["description-rss"].textContent = web
       ? "Mémoire du moteur JavaScript exposée par Chrome ; elle n’est jamais comparée à la RAM Android."
       : "Une hausse continue après plusieurs cycles peut révéler une fuite mémoire.";
-    elements["title-fps"].textContent = web ? "Fluidité Chrome CI" : "Fluidité mesurée";
+    elements["metric-icon-fps"].textContent = web ? "CI" : "FPS";
+    elements["title-fps"].textContent = web ? "Indice de fluidité CI" : "Fluidité mesurée";
     elements["description-fps"].textContent = web
-      ? "Cadence requestAnimationFrame du Chrome headless CI : utile pour suivre les régressions, pas comme FPS utilisateur."
+      ? "Indice relatif à la première nuit visible : 100 est la référence, une baisse indique une dégradation."
       : "Frames rendues par seconde entre le premier et le dernier signal vertical observé.";
     elements["title-jank"].textContent = web ? "Frames lentes" : "Frames saccadées";
     elements["description-jank"].textContent = web
       ? "Part des intervalles requestAnimationFrame supérieurs à 1,5 fois la cadence médiane."
       : "Part des frames où build ou raster dépasse le budget de 16,7 ms à 60 FPS.";
+    elements["title-transition"].textContent = web
+      ? "Temps d’ouverture · transition_ms"
+      : "Ouverture d’une conversation";
+    elements["filter-scenario"].hidden = web;
+    elements["filter-checkpoint"].hidden = web;
     elements["footer-source"].textContent = web
       ? "Chrome headless · GitHub runner · médiane de 3 répétitions"
       : "Mémoire : médiane de 3 runs virtuels · Fluidité : 1 run physique";

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -5,11 +5,12 @@
     MIN_FRAME_SAMPLE,
     ROOM_ENTRY_SUMMARY,
     checkpointForSelection,
+    classifySeries,
     hasEnoughFrames,
     historyWindow,
     isProfileRecord,
     maximumMarkerDelta,
-    median,
+    platformDataPaths,
   } = globalThis.PerfMetrics;
 
   const SCENARIO_LABELS = {
@@ -17,6 +18,8 @@
     scroll_room1: "Scroll d’une conversation riche en images · salle 1",
     scroll_room2: "Scroll d’une conversation riche en images · salle 2",
     chat_list_scroll: "Scroll de la liste des conversations",
+    web_navigation: "Ouverture et retour d’une conversation",
+    web_room_scroll: "Scroll continu d’une conversation",
   };
 
   const CHECKPOINT_LABELS = {
@@ -28,9 +31,11 @@
     list_top: "Haut de la liste",
     list_bottom: "Bas de la liste",
     list_top_again: "Retour en haut",
+    room_opened: "Conversation ouverte",
+    scroll_completed: "Scroll terminé",
   };
 
-  const METRICS = {
+  const ANDROID_METRICS = {
     rss_bytes: {
       label: "Mémoire",
       source: "memory",
@@ -77,7 +82,72 @@
     },
   };
 
+  const WEB_METRICS = {
+    js_heap_used_bytes: {
+      label: "Mémoire JavaScript",
+      source: "web",
+      color: "#b8f34b",
+      lowerIsBetter: true,
+      format: value => `${(value / 1048576).toFixed(1)} Mio`,
+      read: checkpointValue => checkpointValue?.js_heap_used_bytes ?? null,
+      valueElement: "value-rss",
+      metaElement: "meta-rss",
+    },
+    fps: {
+      label: "FPS navigateur",
+      source: "web",
+      color: "#65d9d2",
+      lowerIsBetter: false,
+      format: value => `${value.toFixed(1)} FPS`,
+      read: checkpointValue => checkpointValue?.fps > 0
+        ? checkpointValue.fps
+        : null,
+      valueElement: "value-fps",
+      metaElement: "meta-fps",
+    },
+    slow_frame_rate: {
+      label: "Frames lentes",
+      source: "web",
+      color: "#ffb548",
+      lowerIsBetter: true,
+      format: value => `${(value * 100).toFixed(1)} %`,
+      read: checkpointValue => checkpointValue?.slow_frame_rate ?? null,
+      valueElement: "value-jank",
+      metaElement: "meta-jank",
+    },
+    transition_ms: {
+      label: "Temps d’ouverture",
+      source: "web",
+      color: "#78a9ff",
+      lowerIsBetter: true,
+      format: value => `${value.toFixed(0)} ms`,
+      read: checkpointValue => checkpointValue?.transition_ms ?? null,
+      valueElement: "value-transition",
+      metaElement: "meta-transition",
+    },
+  };
+
+  const androidPaths = platformDataPaths("android");
+  const webPaths = platformDataPaths("web");
+  const PLATFORMS = {
+    android: {
+      indexPath: androidPaths.index,
+      recordRoot: androidPaths.records,
+      family: androidPaths.family,
+      metrics: ANDROID_METRICS,
+    },
+    web: {
+      indexPath: webPaths.index,
+      recordRoot: webPaths.records,
+      family: webPaths.family,
+      metrics: WEB_METRICS,
+    },
+  };
+
+  let METRICS = ANDROID_METRICS;
+
   const state = {
+    platform: "android",
     index: null,
     records: [],
     historyRecords: [],
@@ -88,12 +158,17 @@
   };
 
   const elementIds = [
-    "range-select", "scenario-select", "checkpoint-select",
+    "platform-select", "range-select", "scenario-select", "checkpoint-select",
     "latest-date", "latest-sha", "history-depth",
     "status-light", "status-label", "status-meta",
     "overall-status", "overall-detail", "verdict",
     "inspection-title", "inspection-values", "overview-chart",
-    ...Object.values(METRICS).flatMap(metric => [metric.valueElement, metric.metaElement]),
+    "platform-eyebrow", "web-diagnostic", "value-long-task",
+    "footer-source", "workflow-link",
+    "source-rss", "source-fps", "source-jank", "source-transition",
+    "title-rss", "description-rss", "title-fps",
+    "title-jank", "description-jank", "title-transition",
+    ...Object.values(ANDROID_METRICS).flatMap(metric => [metric.valueElement, metric.metaElement]),
   ];
   const elements = Object.fromEntries(elementIds.map(id => [id, document.getElementById(id)]));
 
@@ -104,26 +179,6 @@
     next.setUTCDate(next.getUTCDate() + amount);
     return isoDay(next);
   };
-
-  function severityForDelta(delta) {
-    if (delta >= 0.2) return "critical";
-    if (delta >= 0.1) return "warning";
-    return "normal";
-  }
-
-  function classify(values, lowerIsBetter) {
-    return values.map((value, index) => {
-      if (value == null) return { severity: "missing", delta: null };
-      const previous = values.slice(0, index).filter(item => item != null).slice(-7);
-      if (previous.length < 7) return { severity: "baseline", delta: null };
-      const baseline = median(previous);
-      if (baseline <= 0) return { severity: "baseline", delta: null };
-      const delta = lowerIsBetter
-        ? (value - baseline) / baseline
-        : (baseline - value) / baseline;
-      return { severity: severityForDelta(delta), delta, baseline };
-    });
-  }
 
   function selectedEntries() {
     if (!state.index?.entries.length) return [];
@@ -136,7 +191,10 @@
 
   async function fetchRecord(entry) {
     if (state.recordCache.has(entry.date)) return state.recordCache.get(entry.date);
-    const response = await fetch(`data/${entry.file}`, { cache: "no-store" });
+    const response = await fetch(
+      `${PLATFORMS[state.platform].recordRoot}/${entry.file}`,
+      { cache: "no-store" }
+    );
     if (!response.ok) throw new Error(`Impossible de charger ${entry.file}`);
     const record = await response.json();
     state.recordCache.set(entry.date, record);
@@ -168,7 +226,11 @@
 
   function metricValue(record, metric, scenario, label) {
     if (!isProfileRecord(record)) return null;
-    if (metric.continuousOnly && !scenario.includes("scroll")) return null;
+    if (
+      state.platform === "android" &&
+      metric.continuousOnly &&
+      !scenario.includes("scroll")
+    ) return null;
     return metric.read(checkpoint(record, metric.source, scenario, label));
   }
 
@@ -188,8 +250,11 @@
   }
 
   function populateScenarios() {
+    const family = PLATFORMS[state.platform].family;
     const available = [...new Set(
-      state.records.flatMap(record => record.memory.checkpoints.map(item => item.scenario))
+      state.records.flatMap(
+        record => (record[family]?.checkpoints || []).map(item => item.scenario)
+      )
     )];
     available.sort((left, right) => {
       if (left === "nav_cycles") return -1;
@@ -208,12 +273,17 @@
 
   function populateCheckpoints() {
     const scenario = elements["scenario-select"].value;
+    const family = PLATFORMS[state.platform].family;
     const labels = [...new Set(state.records.flatMap(record =>
-      record.memory.checkpoints
+      (record[family]?.checkpoints || [])
         .filter(item => item.scenario === scenario)
         .map(item => item.label)
     ))];
-    if (scenario === "nav_cycles" && labels.some(label => /^room_enter_cycle\d+$/.test(label))) {
+    if (
+      state.platform === "android" &&
+      scenario === "nav_cycles" &&
+      labels.some(label => /^room_enter_cycle\d+$/.test(label))
+    ) {
       labels.unshift(ROOM_ENTRY_SUMMARY);
     }
     const previous = elements["checkpoint-select"].value;
@@ -231,7 +301,7 @@
 
   function markersFor(metric, scenario, label, visibleDays) {
     const values = state.historyRecords.map(record => metricValue(record, metric, scenario, label));
-    const markers = classify(values, metric.lowerIsBetter);
+    const markers = classifySeries(values, metric.lowerIsBetter);
     const byDay = new Map(state.historyRecords.map((record, index) => [record.date, markers[index]]));
     return visibleDays.map(day => byDay.get(day) || { severity: "missing", delta: null });
   }
@@ -370,7 +440,11 @@
 
   function metricValueCopy(metricKey, metric, value, context) {
     if (value != null) return metric.format(value);
-    if (metricKey === "fps" && !context.scenario.includes("scroll")) {
+    if (
+      state.platform === "android" &&
+      metricKey === "fps" &&
+      !context.scenario.includes("scroll")
+    ) {
       return "Non applicable";
     }
     if (metricKey === "fps" && hasEnoughFrames(context.physicalCheckpoint)) {
@@ -383,6 +457,12 @@
   }
 
   function metricMetaCopy(metricKey, context, marker) {
+    if (state.platform === "web") {
+      if (["fps", "slow_frame_rate"].includes(metricKey)) {
+        return `${context.selectedCheckpoint?.frame_count || 0} frames analysées · ${severityCopy(marker)}`;
+      }
+      return severityCopy(marker);
+    }
     if (metricKey === "fps" || metricKey === "jank_rate") {
       return frameSampleCopy(
         context.physicalCheckpoint,
@@ -420,23 +500,30 @@
       card.classList.add(marker.severity);
     }
     const isMissingFrameMetric = value == null &&
-      (metricKey === "fps" || metricKey === "jank_rate");
+      ["fps", "jank_rate", "slow_frame_rate"].includes(metricKey);
     valueElement.classList.toggle("insufficient", isMissingFrameMetric);
     valueElement.textContent = metricValueCopy(metricKey, metric, value, context);
     metaElement.textContent = metricMetaCopy(metricKey, context, marker);
   }
 
   function updateMetricCards(latest, scenario, label, latestMarkers) {
+    const selectedFamily = PLATFORMS[state.platform].family;
     const context = {
       latest,
       scenario,
       label,
       latestMarkers,
       physicalCheckpoint: checkpoint(latest, "physical", scenario, label),
+      selectedCheckpoint: checkpoint(latest, selectedFamily, scenario, label),
     };
     Object.entries(METRICS).forEach(
       ([metricKey, metric]) => renderMetricCard(metricKey, metric, context)
     );
+    const longTaskValue = context.selectedCheckpoint?.long_task_total_ms;
+    elements["web-diagnostic"].hidden = state.platform !== "web";
+    elements["value-long-task"].textContent = Number.isFinite(longTaskValue)
+      ? `${longTaskValue.toFixed(0)} ms`
+      : "non mesuré";
   }
 
   function worstMarker(markers) {
@@ -547,7 +634,9 @@
     elements["history-depth"].textContent = `${state.index.entries.length} nuit${state.index.entries.length > 1 ? "s" : ""}`;
     elements["status-light"].classList.add("ready");
     elements["status-label"].textContent = "Mesures disponibles";
-    elements["status-meta"].textContent = `Mise à jour ${state.index.updated_at || state.records.at(-1).generated_at}`;
+    elements["status-meta"].textContent = state.platform === "web"
+      ? "Chrome headless · GitHub runner · médiane de 3 répétitions"
+      : `Mise à jour ${state.index.updated_at || state.records.at(-1).generated_at}`;
   }
 
   function showDatasetError(error) {
@@ -561,7 +650,10 @@
   }
 
   async function fetchIndex() {
-    const response = await fetch("data/index.json", { cache: "no-store" });
+    const response = await fetch(
+      PLATFORMS[state.platform].indexPath,
+      { cache: "no-store" }
+    );
     if (!response.ok) throw new Error(`L’index des mesures répond HTTP ${response.status}`);
     const index = await response.json();
     validateIndex(index);
@@ -574,6 +666,48 @@
     if (!state.records.length) throw new Error("L’historique nightly est vide");
     markDatasetReady();
     populateScenarios();
+  }
+
+  function configurePlatformContent() {
+    const web = state.platform === "web";
+    elements["platform-eyebrow"].textContent = web
+      ? "Patrol Web · suivi quotidien"
+      : "Firebase Test Lab · suivi quotidien";
+    elements["source-rss"].textContent = web
+      ? "médiane · 3 répétitions Chrome"
+      : "médiane · 3 appareils virtuels";
+    elements["source-fps"].textContent = web
+      ? "médiane · 3 répétitions Chrome"
+      : "1 téléphone physique";
+    elements["source-jank"].textContent = elements["source-fps"].textContent;
+    elements["source-transition"].textContent = elements["source-fps"].textContent;
+    elements["title-rss"].textContent = web ? "Mémoire JavaScript" : "Mémoire utilisée";
+    elements["description-rss"].textContent = web
+      ? "Mémoire du moteur JavaScript exposée par Chrome ; elle n’est jamais comparée à la RAM Android."
+      : "Une hausse continue après plusieurs cycles peut révéler une fuite mémoire.";
+    elements["title-jank"].textContent = web ? "Frames lentes" : "Frames saccadées";
+    elements["description-jank"].textContent = web
+      ? "Part des intervalles requestAnimationFrame supérieurs à 1,5 fois la cadence médiane."
+      : "Part des frames où build ou raster dépasse le budget de 16,7 ms à 60 FPS.";
+    elements["footer-source"].textContent = web
+      ? "Chrome headless · GitHub runner · médiane de 3 répétitions"
+      : "Mémoire : médiane de 3 runs virtuels · Fluidité : 1 run physique";
+    elements["workflow-link"].href = web
+      ? "https://github.com/linagora/twake-on-matrix/actions/workflows/patrol-web-integration-test.yaml"
+      : "https://github.com/linagora/twake-on-matrix/actions/workflows/integration-tests.yaml";
+    elements["web-diagnostic"].hidden = !web;
+  }
+
+  async function switchPlatform() {
+    state.platform = elements["platform-select"].value;
+    METRICS = PLATFORMS[state.platform].metrics;
+    state.index = null;
+    state.records = [];
+    state.historyRecords = [];
+    state.recordCache = new Map();
+    state.overviewChart?.destroy();
+    configurePlatformContent();
+    await load();
   }
 
   async function reloadSelectedRange() {
@@ -590,7 +724,11 @@
   elements["range-select"].addEventListener("change", () => {
     reloadSelectedRange().catch(reportRangeError);
   });
+  elements["platform-select"].addEventListener("change", () => {
+    switchPlatform().catch(showDatasetError);
+  });
   elements["scenario-select"].addEventListener("change", populateCheckpoints);
   elements["checkpoint-select"].addEventListener("change", render);
+  configurePlatformContent();
   load().catch(showDatasetError);
 })();

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -3,11 +3,15 @@
 
   const {
     MIN_FRAME_SAMPLE,
+    MIN_WEB_FRAME_SAMPLE,
+    MIN_WEB_FRAME_WINDOW_MS,
     ROOM_ENTRY_SUMMARY,
     checkpointForSelection,
     classifySeries,
     hasEnoughFrames,
+    hasEnoughWebFrames,
     historyWindow,
+    isMetricApplicable,
     isProfileRecord,
     maximumMarkerDelta,
     platformDataPaths,
@@ -99,8 +103,10 @@
       source: "web",
       color: "#65d9d2",
       lowerIsBetter: false,
+      continuousOnly: true,
       format: value => `${value.toFixed(1)} FPS`,
-      read: checkpointValue => checkpointValue?.fps > 0
+      read: checkpointValue => hasEnoughWebFrames(checkpointValue) &&
+        checkpointValue.fps > 0
         ? checkpointValue.fps
         : null,
       valueElement: "value-fps",
@@ -112,7 +118,9 @@
       color: "#ffb548",
       lowerIsBetter: true,
       format: value => `${(value * 100).toFixed(1)} %`,
-      read: checkpointValue => checkpointValue?.slow_frame_rate ?? null,
+      read: checkpointValue => hasEnoughWebFrames(checkpointValue)
+        ? checkpointValue.slow_frame_rate
+        : null,
       valueElement: "value-jank",
       metaElement: "meta-jank",
     },
@@ -227,11 +235,7 @@
 
   function metricValue(record, metric, scenario, label) {
     if (!isProfileRecord(record)) return null;
-    if (
-      state.platform === "android" &&
-      metric.continuousOnly &&
-      !scenario.includes("scroll")
-    ) return null;
+    if (!isMetricApplicable(metric, scenario)) return null;
     return metric.read(checkpoint(record, metric.source, scenario, label));
   }
 
@@ -439,16 +443,30 @@
     return `${frameCount} frames analysées · ${severityCopy(marker)}`;
   }
 
+  function webFrameSampleCopy(checkpointValue, metricKey, marker, scenario) {
+    if (metricKey === "fps" && !scenario.includes("scroll")) {
+      return "Non applicable sur une transition · utilisez le temps d’ouverture";
+    }
+    const frameCount = checkpointValue?.frame_count ?? 0;
+    const frameWindowMs = checkpointValue?.frame_window_ms ?? 0;
+    if (!hasEnoughWebFrames(checkpointValue)) {
+      return `${frameCount} frames sur ${(frameWindowMs / 1000).toFixed(1)} s · ` +
+        `minimum ${MIN_WEB_FRAME_SAMPLE} frames et ${MIN_WEB_FRAME_WINDOW_MS / 1000} s`;
+    }
+    return `${frameCount} frames analysées sur ${(frameWindowMs / 1000).toFixed(1)} s · ` +
+      severityCopy(marker);
+  }
+
   function metricValueCopy(metricKey, metric, value, context) {
     if (value != null) return metric.format(value);
-    if (
-      state.platform === "android" &&
-      metricKey === "fps" &&
-      !context.scenario.includes("scroll")
-    ) {
+    if (!isMetricApplicable(metric, context.scenario)) {
       return "Non applicable";
     }
-    if (metricKey === "fps" && hasEnoughFrames(context.physicalCheckpoint)) {
+    if (
+      metricKey === "fps" &&
+      state.platform === "android" &&
+      hasEnoughFrames(context.physicalCheckpoint)
+    ) {
       return "Prochain nightly";
     }
     if (metricKey === "fps" || metricKey === "jank_rate") {
@@ -460,7 +478,12 @@
   function metricMetaCopy(metricKey, context, marker) {
     if (state.platform === "web") {
       if (["fps", "slow_frame_rate"].includes(metricKey)) {
-        return `${context.selectedCheckpoint?.frame_count || 0} frames analysées · ${severityCopy(marker)}`;
+        return webFrameSampleCopy(
+          context.selectedCheckpoint,
+          metricKey,
+          marker,
+          context.scenario
+        );
       }
       return severityCopy(marker);
     }

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -11,6 +11,7 @@
     isProfileRecord,
     maximumMarkerDelta,
     platformDataPaths,
+    shouldFallbackToWeb,
   } = globalThis.PerfMetrics;
 
   const SCENARIO_LABELS = {
@@ -654,7 +655,15 @@
       PLATFORMS[state.platform].indexPath,
       { cache: "no-store" }
     );
-    if (!response.ok) throw new Error(`L’index des mesures répond HTTP ${response.status}`);
+    if (!response.ok) {
+      const error = new Error(
+        response.status === 404
+          ? `Aucun historique ${state.platform === "web" ? "Web" : "Android"} publié pour le moment`
+          : `L’index des mesures répond HTTP ${response.status}`
+      );
+      error.httpStatus = response.status;
+      throw error;
+    }
     const index = await response.json();
     validateIndex(index);
     return index;
@@ -710,6 +719,16 @@
     await load();
   }
 
+  async function loadInitialPlatform() {
+    try {
+      await load();
+    } catch (error) {
+      if (!shouldFallbackToWeb(state.platform, error.httpStatus)) throw error;
+      elements["platform-select"].value = "web";
+      await switchPlatform();
+    }
+  }
+
   async function reloadSelectedRange() {
     await loadSelectedRecords();
     populateScenarios();
@@ -730,5 +749,5 @@
   elements["scenario-select"].addEventListener("change", populateCheckpoints);
   elements["checkpoint-select"].addEventListener("change", render);
   configurePlatformContent();
-  load().catch(showDatasetError);
+  loadInitialPlatform().catch(showDatasetError);
 })();

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -11,12 +11,14 @@
     hasEnoughFrames,
     hasEnoughWebFrames,
     historyWindow,
+    isCurrentPlatformLoad,
     isMetricApplicable,
     isProfileRecord,
     maximumMarkerDelta,
     metricSelection,
     normalizeHealthIndex,
     platformDataPaths,
+    platformRecordCacheKey,
     shouldFallbackToWeb,
   } = globalThis.PerfMetrics;
 
@@ -172,6 +174,7 @@
     records: [],
     historyRecords: [],
     recordCache: new Map(),
+    loadId: 0,
     windowStart: null,
     windowEnd: null,
     overviewChart: null,
@@ -211,27 +214,40 @@
     return state.index.entries.filter(entry => entry.date >= state.windowStart && entry.date <= state.windowEnd);
   }
 
-  async function fetchRecord(entry) {
-    if (state.recordCache.has(entry.date)) return state.recordCache.get(entry.date);
+  async function fetchRecord(entry, platform = state.platform) {
+    const cacheKey = platformRecordCacheKey(platform, entry.date);
+    if (state.recordCache.has(cacheKey)) return state.recordCache.get(cacheKey);
     const response = await fetch(
-      `${PLATFORMS[state.platform].recordRoot}/${entry.file}`,
+      `${PLATFORMS[platform].recordRoot}/${entry.file}`,
       { cache: "no-store" }
     );
     if (!response.ok) throw new Error(`Impossible de charger ${entry.file}`);
     const record = await response.json();
-    state.recordCache.set(entry.date, record);
+    state.recordCache.set(cacheKey, record);
     return record;
   }
 
-  async function loadSelectedRecords() {
+  async function loadSelectedRecords(
+    platform = state.platform,
+    loadId = state.loadId
+  ) {
     const entries = selectedEntries();
     const firstIndex = state.index.entries.findIndex(entry => entry.date === entries[0]?.date);
     const entriesWithBaseline = state.index.entries.slice(Math.max(0, firstIndex - 7));
-    const loaded = (await Promise.all(entriesWithBaseline.map(fetchRecord)))
+    const loaded = (await Promise.all(
+      entriesWithBaseline.map(entry => fetchRecord(entry, platform))
+    ))
       .sort((left, right) => left.date.localeCompare(right.date));
+    if (!isCurrentPlatformLoad(
+      platform,
+      loadId,
+      state.platform,
+      state.loadId
+    )) return false;
     const selectedDates = new Set(entries.map(entry => entry.date));
     state.historyRecords = loaded;
     state.records = loaded.filter(record => selectedDates.has(record.date));
+    return true;
   }
 
   function calendarDays() {
@@ -271,6 +287,8 @@
   }
 
   function populateScenarios() {
+    elements["scenario-select"].disabled = false;
+    elements["checkpoint-select"].disabled = false;
     const family = PLATFORMS[state.platform].family;
     const available = [...new Set(
       state.records.flatMap(
@@ -691,6 +709,7 @@
 
   function markDatasetReady() {
     elements["history-depth"].textContent = `${state.index.entries.length} nuit${state.index.entries.length > 1 ? "s" : ""}`;
+    elements["status-light"].classList.remove("error");
     elements["status-light"].classList.add("ready");
     elements["status-label"].textContent = "Mesures disponibles";
     elements["status-meta"].textContent = state.platform === "web"
@@ -698,7 +717,47 @@
       : `Mise à jour ${state.index.updated_at || state.records.at(-1).generated_at}`;
   }
 
+  function clearRenderedData(message) {
+    state.overviewChart?.destroy();
+    state.overviewChart = null;
+    elements["latest-date"].textContent = "—";
+    elements["latest-sha"].textContent = "—";
+    elements["history-depth"].textContent = "0 nuit";
+    elements["value-long-task"].textContent = "—";
+    elements["scenario-select"].replaceChildren(
+      new Option("Aucune donnée", "", true, true)
+    );
+    elements["checkpoint-select"].replaceChildren(
+      new Option("Aucune donnée", "", true, true)
+    );
+    elements["scenario-select"].disabled = true;
+    elements["checkpoint-select"].disabled = true;
+    Object.values(METRICS).forEach(metric => {
+      const valueElement = elements[metric.valueElement];
+      const card = valueElement.closest(".metric-card");
+      card.classList.remove("warning", "critical");
+      valueElement.classList.add("insufficient");
+      valueElement.textContent = "—";
+      elements[metric.metaElement].textContent = message;
+    });
+  }
+
+  function prepareDatasetLoad() {
+    elements["status-light"].classList.remove("ready", "error");
+    elements["status-label"].textContent = "Chargement des mesures";
+    elements["status-meta"].textContent = state.platform === "web"
+      ? "Lecture de l’historique Chrome"
+      : "Lecture de l’historique Firebase Test Lab";
+    elements["overall-status"].textContent = "Chargement en cours";
+    elements["overall-detail"].textContent = "Les valeurs vont être remplacées par celles de la plateforme sélectionnée.";
+    elements["inspection-title"].textContent = "Chargement de l’historique";
+    elements["inspection-values"].innerHTML = "<p>Lecture des mesures publiées…</p>";
+    clearRenderedData("Chargement…");
+  }
+
   function showDatasetError(error) {
+    clearRenderedData(error.message);
+    elements["status-light"].classList.remove("ready");
     elements["status-light"].classList.add("error");
     elements["status-label"].textContent = "Mesures indisponibles";
     elements["status-meta"].textContent = error.message;
@@ -708,15 +767,15 @@
     elements["inspection-values"].innerHTML = `<p>${error.message}</p>`;
   }
 
-  async function fetchIndex() {
+  async function fetchIndex(platform = state.platform) {
     const response = await fetch(
-      PLATFORMS[state.platform].indexPath,
+      PLATFORMS[platform].indexPath,
       { cache: "no-store" }
     );
     if (!response.ok) {
       const error = new Error(
         response.status === 404
-          ? `Aucun historique ${state.platform === "web" ? "Web" : "Android"} publié pour le moment`
+          ? `Aucun historique ${platform === "web" ? "Web" : "Android"} publié pour le moment`
           : `L’index des mesures répond HTTP ${response.status}`
       );
       error.httpStatus = response.status;
@@ -727,12 +786,24 @@
     return index;
   }
 
-  async function load() {
-    state.index = await fetchIndex();
-    await loadSelectedRecords();
+  async function load(
+    platform = state.platform,
+    loadId = state.loadId
+  ) {
+    const index = await fetchIndex(platform);
+    if (!isCurrentPlatformLoad(
+      platform,
+      loadId,
+      state.platform,
+      state.loadId
+    )) return false;
+    state.index = index;
+    const loaded = await loadSelectedRecords(platform, loadId);
+    if (!loaded) return false;
     if (!state.records.length) throw new Error("L’historique nightly est vide");
     markDatasetReady();
     populateScenarios();
+    return true;
   }
 
   function configurePlatformContent() {
@@ -780,15 +851,29 @@
   }
 
   async function switchPlatform() {
-    state.platform = elements["platform-select"].value;
-    METRICS = PLATFORMS[state.platform].metrics;
+    const platform = elements["platform-select"].value;
+    const loadId = state.loadId + 1;
+    state.loadId = loadId;
+    state.platform = platform;
+    METRICS = PLATFORMS[platform].metrics;
     state.index = null;
     state.records = [];
     state.historyRecords = [];
     state.recordCache = new Map();
-    state.overviewChart?.destroy();
     configurePlatformContent();
-    await load();
+    prepareDatasetLoad();
+    try {
+      await load(platform, loadId);
+    } catch (error) {
+      if (isCurrentPlatformLoad(
+        platform,
+        loadId,
+        state.platform,
+        state.loadId
+      )) {
+        showDatasetError(error);
+      }
+    }
   }
 
   async function loadInitialPlatform() {
@@ -802,8 +887,8 @@
   }
 
   async function reloadSelectedRange() {
-    await loadSelectedRecords();
-    populateScenarios();
+    const loaded = await loadSelectedRecords(state.platform, state.loadId);
+    if (loaded) populateScenarios();
   }
 
   function reportRangeError(error) {
@@ -816,7 +901,7 @@
     reloadSelectedRange().catch(reportRangeError);
   });
   elements["platform-select"].addEventListener("change", () => {
-    switchPlatform().catch(showDatasetError);
+    switchPlatform();
   });
   elements["scenario-select"].addEventListener("change", populateCheckpoints);
   elements["checkpoint-select"].addEventListener("change", render);

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -17,6 +17,7 @@
     maximumMarkerDelta,
     metricSelection,
     normalizeHealthIndex,
+    platformDataCandidates,
     platformDataPaths,
     platformRecordCacheKey,
     shouldFallbackToWeb,
@@ -153,12 +154,14 @@
   const webPaths = platformDataPaths("web");
   const PLATFORMS = {
     android: {
+      dataCandidates: platformDataCandidates("android", location.pathname),
       indexPath: androidPaths.index,
       recordRoot: androidPaths.records,
       family: androidPaths.family,
       metrics: ANDROID_METRICS,
     },
     web: {
+      dataCandidates: platformDataCandidates("web", location.pathname),
       indexPath: webPaths.index,
       recordRoot: webPaths.records,
       family: webPaths.family,
@@ -174,6 +177,7 @@
     records: [],
     historyRecords: [],
     recordCache: new Map(),
+    recordRoot: androidPaths.records,
     loadId: 0,
     windowStart: null,
     windowEnd: null,
@@ -218,7 +222,7 @@
     const cacheKey = platformRecordCacheKey(platform, entry.date);
     if (state.recordCache.has(cacheKey)) return state.recordCache.get(cacheKey);
     const response = await fetch(
-      `${PLATFORMS[platform].recordRoot}/${entry.file}`,
+      `${state.recordRoot}/${entry.file}`,
       { cache: "no-store" }
     );
     if (!response.ok) throw new Error(`Impossible de charger ${entry.file}`);
@@ -771,36 +775,38 @@
   }
 
   async function fetchIndex(platform = state.platform) {
-    const response = await fetch(
-      PLATFORMS[platform].indexPath,
-      { cache: "no-store" }
-    );
-    if (!response.ok) {
-      const error = new Error(
-        response.status === 404
-          ? `Aucun historique ${platform === "web" ? "Web" : "Android"} publié pour le moment`
-          : `L’index des mesures répond HTTP ${response.status}`
-      );
-      error.httpStatus = response.status;
-      throw error;
+    let response;
+    for (const candidate of PLATFORMS[platform].dataCandidates) {
+      response = await fetch(candidate.index, { cache: "no-store" });
+      if (response.ok) {
+        const index = await response.json();
+        validateIndex(index);
+        return { index, recordRoot: candidate.records };
+      }
+      if (response.status !== 404) break;
     }
-    const index = await response.json();
-    validateIndex(index);
-    return index;
+    const error = new Error(
+      response.status === 404
+        ? `Aucun historique ${platform === "web" ? "Web" : "Android"} publié pour le moment`
+        : `L’index des mesures répond HTTP ${response.status}`
+    );
+    error.httpStatus = response.status;
+    throw error;
   }
 
   async function load(
     platform = state.platform,
     loadId = state.loadId
   ) {
-    const index = await fetchIndex(platform);
+    const dataset = await fetchIndex(platform);
     if (!isCurrentPlatformLoad(
       platform,
       loadId,
       state.platform,
       state.loadId
     )) return false;
-    state.index = index;
+    state.index = dataset.index;
+    state.recordRoot = dataset.recordRoot;
     const loaded = await loadSelectedRecords(platform, loadId);
     if (!loaded) return false;
     if (!state.records.length) throw new Error("L’historique nightly est vide");
@@ -863,6 +869,7 @@
     state.records = [];
     state.historyRecords = [];
     state.recordCache = new Map();
+    state.recordRoot = PLATFORMS[platform].recordRoot;
     configurePlatformContent();
     prepareDatasetLoad();
     try {

--- a/scripts/perf/dashboard/index.html
+++ b/scripts/perf/dashboard/index.html
@@ -30,7 +30,7 @@
     <main>
       <section class="hero">
         <div>
-          <p class="eyebrow">Firebase Test Lab · suivi quotidien</p>
+          <p class="eyebrow" id="platform-eyebrow">Firebase Test Lab · suivi quotidien</p>
           <h1>Est-ce que Twake<br /><em>reste fluide&nbsp;?</em></h1>
         </div>
         <p class="hero-copy">
@@ -41,6 +41,13 @@
       </section>
 
       <section class="control-deck" aria-label="Filtres du graphique">
+        <label>
+          <span>Plateforme mesurée</span>
+          <select id="platform-select">
+            <option value="android" selected>Android FTL</option>
+            <option value="web">Web Chrome</option>
+          </select>
+        </label>
         <label>
           <span>Période observée</span>
           <select id="range-select">
@@ -72,6 +79,7 @@
           <span>Dernière mesure <strong id="latest-date">—</strong></span>
           <span>Commit <strong id="latest-sha">—</strong></span>
           <span>Historique <strong id="history-depth">—</strong></span>
+          <span id="web-diagnostic" hidden>Longues tâches <strong id="value-long-task">—</strong></span>
         </div>
       </section>
 
@@ -79,21 +87,21 @@
         <article class="metric-card metric-memory" data-metric="rss_bytes">
           <div class="metric-heading">
             <span class="metric-icon">RAM</span>
-            <span class="source-badge">médiane · 3 appareils virtuels</span>
+            <span class="source-badge" id="source-rss">médiane · 3 appareils virtuels</span>
           </div>
           <strong id="value-rss">—</strong>
-          <h2>Mémoire utilisée</h2>
-          <p>Une hausse continue après plusieurs cycles peut révéler une fuite mémoire.</p>
+          <h2 id="title-rss">Mémoire utilisée</h2>
+          <p id="description-rss">Une hausse continue après plusieurs cycles peut révéler une fuite mémoire.</p>
           <small id="meta-rss">Plus bas est préférable</small>
         </article>
 
         <article class="metric-card metric-fps" data-metric="fps">
           <div class="metric-heading">
             <span class="metric-icon">FPS</span>
-            <span class="source-badge physical">1 téléphone physique</span>
+            <span class="source-badge physical" id="source-fps">1 téléphone physique</span>
           </div>
           <strong id="value-fps">—</strong>
-          <h2>Fluidité mesurée</h2>
+          <h2 id="title-fps">Fluidité mesurée</h2>
           <p>Frames rendues par seconde entre le premier et le dernier signal vertical observé.</p>
           <small id="meta-fps">Minimum 30 frames · APK profile</small>
         </article>
@@ -101,21 +109,21 @@
         <article class="metric-card metric-jank" data-metric="jank_rate">
           <div class="metric-heading">
             <span class="metric-icon">!</span>
-            <span class="source-badge physical">1 téléphone physique</span>
+            <span class="source-badge physical" id="source-jank">1 téléphone physique</span>
           </div>
           <strong id="value-jank">—</strong>
-          <h2>Frames saccadées</h2>
-          <p>Part des frames où build ou raster dépasse le budget de 16,7 ms à 60 FPS.</p>
+          <h2 id="title-jank">Frames saccadées</h2>
+          <p id="description-jank">Part des frames où build ou raster dépasse le budget de 16,7 ms à 60 FPS.</p>
           <small id="meta-jank">Minimum 30 frames · plus proche de 0 % est préférable</small>
         </article>
 
         <article class="metric-card metric-transition" data-metric="transition_ms">
           <div class="metric-heading">
             <span class="metric-icon">↗</span>
-            <span class="source-badge physical">1 téléphone physique</span>
+            <span class="source-badge physical" id="source-transition">1 téléphone physique</span>
           </div>
           <strong id="value-transition">—</strong>
-          <h2>Ouverture d’une conversation</h2>
+          <h2 id="title-transition">Ouverture d’une conversation</h2>
           <p>Temps entre l’action utilisateur et l’affichage stabilisé de la conversation.</p>
           <small id="meta-transition">Disponible sur les checkpoints d’ouverture</small>
         </article>
@@ -178,8 +186,8 @@
     </main>
 
     <footer>
-      <span>Mémoire&nbsp;: médiane de 3 runs virtuels · Fluidité&nbsp;: 1 run physique</span>
-      <a href="https://github.com/linagora/twake-on-matrix/actions/workflows/integration-tests.yaml">
+      <span id="footer-source">Mémoire&nbsp;: médiane de 3 runs virtuels · Fluidité&nbsp;: 1 run physique</span>
+      <a id="workflow-link" href="https://github.com/linagora/twake-on-matrix/actions/workflows/integration-tests.yaml">
         Voir le workflow nightly ↗
       </a>
     </footer>

--- a/scripts/perf/dashboard/index.html
+++ b/scripts/perf/dashboard/index.html
@@ -57,11 +57,11 @@
             <option value="all">Tout l’historique</option>
           </select>
         </label>
-        <label>
+        <label id="filter-scenario">
           <span>Parcours testé</span>
           <select id="scenario-select"></select>
         </label>
-        <label>
+        <label id="filter-checkpoint">
           <span>Moment du parcours</span>
           <select id="checkpoint-select"></select>
         </label>
@@ -97,7 +97,7 @@
 
         <article class="metric-card metric-fps" data-metric="fps">
           <div class="metric-heading">
-            <span class="metric-icon">FPS</span>
+            <span class="metric-icon" id="metric-icon-fps">FPS</span>
             <span class="source-badge physical" id="source-fps">1 téléphone physique</span>
           </div>
           <strong id="value-fps">—</strong>

--- a/scripts/perf/dashboard/index.html
+++ b/scripts/perf/dashboard/index.html
@@ -102,7 +102,7 @@
           </div>
           <strong id="value-fps">—</strong>
           <h2 id="title-fps">Fluidité mesurée</h2>
-          <p>Frames rendues par seconde entre le premier et le dernier signal vertical observé.</p>
+          <p id="description-fps">Frames rendues par seconde entre le premier et le dernier signal vertical observé.</p>
           <small id="meta-fps">Minimum 30 frames · APK profile</small>
         </article>
 

--- a/scripts/perf/dashboard/metrics.js
+++ b/scripts/perf/dashboard/metrics.js
@@ -47,6 +47,14 @@ globalThis.PerfMetrics = (() => {
       : { index: "data/index.json", records: "data", family: "memory" };
   }
 
+  function platformRecordCacheKey(platform, date) {
+    return `${platform}:${date}`;
+  }
+
+  function isCurrentPlatformLoad(platform, loadId, currentPlatform, currentLoadId) {
+    return platform === currentPlatform && loadId === currentLoadId;
+  }
+
   function shouldFallbackToWeb(platform, status) {
     return platform === "android" && status === 404;
   }
@@ -177,6 +185,8 @@ globalThis.PerfMetrics = (() => {
     metricSelection,
     normalizeHealthIndex,
     platformDataPaths,
+    platformRecordCacheKey,
+    isCurrentPlatformLoad,
     shouldFallbackToWeb,
     summarizeRoomEntries,
   };

--- a/scripts/perf/dashboard/metrics.js
+++ b/scripts/perf/dashboard/metrics.js
@@ -55,6 +55,25 @@ globalThis.PerfMetrics = (() => {
     return !metric.continuousOnly || scenario.includes("scroll");
   }
 
+  function metricSelection(metric, scenario, label) {
+    return {
+      scenario: metric.scenario || scenario,
+      label: metric.checkpoint || label,
+    };
+  }
+
+  function normalizeHealthIndex(values, lowerIsBetter) {
+    const reference = values.find(value => isNumber(value) && value > 0);
+    if (reference == null) return values.map(() => null);
+    return values.map(value => {
+      if (!isNumber(value) || value <= 0) return null;
+      const index = lowerIsBetter
+        ? (reference / value) * 100
+        : (value / reference) * 100;
+      return Number(index.toFixed(1));
+    });
+  }
+
   function classifySeries(values, lowerIsBetter) {
     return values.map((value, index) => {
       if (!isNumber(value)) return { severity: "missing", delta: null };
@@ -155,6 +174,8 @@ globalThis.PerfMetrics = (() => {
     isMetricApplicable,
     maximumMarkerDelta,
     median,
+    metricSelection,
+    normalizeHealthIndex,
     platformDataPaths,
     shouldFallbackToWeb,
     summarizeRoomEntries,

--- a/scripts/perf/dashboard/metrics.js
+++ b/scripts/perf/dashboard/metrics.js
@@ -39,6 +39,31 @@ globalThis.PerfMetrics = (() => {
     return deltas.length ? Math.max(...deltas) : null;
   }
 
+  function platformDataPaths(platform) {
+    return platform === "web"
+      ? { index: "data/web/index.json", records: "data/web", family: "web" }
+      : { index: "data/index.json", records: "data", family: "memory" };
+  }
+
+  function classifySeries(values, lowerIsBetter) {
+    return values.map((value, index) => {
+      if (!isNumber(value)) return { severity: "missing", delta: null };
+      const previous = values.slice(0, index).filter(isNumber).slice(-7);
+      if (previous.length < 7) return { severity: "baseline", delta: null };
+      const baseline = median(previous);
+      if (!(baseline > 0)) return { severity: "baseline", delta: null };
+      const delta = lowerIsBetter
+        ? (value - baseline) / baseline
+        : (baseline - value) / baseline;
+      const severity = delta >= 0.2
+        ? "critical"
+        : delta >= 0.1
+          ? "warning"
+          : "normal";
+      return { severity, delta, baseline };
+    });
+  }
+
   function roomEntryCheckpoints(record, family, scenario) {
     return (record?.[family]?.checkpoints || []).filter(
       checkpoint => checkpoint.scenario === scenario &&
@@ -105,11 +130,13 @@ globalThis.PerfMetrics = (() => {
     MIN_FRAME_SAMPLE,
     ROOM_ENTRY_SUMMARY,
     checkpointForSelection,
+    classifySeries,
     hasEnoughFrames,
     historyWindow,
     isProfileRecord,
     maximumMarkerDelta,
     median,
+    platformDataPaths,
     summarizeRoomEntries,
   };
 })();

--- a/scripts/perf/dashboard/metrics.js
+++ b/scripts/perf/dashboard/metrics.js
@@ -45,6 +45,10 @@ globalThis.PerfMetrics = (() => {
       : { index: "data/index.json", records: "data", family: "memory" };
   }
 
+  function shouldFallbackToWeb(platform, status) {
+    return platform === "android" && status === 404;
+  }
+
   function classifySeries(values, lowerIsBetter) {
     return values.map((value, index) => {
       if (!isNumber(value)) return { severity: "missing", delta: null };
@@ -137,6 +141,7 @@ globalThis.PerfMetrics = (() => {
     maximumMarkerDelta,
     median,
     platformDataPaths,
+    shouldFallbackToWeb,
     summarizeRoomEntries,
   };
 })();

--- a/scripts/perf/dashboard/metrics.js
+++ b/scripts/perf/dashboard/metrics.js
@@ -2,6 +2,8 @@ globalThis.PerfMetrics = (() => {
   "use strict";
 
   const MIN_FRAME_SAMPLE = 30;
+  const MIN_WEB_FRAME_SAMPLE = 60;
+  const MIN_WEB_FRAME_WINDOW_MS = 5000;
   const ROOM_ENTRY_SUMMARY = "room_enter_all";
 
   const isNumber = value => Number.isFinite(value);
@@ -47,6 +49,10 @@ globalThis.PerfMetrics = (() => {
 
   function shouldFallbackToWeb(platform, status) {
     return platform === "android" && status === 404;
+  }
+
+  function isMetricApplicable(metric, scenario) {
+    return !metric.continuousOnly || scenario.includes("scroll");
   }
 
   function classifySeries(values, lowerIsBetter) {
@@ -126,18 +132,27 @@ globalThis.PerfMetrics = (() => {
     return Number(checkpoint?.frame_count || 0) >= MIN_FRAME_SAMPLE;
   }
 
+  function hasEnoughWebFrames(checkpoint) {
+    return Number(checkpoint?.frame_count || 0) >= MIN_WEB_FRAME_SAMPLE &&
+      Number(checkpoint?.frame_window_ms || 0) >= MIN_WEB_FRAME_WINDOW_MS;
+  }
+
   function isProfileRecord(record) {
     return record?.environment?.build_mode === "profile";
   }
 
   return {
     MIN_FRAME_SAMPLE,
+    MIN_WEB_FRAME_SAMPLE,
+    MIN_WEB_FRAME_WINDOW_MS,
     ROOM_ENTRY_SUMMARY,
     checkpointForSelection,
     classifySeries,
     hasEnoughFrames,
+    hasEnoughWebFrames,
     historyWindow,
     isProfileRecord,
+    isMetricApplicable,
     maximumMarkerDelta,
     median,
     platformDataPaths,

--- a/scripts/perf/dashboard/metrics.js
+++ b/scripts/perf/dashboard/metrics.js
@@ -47,6 +47,24 @@ globalThis.PerfMetrics = (() => {
       : { index: "data/index.json", records: "data", family: "memory" };
   }
 
+  function platformDataCandidates(platform, pathname = "") {
+    const local = platformDataPaths(platform);
+    if (
+      platform !== "android" ||
+      !pathname.includes("/performance-previews/")
+    ) {
+      return [local];
+    }
+
+    const repository = pathname.split("/").filter(Boolean)[0];
+    if (!repository) return [local];
+    const records = `/${repository}/performance/data`;
+    return [
+      local,
+      { index: `${records}/index.json`, records, family: "memory" },
+    ];
+  }
+
   function platformRecordCacheKey(platform, date) {
     return `${platform}:${date}`;
   }
@@ -184,6 +202,7 @@ globalThis.PerfMetrics = (() => {
     median,
     metricSelection,
     normalizeHealthIndex,
+    platformDataCandidates,
     platformDataPaths,
     platformRecordCacheKey,
     isCurrentPlatformLoad,

--- a/scripts/perf/dashboard/styles.css
+++ b/scripts/perf/dashboard/styles.css
@@ -145,7 +145,7 @@ h1 em {
 
 .control-deck {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   border: 1px solid var(--line);
   background: rgba(13, 25, 28, 0.86);
 }

--- a/scripts/perf/dashboard/styles.css
+++ b/scripts/perf/dashboard/styles.css
@@ -18,6 +18,8 @@
 
 * { box-sizing: border-box; }
 
+[hidden] { display: none !important; }
+
 html { background: var(--night); scroll-behavior: smooth; }
 
 body {

--- a/scripts/perf/tests/test_compute_median.py
+++ b/scripts/perf/tests/test_compute_median.py
@@ -1,0 +1,47 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.perf.compute_median import compute_median
+
+
+class ComputeMedianTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.directory = Path(self.temporary_directory.name)
+        self.logs = []
+        for index, fps in enumerate((58.0, 60.0, 62.0), start=1):
+            path = self.directory / f"run-{index}.log"
+            path.write_text(
+                "PERF_METRIC | web_navigation | room_opened"
+                f" | fps={fps} | transition_ms={100 + index}\n",
+                encoding="utf-8",
+            )
+            self.logs.append(str(path))
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def test_default_output_keeps_existing_contract(self) -> None:
+        output = self.directory / "median.json"
+        compute_median(self.logs, str(output))
+
+        checkpoint = json.loads(output.read_text(encoding="utf-8"))[0]
+        self.assertEqual(checkpoint["fps"], 60.0)
+        self.assertNotIn("fps_values", checkpoint)
+
+    def test_optional_raw_values_are_kept_with_aggregates(self) -> None:
+        output = self.directory / "median.json"
+        compute_median(self.logs, str(output), include_values=True)
+
+        checkpoint = json.loads(output.read_text(encoding="utf-8"))[0]
+        self.assertEqual(checkpoint["sample_count"], 3)
+        self.assertEqual(checkpoint["fps"], 60.0)
+        self.assertEqual(checkpoint["fps_values"], [58.0, 60.0, 62.0])
+        self.assertEqual(checkpoint["fps_range"], 4.0)
+        self.assertEqual(checkpoint["fps_stddev"], 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/perf/tests/test_compute_median.py
+++ b/scripts/perf/tests/test_compute_median.py
@@ -42,6 +42,31 @@ class ComputeMedianTest(unittest.TestCase):
         self.assertEqual(checkpoint["fps_range"], 4.0)
         self.assertEqual(checkpoint["fps_stddev"], 2.0)
 
+    def test_optional_metric_does_not_reduce_checkpoint_sample_count(self) -> None:
+        Path(self.logs[1]).write_text(
+            "PERF_METRIC | web_navigation | room_opened"
+            " | transition_ms=102\n",
+            encoding="utf-8",
+        )
+        output = self.directory / "median.json"
+
+        compute_median(self.logs, str(output), include_values=True)
+
+        checkpoint = json.loads(output.read_text(encoding="utf-8"))[0]
+        self.assertEqual(checkpoint["sample_count"], 3)
+        self.assertEqual(checkpoint["fps"], 60.0)
+        self.assertEqual(checkpoint["fps_values"], [58.0, 62.0])
+        self.assertEqual(checkpoint["transition_ms_values"], [101.0, 102.0, 103.0])
+
+    def test_missing_checkpoint_reduces_sample_count(self) -> None:
+        Path(self.logs[1]).write_text("", encoding="utf-8")
+        output = self.directory / "median.json"
+
+        compute_median(self.logs, str(output))
+
+        checkpoint = json.loads(output.read_text(encoding="utf-8"))[0]
+        self.assertEqual(checkpoint["sample_count"], 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/perf/tests/test_dashboard_metrics.js
+++ b/scripts/perf/tests/test_dashboard_metrics.js
@@ -13,6 +13,7 @@ const {
   isProfileRecord,
   maximumMarkerDelta,
   platformDataPaths,
+  shouldFallbackToWeb,
   summarizeRoomEntries,
 } = globalThis.PerfMetrics;
 
@@ -130,6 +131,12 @@ test("keeps Android and Web history paths and families separate", () => {
     records: "data/web",
     family: "web",
   });
+});
+
+test("falls back to Web only when the default Android index is missing", () => {
+  assert.equal(shouldFallbackToWeb("android", 404), true);
+  assert.equal(shouldFallbackToWeb("android", 500), false);
+  assert.equal(shouldFallbackToWeb("web", 404), false);
 });
 
 test("uses seven prior points and ignores missing nights for a Web baseline", () => {

--- a/scripts/perf/tests/test_dashboard_metrics.js
+++ b/scripts/perf/tests/test_dashboard_metrics.js
@@ -5,11 +5,15 @@ require("../dashboard/metrics.js");
 
 const {
   MIN_FRAME_SAMPLE,
+  MIN_WEB_FRAME_SAMPLE,
+  MIN_WEB_FRAME_WINDOW_MS,
   ROOM_ENTRY_SUMMARY,
   checkpointForSelection,
   classifySeries,
   hasEnoughFrames,
+  hasEnoughWebFrames,
   historyWindow,
+  isMetricApplicable,
   isProfileRecord,
   maximumMarkerDelta,
   platformDataPaths,
@@ -74,6 +78,30 @@ test("rejects frame metrics below the minimum sample", () => {
   assert.equal(MIN_FRAME_SAMPLE, 30);
   assert.equal(hasEnoughFrames({ frame_count: 29 }), false);
   assert.equal(hasEnoughFrames({ frame_count: 30 }), true);
+});
+
+test("requires a meaningful Web frame count and measurement window", () => {
+  assert.equal(MIN_WEB_FRAME_SAMPLE, 60);
+  assert.equal(MIN_WEB_FRAME_WINDOW_MS, 5000);
+  assert.equal(hasEnoughWebFrames({
+    frame_count: 59,
+    frame_window_ms: 5000,
+  }), false);
+  assert.equal(hasEnoughWebFrames({
+    frame_count: 60,
+    frame_window_ms: 4999,
+  }), false);
+  assert.equal(hasEnoughWebFrames({
+    frame_count: 60,
+    frame_window_ms: 5000,
+  }), true);
+});
+
+test("keeps FPS out of transition scenarios", () => {
+  const fpsMetric = { continuousOnly: true };
+  assert.equal(isMetricApplicable(fpsMetric, "web_navigation"), false);
+  assert.equal(isMetricApplicable(fpsMetric, "web_room_scroll"), true);
+  assert.equal(isMetricApplicable({}, "web_navigation"), true);
 });
 
 test("uses the final cycle RSS for the room-opening summary", () => {

--- a/scripts/perf/tests/test_dashboard_metrics.js
+++ b/scripts/perf/tests/test_dashboard_metrics.js
@@ -7,10 +7,12 @@ const {
   MIN_FRAME_SAMPLE,
   ROOM_ENTRY_SUMMARY,
   checkpointForSelection,
+  classifySeries,
   hasEnoughFrames,
   historyWindow,
   isProfileRecord,
   maximumMarkerDelta,
+  platformDataPaths,
   summarizeRoomEntries,
 } = globalThis.PerfMetrics;
 
@@ -115,4 +117,26 @@ test("selects the largest available regression delta", () => {
     { delta: -0.05 },
   ]), 0.24);
   assert.equal(maximumMarkerDelta([{ delta: null }, {}]), null);
+});
+
+test("keeps Android and Web history paths and families separate", () => {
+  assert.deepEqual(platformDataPaths("android"), {
+    index: "data/index.json",
+    records: "data",
+    family: "memory",
+  });
+  assert.deepEqual(platformDataPaths("web"), {
+    index: "data/web/index.json",
+    records: "data/web",
+    family: "web",
+  });
+});
+
+test("uses seven prior points and ignores missing nights for a Web baseline", () => {
+  const values = [100, 100, null, 100, 100, 100, 100, 100, 111];
+  const markers = classifySeries(values, true);
+
+  assert.equal(markers[7].severity, "baseline");
+  assert.equal(markers[8].severity, "warning");
+  assert.ok(Math.abs(markers[8].delta - 0.11) < 0.0001);
 });

--- a/scripts/perf/tests/test_dashboard_metrics.js
+++ b/scripts/perf/tests/test_dashboard_metrics.js
@@ -13,12 +13,14 @@ const {
   hasEnoughFrames,
   hasEnoughWebFrames,
   historyWindow,
+  isCurrentPlatformLoad,
   isMetricApplicable,
   isProfileRecord,
   maximumMarkerDelta,
   metricSelection,
   normalizeHealthIndex,
   platformDataPaths,
+  platformRecordCacheKey,
   shouldFallbackToWeb,
   summarizeRoomEntries,
 } = globalThis.PerfMetrics;
@@ -188,6 +190,20 @@ test("keeps Android and Web history paths and families separate", () => {
     records: "data/web",
     family: "web",
   });
+});
+
+test("keeps platform caches and asynchronous loads isolated", () => {
+  assert.equal(
+    platformRecordCacheKey("android", "2026-07-24"),
+    "android:2026-07-24"
+  );
+  assert.equal(
+    platformRecordCacheKey("web", "2026-07-24"),
+    "web:2026-07-24"
+  );
+  assert.equal(isCurrentPlatformLoad("web", 3, "web", 3), true);
+  assert.equal(isCurrentPlatformLoad("android", 3, "web", 3), false);
+  assert.equal(isCurrentPlatformLoad("web", 2, "web", 3), false);
 });
 
 test("falls back to Web only when the default Android index is missing", () => {

--- a/scripts/perf/tests/test_dashboard_metrics.js
+++ b/scripts/perf/tests/test_dashboard_metrics.js
@@ -16,6 +16,8 @@ const {
   isMetricApplicable,
   isProfileRecord,
   maximumMarkerDelta,
+  metricSelection,
+  normalizeHealthIndex,
   platformDataPaths,
   shouldFallbackToWeb,
   summarizeRoomEntries,
@@ -102,6 +104,33 @@ test("keeps FPS out of transition scenarios", () => {
   assert.equal(isMetricApplicable(fpsMetric, "web_navigation"), false);
   assert.equal(isMetricApplicable(fpsMetric, "web_room_scroll"), true);
   assert.equal(isMetricApplicable({}, "web_navigation"), true);
+});
+
+test("normalizes the CI fluidity index without exposing absolute FPS", () => {
+  assert.deepEqual(
+    normalizeHealthIndex([20, null, 22, 18], false),
+    [100, null, 110, 90]
+  );
+  assert.deepEqual(
+    normalizeHealthIndex([800, 880], true),
+    [100, 90.9]
+  );
+  assert.deepEqual(normalizeHealthIndex([null, 0], false), [null, null]);
+});
+
+test("keeps Web fluidity and transition sources independent", () => {
+  assert.deepEqual(
+    metricSelection(
+      { scenario: "web_room_scroll", checkpoint: "scroll_completed" },
+      "web_navigation",
+      "room_opened"
+    ),
+    { scenario: "web_room_scroll", label: "scroll_completed" }
+  );
+  assert.deepEqual(
+    metricSelection({}, "nav_cycles", "room_enter_all"),
+    { scenario: "nav_cycles", label: "room_enter_all" }
+  );
 });
 
 test("uses the final cycle RSS for the room-opening summary", () => {

--- a/scripts/perf/tests/test_dashboard_metrics.js
+++ b/scripts/perf/tests/test_dashboard_metrics.js
@@ -19,6 +19,7 @@ const {
   maximumMarkerDelta,
   metricSelection,
   normalizeHealthIndex,
+  platformDataCandidates,
   platformDataPaths,
   platformRecordCacheKey,
   shouldFallbackToWeb,
@@ -190,6 +191,35 @@ test("keeps Android and Web history paths and families separate", () => {
     records: "data/web",
     family: "web",
   });
+});
+
+test("loads canonical Android history when running from a performance preview", () => {
+  assert.deepEqual(
+    platformDataCandidates(
+      "android",
+      "/twake-on-matrix/performance-previews/feat-patrol-web-performance-pages/"
+    ),
+    [
+      {
+        index: "data/index.json",
+        records: "data",
+        family: "memory",
+      },
+      {
+        index: "/twake-on-matrix/performance/data/index.json",
+        records: "/twake-on-matrix/performance/data",
+        family: "memory",
+      },
+    ]
+  );
+  assert.deepEqual(
+    platformDataCandidates("web", "/twake-on-matrix/performance-previews/foo/"),
+    [{
+      index: "data/web/index.json",
+      records: "data/web",
+      family: "web",
+    }]
+  );
 });
 
 test("keeps platform caches and asynchronous loads isolated", () => {

--- a/scripts/perf/tests/test_update_web_history.py
+++ b/scripts/perf/tests/test_update_web_history.py
@@ -1,0 +1,128 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.perf.update_web_history import (
+    WebHistoryError,
+    WebMetadata,
+    build_daily_record,
+    parse_environment,
+    update_history,
+)
+
+
+def checkpoint(fps: float = 60.0) -> dict:
+    result = {
+        "scenario": "web_navigation",
+        "label": "room_opened",
+        "sample_count": 3,
+    }
+    metrics = {
+        "frame_count": 60.0,
+        "fps": fps,
+        "frame_interval_p95_ms": 17.0,
+        "frame_interval_p99_ms": 18.0,
+        "slow_frame_rate": 0.02,
+        "long_task_total_ms": 10.0,
+    }
+    for key, value in metrics.items():
+        result[key] = value
+        result[f"{key}_values"] = [value - 1, value, value + 1]
+        result[f"{key}_stddev"] = 1.0
+        result[f"{key}_range"] = 2.0
+    return result
+
+
+def metadata(day: str = "2026-07-24", sha: str = "abc") -> WebMetadata:
+    return WebMetadata(
+        day=day,
+        generated_at=f"{day}T02:30:00Z",
+        repository="linagora/twake-on-matrix",
+        sha=sha,
+        run_id="123",
+        flutter_version="3.38.9",
+        patrol_version="4.3.1",
+        runner_image="ubuntu-24.04",
+    )
+
+
+ENVIRONMENT = {
+    "user_agent": "Mozilla/5.0 HeadlessChrome/140.0.1.2 Safari/537.36",
+    "viewport": {"width": 1440, "height": 900, "device_pixel_ratio": 1},
+    "renderer": "canvas",
+}
+
+
+class UpdateWebHistoryTest(unittest.TestCase):
+    def test_builds_versioned_record_with_environment_and_raw_values(self) -> None:
+        record = build_daily_record([checkpoint()], ENVIRONMENT, metadata())
+
+        self.assertEqual(record["schema_version"], 1)
+        self.assertEqual(record["web"]["aggregation"], "median")
+        self.assertEqual(record["web"]["repetitions"], 3)
+        self.assertEqual(record["environment"]["browser"]["version"], "140.0.1.2")
+        self.assertEqual(record["web"]["checkpoints"][0]["fps_values"], [59, 60, 61])
+
+    def test_rejects_partial_or_invalid_result(self) -> None:
+        partial = checkpoint()
+        partial["sample_count"] = 2
+        with self.assertRaises(WebHistoryError):
+            build_daily_record([partial], ENVIRONMENT, metadata())
+
+        missing = checkpoint()
+        del missing["fps_values"]
+        with self.assertRaises(WebHistoryError):
+            build_daily_record([missing], ENVIRONMENT, metadata())
+
+    def test_history_is_sorted_and_same_day_is_replaced(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            data = Path(directory)
+            later = build_daily_record([checkpoint()], ENVIRONMENT, metadata())
+            earlier = build_daily_record(
+                [checkpoint(55.0)],
+                ENVIRONMENT,
+                metadata("2026-07-23", "older"),
+            )
+            update_history(data, later)
+            index = update_history(data, earlier)
+            self.assertEqual(
+                [entry["date"] for entry in index["entries"]],
+                ["2026-07-23", "2026-07-24"],
+            )
+
+            replacement = build_daily_record(
+                [checkpoint(61.0)],
+                ENVIRONMENT,
+                metadata("2026-07-24", "replacement"),
+            )
+            index = update_history(data, replacement)
+            self.assertEqual(len(index["entries"]), 2)
+            self.assertEqual(index["entries"][1]["sha"], "replacement")
+
+    def test_rejects_future_index_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            data = Path(directory)
+            (data / "index.json").write_text(
+                '{"schema_version": 2, "entries": []}',
+                encoding="utf-8",
+            )
+            with self.assertRaises(WebHistoryError):
+                update_history(
+                    data,
+                    build_daily_record([checkpoint()], ENVIRONMENT, metadata()),
+                )
+
+    def test_parses_environment_from_prefixed_log_line(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            log = Path(directory) / "web.log"
+            log.write_text(
+                'browser: PERF_WEB_ENV | {"user_agent":"Chrome/140.0",'
+                '"viewport":{"width":1440,"height":900,"device_pixel_ratio":1},'
+                '"renderer":"canvas"}\n',
+                encoding="utf-8",
+            )
+            self.assertEqual(parse_environment(log)["renderer"], "canvas")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/perf/update_web_history.py
+++ b/scripts/perf/update_web_history.py
@@ -115,14 +115,13 @@ def _validate_metadata(metadata: WebMetadata) -> None:
 
 def _validate_values(checkpoint: dict, metric: str, location: str) -> None:
     values = checkpoint.get(f"{metric}_values")
-    if (
-        not isinstance(values, list)
-        or len(values) != REPETITIONS
-        or not all(_finite_number(value) for value in values)
-    ):
-        raise WebHistoryError(
-            f"{location}.{metric}_values must contain {REPETITIONS} finite values"
-        )
+    error = f"{location}.{metric}_values must contain {REPETITIONS} finite values"
+    if not isinstance(values, list):
+        raise WebHistoryError(error)
+    if len(values) != REPETITIONS:
+        raise WebHistoryError(error)
+    if not all(_finite_number(value) for value in values):
+        raise WebHistoryError(error)
 
 
 def _validate_identity(checkpoint: dict, identity: str, location: str) -> None:

--- a/scripts/perf/update_web_history.py
+++ b/scripts/perf/update_web_history.py
@@ -213,10 +213,22 @@ def build_daily_record(
     }
 
 
-def _load_index(path: Path) -> dict:
-    if not path.exists():
-        return {"schema_version": SCHEMA_VERSION, "updated_at": None, "entries": []}
-    index = _load_json(path)
+def _empty_index() -> dict:
+    return {"schema_version": SCHEMA_VERSION, "updated_at": None, "entries": []}
+
+
+def _validate_index_entry(entry: Any, path: Path) -> None:
+    if not isinstance(entry, dict):
+        raise WebHistoryError(f"Malformed history index entry in {path}")
+    if entry.get("file") != f"{entry.get('date')}.json":
+        raise WebHistoryError(f"Malformed history index entry in {path}")
+    try:
+        date.fromisoformat(entry["date"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise WebHistoryError(f"Malformed history index date in {path}") from error
+
+
+def _validate_index(index: Any, path: Path) -> dict:
     if (
         not isinstance(index, dict)
         or index.get("schema_version") != SCHEMA_VERSION
@@ -224,16 +236,14 @@ def _load_index(path: Path) -> dict:
     ):
         raise WebHistoryError(f"Unsupported history index schema in {path}")
     for entry in index["entries"]:
-        if (
-            not isinstance(entry, dict)
-            or entry.get("file") != f"{entry.get('date')}.json"
-        ):
-            raise WebHistoryError(f"Malformed history index entry in {path}")
-        try:
-            date.fromisoformat(entry["date"])
-        except (KeyError, TypeError, ValueError) as error:
-            raise WebHistoryError(f"Malformed history index date in {path}") from error
+        _validate_index_entry(entry, path)
     return index
+
+
+def _load_index(path: Path) -> dict:
+    if not path.exists():
+        return _empty_index()
+    return _validate_index(_load_json(path), path)
 
 
 def update_history(data_directory: Path, record: dict) -> dict:

--- a/scripts/perf/update_web_history.py
+++ b/scripts/perf/update_web_history.py
@@ -57,16 +57,17 @@ def _finite_number(value: Any) -> bool:
     )
 
 
-def parse_environment(log_path: Path) -> dict:
-    environments = []
-    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
-        marker = line.find(ENV_PREFIX)
-        if marker < 0:
-            continue
-        try:
-            environments.append(json.loads(line[marker + len(ENV_PREFIX) :]))
-        except json.JSONDecodeError as error:
-            raise WebHistoryError("Malformed PERF_WEB_ENV payload") from error
+def _parse_environment_line(line: str) -> Any | None:
+    marker = line.find(ENV_PREFIX)
+    if marker < 0:
+        return None
+    try:
+        return json.loads(line[marker + len(ENV_PREFIX) :])
+    except json.JSONDecodeError as error:
+        raise WebHistoryError("Malformed PERF_WEB_ENV payload") from error
+
+
+def _validate_environment_payloads(environments: list[Any]) -> dict:
     if not environments:
         raise WebHistoryError("Missing PERF_WEB_ENV payload")
     first = environments[0]
@@ -75,6 +76,19 @@ def parse_environment(log_path: Path) -> dict:
     if not isinstance(first, dict):
         raise WebHistoryError("PERF_WEB_ENV must be an object")
     return first
+
+
+def parse_environment(log_path: Path) -> dict:
+    lines = log_path.read_text(
+        encoding="utf-8",
+        errors="replace",
+    ).splitlines()
+    environments = [
+        payload
+        for line in lines
+        if (payload := _parse_environment_line(line)) is not None
+    ]
+    return _validate_environment_payloads(environments)
 
 
 def _browser_version(user_agent: str) -> str:

--- a/scripts/perf/update_web_history.py
+++ b/scripts/perf/update_web_history.py
@@ -258,11 +258,11 @@ def _validate_index_entry(entry: Any, path: Path) -> None:
 
 
 def _validate_index(index: Any, path: Path) -> dict:
-    if (
-        not isinstance(index, dict)
-        or index.get("schema_version") != SCHEMA_VERSION
-        or not isinstance(index.get("entries"), list)
-    ):
+    if not isinstance(index, dict):
+        raise WebHistoryError(f"Unsupported history index schema in {path}")
+    if index.get("schema_version") != SCHEMA_VERSION:
+        raise WebHistoryError(f"Unsupported history index schema in {path}")
+    if not isinstance(index.get("entries"), list):
         raise WebHistoryError(f"Unsupported history index schema in {path}")
     for entry in index["entries"]:
         _validate_index_entry(entry, path)
@@ -275,18 +275,29 @@ def _load_index(path: Path) -> dict:
     return _validate_index(_load_json(path), path)
 
 
+def _validate_persisted_record(
+    data_directory: Path,
+    entry: dict,
+) -> None:
+    persisted = _load_json(data_directory / entry["file"])
+    if not isinstance(persisted, dict):
+        raise WebHistoryError(f"Malformed persisted record {entry['file']}")
+    if persisted.get("schema_version") != SCHEMA_VERSION:
+        raise WebHistoryError(f"Malformed persisted record {entry['file']}")
+    if persisted.get("date") != entry["date"]:
+        raise WebHistoryError(f"Malformed persisted record {entry['file']}")
+
+
+def _validate_persisted_history(data_directory: Path, index: dict) -> None:
+    for entry in index["entries"]:
+        _validate_persisted_record(data_directory, entry)
+
+
 def update_history(data_directory: Path, record: dict) -> dict:
     data_directory.mkdir(parents=True, exist_ok=True)
     index_path = data_directory / "index.json"
     index = _load_index(index_path)
-    for entry in index["entries"]:
-        persisted = _load_json(data_directory / entry["file"])
-        if (
-            not isinstance(persisted, dict)
-            or persisted.get("schema_version") != SCHEMA_VERSION
-            or persisted.get("date") != entry["date"]
-        ):
-            raise WebHistoryError(f"Malformed persisted record {entry['file']}")
+    _validate_persisted_history(data_directory, index)
     day = record["date"]
     file_name = f"{day}.json"
     (data_directory / file_name).write_text(

--- a/scripts/perf/update_web_history.py
+++ b/scripts/perf/update_web_history.py
@@ -111,33 +111,57 @@ def _validate_values(checkpoint: dict, metric: str, location: str) -> None:
         )
 
 
+def _validate_identity(checkpoint: dict, identity: str, location: str) -> None:
+    value = checkpoint.get(identity)
+    if not isinstance(value, str) or not value:
+        raise WebHistoryError(f"{location}.{identity} must be non-empty")
+
+
+def _validate_numeric_metric(key: str, metric: Any, location: str) -> None:
+    if key in {"scenario", "label"} or key.endswith("_values"):
+        return
+    if not _finite_number(metric):
+        raise WebHistoryError(f"{location}.{key} must be finite")
+
+
+def _validate_required_metric(
+    checkpoint: dict,
+    metric: str,
+    location: str,
+) -> None:
+    if not _finite_number(checkpoint.get(metric)):
+        raise WebHistoryError(f"{location}.{metric} is required")
+    _validate_values(checkpoint, metric, location)
+
+
+def _validate_raw_value_key(checkpoint: dict, key: str, location: str) -> None:
+    if key.endswith("_values"):
+        _validate_values(checkpoint, key.removesuffix("_values"), location)
+
+
+def _validate_checkpoint(checkpoint: Any, location: str) -> dict:
+    if not isinstance(checkpoint, dict):
+        raise WebHistoryError(f"{location} must be an object")
+    if checkpoint.get("sample_count") != REPETITIONS:
+        raise WebHistoryError(f"{location} must aggregate exactly 3 repetitions")
+    for identity in ("scenario", "label"):
+        _validate_identity(checkpoint, identity, location)
+    for key, metric in checkpoint.items():
+        _validate_numeric_metric(key, metric, location)
+    for metric in REQUIRED_METRICS:
+        _validate_required_metric(checkpoint, metric, location)
+    for key in checkpoint:
+        _validate_raw_value_key(checkpoint, key, location)
+    return checkpoint
+
+
 def validate_checkpoints(value: Any) -> list[dict]:
     if not isinstance(value, list) or not value:
         raise WebHistoryError("web must contain a non-empty checkpoint list")
-    validated = []
-    for position, checkpoint in enumerate(value):
-        location = f"web[{position}]"
-        if not isinstance(checkpoint, dict):
-            raise WebHistoryError(f"{location} must be an object")
-        if checkpoint.get("sample_count") != REPETITIONS:
-            raise WebHistoryError(f"{location} must aggregate exactly 3 repetitions")
-        for identity in ("scenario", "label"):
-            if not isinstance(checkpoint.get(identity), str) or not checkpoint[identity]:
-                raise WebHistoryError(f"{location}.{identity} must be non-empty")
-        for key, metric in checkpoint.items():
-            if key in {"scenario", "label"} or key.endswith("_values"):
-                continue
-            if not _finite_number(metric):
-                raise WebHistoryError(f"{location}.{key} must be finite")
-        for metric in REQUIRED_METRICS:
-            if not _finite_number(checkpoint.get(metric)):
-                raise WebHistoryError(f"{location}.{metric} is required")
-            _validate_values(checkpoint, metric, location)
-        for key in checkpoint:
-            if key.endswith("_values"):
-                _validate_values(checkpoint, key.removesuffix("_values"), location)
-        validated.append(checkpoint)
-    return validated
+    return [
+        _validate_checkpoint(checkpoint, f"web[{position}]")
+        for position, checkpoint in enumerate(value)
+    ]
 
 
 def build_daily_record(

--- a/scripts/perf/update_web_history.py
+++ b/scripts/perf/update_web_history.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Build and persist one versioned daily Patrol Web performance record."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+REPETITIONS = 3
+ENV_PREFIX = "PERF_WEB_ENV | "
+REQUIRED_METRICS = (
+    "frame_count",
+    "fps",
+    "frame_interval_p95_ms",
+    "frame_interval_p99_ms",
+    "slow_frame_rate",
+    "long_task_total_ms",
+)
+
+
+class WebHistoryError(ValueError):
+    """Raised when a Web result is incomplete or unsafe to publish."""
+
+
+@dataclass(frozen=True)
+class WebMetadata:
+    day: str
+    generated_at: str
+    repository: str
+    sha: str
+    run_id: str
+    flutter_version: str
+    patrol_version: str
+    runner_image: str
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise WebHistoryError(f"Cannot read valid JSON from {path}: {error}") from error
+
+
+def _finite_number(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+    )
+
+
+def parse_environment(log_path: Path) -> dict:
+    environments = []
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        marker = line.find(ENV_PREFIX)
+        if marker < 0:
+            continue
+        try:
+            environments.append(json.loads(line[marker + len(ENV_PREFIX) :]))
+        except json.JSONDecodeError as error:
+            raise WebHistoryError("Malformed PERF_WEB_ENV payload") from error
+    if not environments:
+        raise WebHistoryError("Missing PERF_WEB_ENV payload")
+    first = environments[0]
+    if any(environment != first for environment in environments[1:]):
+        raise WebHistoryError("Browser environment changed during the benchmark")
+    if not isinstance(first, dict):
+        raise WebHistoryError("PERF_WEB_ENV must be an object")
+    return first
+
+
+def _browser_version(user_agent: str) -> str:
+    match = re.search(r"(?:HeadlessChrome|Chrome)/([0-9.]+)", user_agent)
+    return match.group(1) if match else "unknown"
+
+
+def _validate_metadata(metadata: WebMetadata) -> None:
+    try:
+        date.fromisoformat(metadata.day)
+        datetime.fromisoformat(metadata.generated_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise WebHistoryError("Invalid date or generated_at timestamp") from error
+    required = (
+        metadata.sha,
+        metadata.run_id,
+        metadata.flutter_version,
+        metadata.patrol_version,
+        metadata.runner_image,
+    )
+    if "/" not in metadata.repository or not all(required):
+        raise WebHistoryError("Incomplete Web run metadata")
+
+
+def _validate_values(checkpoint: dict, metric: str, location: str) -> None:
+    values = checkpoint.get(f"{metric}_values")
+    if (
+        not isinstance(values, list)
+        or len(values) != REPETITIONS
+        or not all(_finite_number(value) for value in values)
+    ):
+        raise WebHistoryError(
+            f"{location}.{metric}_values must contain {REPETITIONS} finite values"
+        )
+
+
+def validate_checkpoints(value: Any) -> list[dict]:
+    if not isinstance(value, list) or not value:
+        raise WebHistoryError("web must contain a non-empty checkpoint list")
+    validated = []
+    for position, checkpoint in enumerate(value):
+        location = f"web[{position}]"
+        if not isinstance(checkpoint, dict):
+            raise WebHistoryError(f"{location} must be an object")
+        if checkpoint.get("sample_count") != REPETITIONS:
+            raise WebHistoryError(f"{location} must aggregate exactly 3 repetitions")
+        for identity in ("scenario", "label"):
+            if not isinstance(checkpoint.get(identity), str) or not checkpoint[identity]:
+                raise WebHistoryError(f"{location}.{identity} must be non-empty")
+        for key, metric in checkpoint.items():
+            if key in {"scenario", "label"} or key.endswith("_values"):
+                continue
+            if not _finite_number(metric):
+                raise WebHistoryError(f"{location}.{key} must be finite")
+        for metric in REQUIRED_METRICS:
+            if not _finite_number(checkpoint.get(metric)):
+                raise WebHistoryError(f"{location}.{metric} is required")
+            _validate_values(checkpoint, metric, location)
+        for key in checkpoint:
+            if key.endswith("_values"):
+                _validate_values(checkpoint, key.removesuffix("_values"), location)
+        validated.append(checkpoint)
+    return validated
+
+
+def build_daily_record(
+    checkpoints: Any,
+    environment: dict,
+    metadata: WebMetadata,
+) -> dict:
+    _validate_metadata(metadata)
+    validated = validate_checkpoints(checkpoints)
+    user_agent = environment.get("user_agent")
+    viewport = environment.get("viewport")
+    if not isinstance(user_agent, str) or not isinstance(viewport, dict):
+        raise WebHistoryError("Browser user agent and viewport are required")
+    for key in ("width", "height", "device_pixel_ratio"):
+        if not _finite_number(viewport.get(key)):
+            raise WebHistoryError(f"environment.viewport.{key} must be finite")
+    repository_url = f"https://github.com/{metadata.repository}"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "date": metadata.day,
+        "generated_at": metadata.generated_at,
+        "commit": {
+            "sha": metadata.sha,
+            "url": f"{repository_url}/commit/{metadata.sha}",
+        },
+        "run": {
+            "id": str(metadata.run_id),
+            "url": f"{repository_url}/actions/runs/{metadata.run_id}",
+        },
+        "environment": {
+            "platform": "web",
+            "build_mode": "profile",
+            "flutter_version": metadata.flutter_version,
+            "patrol_version": metadata.patrol_version,
+            "browser": {
+                "name": "chromium",
+                "version": _browser_version(user_agent),
+                "user_agent": user_agent,
+            },
+            "runner": {"image": metadata.runner_image},
+            "viewport": viewport,
+            "renderer": environment.get("renderer", "unknown"),
+        },
+        "web": {
+            "aggregation": "median",
+            "repetitions": REPETITIONS,
+            "checkpoints": validated,
+        },
+    }
+
+
+def _load_index(path: Path) -> dict:
+    if not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "updated_at": None, "entries": []}
+    index = _load_json(path)
+    if (
+        not isinstance(index, dict)
+        or index.get("schema_version") != SCHEMA_VERSION
+        or not isinstance(index.get("entries"), list)
+    ):
+        raise WebHistoryError(f"Unsupported history index schema in {path}")
+    for entry in index["entries"]:
+        if (
+            not isinstance(entry, dict)
+            or entry.get("file") != f"{entry.get('date')}.json"
+        ):
+            raise WebHistoryError(f"Malformed history index entry in {path}")
+        try:
+            date.fromisoformat(entry["date"])
+        except (KeyError, TypeError, ValueError) as error:
+            raise WebHistoryError(f"Malformed history index date in {path}") from error
+    return index
+
+
+def update_history(data_directory: Path, record: dict) -> dict:
+    data_directory.mkdir(parents=True, exist_ok=True)
+    index_path = data_directory / "index.json"
+    index = _load_index(index_path)
+    for entry in index["entries"]:
+        persisted = _load_json(data_directory / entry["file"])
+        if (
+            not isinstance(persisted, dict)
+            or persisted.get("schema_version") != SCHEMA_VERSION
+            or persisted.get("date") != entry["date"]
+        ):
+            raise WebHistoryError(f"Malformed persisted record {entry['file']}")
+    day = record["date"]
+    file_name = f"{day}.json"
+    (data_directory / file_name).write_text(
+        json.dumps(record, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    entries = {entry["date"]: entry for entry in index["entries"]}
+    entries[day] = {
+        "date": day,
+        "file": file_name,
+        "sha": record["commit"]["sha"],
+        "run_id": record["run"]["id"],
+    }
+    index["entries"] = [entries[key] for key in sorted(entries)]
+    index["updated_at"] = record["generated_at"]
+    index_path.write_text(json.dumps(index, indent=2) + "\n", encoding="utf-8")
+    return index
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--web", type=Path, required=True)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--data-directory", type=Path, required=True)
+    parser.add_argument("--date", required=True)
+    parser.add_argument("--generated-at", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--flutter-version", required=True)
+    parser.add_argument("--patrol-version", required=True)
+    parser.add_argument("--runner-image", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = _arguments()
+    record = build_daily_record(
+        _load_json(arguments.web),
+        parse_environment(arguments.log),
+        WebMetadata(
+            day=arguments.date,
+            generated_at=arguments.generated_at,
+            repository=arguments.repository,
+            sha=arguments.sha,
+            run_id=arguments.run_id,
+            flutter_version=arguments.flutter_version,
+            patrol_version=arguments.patrol_version,
+            runner_image=arguments.runner_image,
+        ),
+    )
+    update_history(arguments.data_directory, record)
+    print(
+        f"Published Web performance point {record['date']} "
+        f"with {len(record['web']['checkpoints'])} checkpoint(s)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/perf/update_web_history.py
+++ b/scripts/perf/update_web_history.py
@@ -153,19 +153,35 @@ def _validate_raw_value_key(checkpoint: dict, key: str, location: str) -> None:
         _validate_values(checkpoint, key.removesuffix("_values"), location)
 
 
+def _validate_identities(checkpoint: dict, location: str) -> None:
+    for identity in ("scenario", "label"):
+        _validate_identity(checkpoint, identity, location)
+
+
+def _validate_numeric_metrics(checkpoint: dict, location: str) -> None:
+    for key, metric in checkpoint.items():
+        _validate_numeric_metric(key, metric, location)
+
+
+def _validate_required_metrics(checkpoint: dict, location: str) -> None:
+    for metric in REQUIRED_METRICS:
+        _validate_required_metric(checkpoint, metric, location)
+
+
+def _validate_raw_values(checkpoint: dict, location: str) -> None:
+    for key in checkpoint:
+        _validate_raw_value_key(checkpoint, key, location)
+
+
 def _validate_checkpoint(checkpoint: Any, location: str) -> dict:
     if not isinstance(checkpoint, dict):
         raise WebHistoryError(f"{location} must be an object")
     if checkpoint.get("sample_count") != REPETITIONS:
         raise WebHistoryError(f"{location} must aggregate exactly 3 repetitions")
-    for identity in ("scenario", "label"):
-        _validate_identity(checkpoint, identity, location)
-    for key, metric in checkpoint.items():
-        _validate_numeric_metric(key, metric, location)
-    for metric in REQUIRED_METRICS:
-        _validate_required_metric(checkpoint, metric, location)
-    for key in checkpoint:
-        _validate_raw_value_key(checkpoint, key, location)
+    _validate_identities(checkpoint, location)
+    _validate_numeric_metrics(checkpoint, location)
+    _validate_required_metrics(checkpoint, location)
+    _validate_raw_values(checkpoint, location)
     return checkpoint
 
 

--- a/test/integration_test/base/web_perf_metrics_test.dart
+++ b/test/integration_test/base/web_perf_metrics_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../integration_test/base/web_perf_metrics.dart';
+
+void main() {
+  test(
+    'computes FPS and percentiles from requestAnimationFrame timestamps',
+    () {
+      final timestamps = List.generate(31, (index) => index * 16.667);
+
+      final metrics = computeWebPerfMetrics(frameTimestampsMs: timestamps);
+
+      expect(metrics['frame_count'], 31);
+      expect(metrics['fps'], closeTo(60, 0.1));
+      expect(metrics['frame_interval_p50_ms'], closeTo(16.667, 0.001));
+      expect(metrics['frame_interval_p95_ms'], closeTo(16.667, 0.001));
+      expect(metrics['frame_interval_p99_ms'], closeTo(16.667, 0.001));
+      expect(metrics['slow_frame_count'], 0);
+    },
+  );
+
+  test('uses the median interval to classify slow browser frames', () {
+    final metrics = computeWebPerfMetrics(frameTimestampsMs: [0, 16, 32, 72]);
+
+    expect(metrics['expected_frame_interval_ms'], 16);
+    expect(metrics['slow_frame_count'], 1);
+    expect(metrics['slow_frame_rate'], closeTo(1 / 3, 0.001));
+  });
+
+  test('records long tasks and optional Chrome JS heap', () {
+    final metrics = computeWebPerfMetrics(
+      frameTimestampsMs: [0, 16],
+      longTaskDurationsMs: [51, 75],
+      jsHeapUsedBytes: 123456,
+    );
+
+    expect(metrics['long_task_count'], 2);
+    expect(metrics['long_task_total_ms'], 126);
+    expect(metrics['long_task_max_ms'], 75);
+    expect(metrics['js_heap_used_bytes'], 123456);
+  });
+
+  test('omits unavailable JS heap and handles an empty frame window', () {
+    final metrics = computeWebPerfMetrics(frameTimestampsMs: const []);
+
+    expect(metrics['frame_count'], 0);
+    expect(metrics['fps'], 0);
+    expect(metrics.containsKey('js_heap_used_bytes'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- run a three-repetition Patrol Web profile benchmark after successful nightly E2E jobs
- aggregate and persist a separate Web performance history in GitHub Pages
- add an Android FTL / Web Chrome selector with independent regression baselines

## Validation
- Flutter analyzer and focused Dart tests
- 17 Python tests
- 9 Node dashboard tests
- actionlint
- local desktop and mobile dashboard validation

Follow-up to #3283, which is already merged.

## Dependency and GitHub Pages safety

- #3283 is already merged and provides the shared `gh-pages-writes` concurrency group for every existing Pages writer.
- #3283 also removed `force_orphan` from PR preview deployments so publishing one destination preserves the other preview and performance directories.
- This PR does not duplicate those global workflow changes. Its new Web performance publisher reuses the existing `gh-pages-writes` group and `keep_files: true` contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Web performance benchmarking and median aggregation, with artifact upload and validation.
  * Added optional publishing of Web performance history to the dashboard, including new Web scenarios/checkpoints.
  * Introduced browser-based Web performance collection and a web-only performance test; added optional performance fixture message seeding for repeatable runs.
  * Updated the performance dashboard with Android/Web platform selection and long-task web diagnostics.
* **Bug Fixes**
  * Improved Web history and checkpoint validation to prevent publishing incomplete or malformed benchmark data.
* **Tests**
  * Expanded unit/integration coverage for Web metric aggregation, dashboard logic/gating, and Web history updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->