### PR TITLE
fix(ci): build profile instrumentation APK

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -220,6 +220,7 @@ jobs:
       - name: Build perf test APK
         env:
           INTEGRATION_TEST_ENV_BASE64: ${{ secrets.INTEGRATION_TEST_ENV_BASE64 }}
+          ORG_GRADLE_PROJECT_patrolTestBuildType: profile
         run: |
           dart pub global activate patrol_cli 4.3.1
           flutter build apk --config-only

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,6 +86,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    // Android only creates instrumentation-test tasks for testBuildType.
+    // Keep debug as the default and let performance CI opt into profile.
+    testBuildType project.findProperty('patrolTestBuildType') ?: 'debug'
     testOptions {
         execution "ANDROIDX_TEST_ORCHESTRATOR"
     }


### PR DESCRIPTION
## What changed

- make Android's instrumentation testBuildType configurable while keeping debug as the default
- opt the FTL performance build into the profile instrumentation variant

## Root cause

The performance workflow invoked Patrol with --profile. Patrol successfully built app-profile.apk, then failed because Gradle had not generated :app:assembleProfileAndroidTest; Android only generated the default debugAndroidTest variant.

## Impact

The performance APK and its instrumentation APK can now be built in profile mode, allowing the FTL median jobs and the GitHub Pages publication job to run.

## Validation

- ./gradlew :app:tasks --all -PpatrolTestBuildType=profile exposes assembleProfileAndroidTest
- the default Gradle configuration still exposes assembleDebugAndroidTest
- actionlint .github/workflows/integration-tests.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android instrumentation test configuration by explicitly selecting the build type used for tests.
  * Performance APK builds now use the profile build configuration for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->