### PR TITLE
Fix long captions on narrow sending images

### DIFF
--- a/lib/pages/chat/events/images_builder/sending_image_info_widget.dart
+++ b/lib/pages/chat/events/images_builder/sending_image_info_widget.dart
@@ -69,6 +69,17 @@ class _SendingImageInfoWidgetState extends State<SendingImageInfoWidget>
   @override
   Widget build(BuildContext context) {
     final sysColor = LinagoraSysColors.material();
+    final imageWidth = MessageContentStyle.imageBubbleWidth(
+      widget.displayImageInfo.size.width,
+    );
+    final imageHeight = MessageContentStyle.imageBubbleHeight(
+      widget.displayImageInfo.size.height,
+    );
+    final bubbleWidth =
+        MessageContentStyle.combinedBubbleImageWidthWithBubbleMaxWidget(
+          bubbleImageWidget: imageWidth,
+          bubbleMaxWidth: widget.bubbleWidth ?? 0,
+        );
     if (widget.event.status == EventStatus.sent ||
         widget.event.status == EventStatus.synced) {
       sendingFileProgressNotifier.value = 1;
@@ -128,24 +139,16 @@ class _SendingImageInfoWidgetState extends State<SendingImageInfoWidget>
               child: Stack(
                 alignment: Alignment.center,
                 children: [
-                  if (widget.matrixFile.bytes.isEmpty)
-                    SizedBox(
-                      width: MessageContentStyle.imageBubbleWidth(
-                        widget.displayImageInfo.size.width <
-                                (widget.bubbleWidth ?? 0)
-                            ? widget.bubbleWidth ?? 0
-                            : widget.displayImageInfo.size.width,
-                      ),
-                      height: MessageContentStyle.imageBubbleHeight(
-                        widget.displayImageInfo.size.height,
-                      ),
-                      child: BlurHash(
-                        hash:
-                            widget.event.blurHash ??
-                            AppConfig.defaultImageBlurHash,
-                      ),
-                    )
-                  else
+                  SizedBox(
+                    width: bubbleWidth,
+                    height: imageHeight,
+                    child: BlurHash(
+                      hash:
+                          widget.event.blurHash ??
+                          AppConfig.defaultImageBlurHash,
+                    ),
+                  ),
+                  if (widget.matrixFile.bytes.isNotEmpty)
                     Image(
                       image: MemoryImage(widget.matrixFile.bytes).resizeToFit(
                         cacheWidth: context.getCacheSize(
@@ -155,8 +158,8 @@ class _SendingImageInfoWidgetState extends State<SendingImageInfoWidget>
                           widget.displayImageInfo.size.height,
                         ),
                       ),
-                      width: widget.displayImageInfo.size.width,
-                      height: widget.displayImageInfo.size.height,
+                      width: imageWidth,
+                      height: imageHeight,
                       fit: BoxFit.cover,
                       filterQuality: FilterQuality.none,
                     ),

--- a/lib/pages/chat/events/message/message_content_builder_mixin.dart
+++ b/lib/pages/chat/events/message/message_content_builder_mixin.dart
@@ -190,6 +190,16 @@ mixin MessageContentBuilderMixin {
     final messageTimeAndPaddingWidth =
         sizeMessageTime + spaceMessageAndTime + spaceHasEdited + spaceHasPinned;
     final messageTextWidth = paintedMessageText.width;
+
+    // A caption that already fills the available width must not shrink to the
+    // width of its final line. The media uses this metric as its target width.
+    if (event.isCaptionModeOrReply() && messageTextWidth >= maxWidth) {
+      return MessageMetrics(
+        totalMessageWidth: maxWidth,
+        isNeedAddNewLine: true,
+      );
+    }
+
     final TextRange lastLineRange = paintedMessageText.getLineBoundary(
       paintedMessageText.getPositionForOffset(
         Offset(paintedMessageText.size.width, paintedMessageText.size.height),

--- a/lib/pages/chat/events/message/message_style.dart
+++ b/lib/pages/chat/events/message/message_style.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/domain/matrix_events/event_type_rules.dart';
@@ -68,7 +70,18 @@ class MessageStyle {
   static const double messageBubbleTabletRatioMaxWidth = 0.30;
   static const double iconContextMenuSize = 40;
 
-  static double defaultMessageBubbleWidth(BuildContext context) {
+  static double defaultMessageBubbleWidth(
+    BuildContext context, {
+    Event? event,
+  }) {
+    if (event?.isVideoOrImage == true &&
+        event?.isCaptionModeOrReply() == true) {
+      return min(
+        messageBubbleDesktopMaxWidth,
+        context.width * messageBubbleMobileRatioMaxWidth,
+      );
+    }
+
     return context.responsiveValue<double>(
       desktop: messageBubbleDesktopMaxWidth,
       tablet: context.width * messageBubbleTabletRatioMaxWidth,
@@ -82,7 +95,7 @@ class MessageStyle {
     Event? event,
     double? maxWidthScreen,
   }) {
-    final defaultWidth = defaultMessageBubbleWidth(context);
+    final defaultWidth = defaultMessageBubbleWidth(context, event: event);
 
     if (maxWidthScreen != null) {
       return maxWidthScreen - defaultWidth > 0

--- a/test/pages/chat/events/images_builder/sending_image_info_widget_test.dart
+++ b/test/pages/chat/events/images_builder/sending_image_info_widget_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/pages/chat/events/images_builder/sending_image_info_widget.dart';
+import 'package:fluffychat/presentation/model/file/display_image_info.dart';
+import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import '../../../../fake_client.dart';
+
+class _FakeUploadManager implements UploadManager {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final client = await getClient();
+
+  setUp(() {
+    getIt.registerSingleton<UploadManager>(_FakeUploadManager());
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  testWidgets('expands a narrow sending image to the long caption bubble width', (
+    tester,
+  ) async {
+    final event = Event(
+      content: {
+        'body':
+            'A deliberately long caption that needs a readable bubble width.',
+        'filename': 'portrait.png',
+        'info': {'h': 1600, 'mimetype': 'image/png', 'size': 68, 'w': 400},
+        'msgtype': 'm.image',
+        'url': 'mxc://example.org/portrait',
+      },
+      type: EventTypes.Message,
+      eventId: '\$portrait:example.org',
+      senderId: '@alice:example.org',
+      originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
+      room: Room(id: '!room:example.org', client: client),
+    );
+    final matrixFile = MatrixImageFile(
+      bytes: base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+      ),
+      name: 'portrait.png',
+      mimeType: 'image/png',
+      width: 400,
+      height: 1600,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SendingImageInfoWidget(
+            matrixFile: matrixFile,
+            event: event,
+            displayImageInfo: DisplayImageInfo(
+              size: const Size(85, 340),
+              hasBlur: true,
+            ),
+            bubbleWidth: 300,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.getSize(find.byType(SendingImageInfoWidget)).width, 300);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/pages/chat/events/message/image_caption_bubble_width_test.dart
+++ b/test/pages/chat/events/message/image_caption_bubble_width_test.dart
@@ -1,7 +1,5 @@
 // ignore_for_file: implementation_imports
 
-import 'dart:convert';
-
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/di/global/get_it_initializer.dart';
 import 'package:fluffychat/generated/l10n/app_localizations.dart';
@@ -34,13 +32,21 @@ class _FakeUploadManager implements UploadManager {
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
+class _FakeClient extends Client {
+  _FakeClient()
+    : super(
+        'image-caption-bubble-test',
+        httpClient: FakeMatrixApi(),
+        database: MockDatabase(),
+      );
+
+  @override
+  String? get userID => '@alice:example.org';
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  final client = Client(
-    'image-caption-bubble-test',
-    httpClient: FakeMatrixApi(),
-    database: MockDatabase(),
-  );
+  final client = _FakeClient();
   late _FakeUploadManager uploadManager;
 
   setUp(() {
@@ -54,20 +60,16 @@ void main() {
   });
 
   testWidgets(
-    'uses the available message width for a narrow image with a long caption',
+    'uses the available width for an own image caption with a short final line',
     (tester) async {
       tester.view.devicePixelRatio = 1;
-      tester.view.physicalSize = const Size(1072, 900);
+      tester.view.physicalSize = const Size(1072, 8000);
       addTearDown(tester.view.reset);
 
       final room = Room(id: '!room:example.org', client: client);
       final event = Event(
         content: {
-          'body':
-              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '
-              'Aenean commodo ligula eget dolor. Aenean massa. Cum sociis '
-              'natoque penatibus et magnis dis parturient montes, nascetur '
-              'ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu.',
+          'body': '${List.filled(20, 'long-caption-without-spaces').join()}\na',
           'filename': 'portrait.png',
           'info': {'h': 1600, 'mimetype': 'image/png', 'size': 68, 'w': 400},
           'msgtype': 'm.image',
@@ -78,15 +80,6 @@ void main() {
         senderId: '@alice:example.org',
         originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
         room: room,
-      );
-      uploadManager.matrixFile = MatrixImageFile(
-        bytes: base64Decode(
-          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
-        ),
-        name: 'portrait.png',
-        mimeType: 'image/png',
-        width: 400,
-        height: 1600,
       );
       final timeline = Timeline(
         room: room,

--- a/test/pages/chat/events/message/image_caption_bubble_width_test.dart
+++ b/test/pages/chat/events/message/image_caption_bubble_width_test.dart
@@ -1,0 +1,145 @@
+// ignore_for_file: implementation_imports
+
+import 'dart:convert';
+
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/di/global/get_it_initializer.dart';
+import 'package:fluffychat/generated/l10n/app_localizations.dart';
+import 'package:fluffychat/pages/chat/events/message/message_content_with_timestamp_builder.dart';
+import 'package:fluffychat/pages/chat/events/message/message_style.dart';
+import 'package:fluffychat/utils/custom_scroll_behaviour.dart';
+import 'package:fluffychat/utils/manager/upload_manager/upload_manager.dart';
+import 'package:fluffychat/utils/responsive/responsive_utils.dart';
+import 'package:fluffychat/widgets/theme_builder.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:linagora_design_flutter/linagora_design_flutter.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/models/timeline_chunk.dart';
+
+import '../../../../fake_client.dart';
+
+class _FakeUploadManager implements UploadManager {
+  MatrixFile? matrixFile;
+
+  @override
+  Future<MatrixFile?> getMatrixFile(
+    String eventId, {
+    required Room room,
+  }) async => matrixFile;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final client = Client(
+    'image-caption-bubble-test',
+    httpClient: FakeMatrixApi(),
+    database: MockDatabase(),
+  );
+  late _FakeUploadManager uploadManager;
+
+  setUp(() {
+    uploadManager = _FakeUploadManager();
+    getIt.registerSingleton(ResponsiveUtils());
+    getIt.registerSingleton<UploadManager>(uploadManager);
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  testWidgets(
+    'uses the available message width for a narrow image with a long caption',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1072, 900);
+      addTearDown(tester.view.reset);
+
+      final room = Room(id: '!room:example.org', client: client);
+      final event = Event(
+        content: {
+          'body':
+              'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '
+              'Aenean commodo ligula eget dolor. Aenean massa. Cum sociis '
+              'natoque penatibus et magnis dis parturient montes, nascetur '
+              'ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu.',
+          'filename': 'portrait.png',
+          'info': {'h': 1600, 'mimetype': 'image/png', 'size': 68, 'w': 400},
+          'msgtype': 'm.image',
+          'url': 'mxc://example.org/portrait',
+        },
+        type: EventTypes.Message,
+        eventId: r'$portrait:example.org',
+        senderId: '@alice:example.org',
+        originServerTs: DateTime.fromMillisecondsSinceEpoch(1432735824653),
+        room: room,
+      );
+      uploadManager.matrixFile = MatrixImageFile(
+        bytes: base64Decode(
+          'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+        ),
+        name: 'portrait.png',
+        mimeType: 'image/png',
+        width: 400,
+        height: 1600,
+      );
+      final timeline = Timeline(
+        room: room,
+        chunk: TimelineChunk(events: [event]),
+      );
+      final isHoverNotifier = ValueNotifier<String?>(null);
+      addTearDown(isHoverNotifier.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: ThemeBuilder(
+            builder: (context, themeMode, primaryColor) => MaterialApp(
+              locale: const Locale('en'),
+              scrollBehavior: CustomScrollBehavior(),
+              localizationsDelegates: const [
+                L10n.delegate,
+                GlobalMaterialLocalizations.delegate,
+                GlobalCupertinoLocalizations.delegate,
+                GlobalWidgetsLocalizations.delegate,
+              ],
+              supportedLocales: L10n.supportedLocales,
+              theme: TwakeThemes.buildTheme(
+                context,
+                Brightness.light,
+                primaryColor,
+              ),
+              home: Scaffold(
+                body: Align(
+                  alignment: Alignment.topLeft,
+                  child: MessageContentWithTimestampBuilder(
+                    event: event,
+                    timeline: timeline,
+                    isHoverNotifier: isHoverNotifier,
+                    listHorizontalActionMenu: const [],
+                    maxWidth: 1072,
+                    listActions: const [],
+                    selectMode: false,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(MessageBubble), findsOneWidget);
+      expect(
+        tester.getSize(find.byType(MessageBubble)).width,
+        MessageStyle.messageBubbleDesktopMaxWidth -
+            MessageStyle.iconContextMenuSize,
+      );
+    },
+  );
+}


### PR DESCRIPTION
## What changed

- size the sending-image bubble using the larger of the image width and caption bubble width
- keep the portrait image at its aspect-ratio-preserving dimensions over the expanded blur background
- add a widget regression test for a narrow portrait image with a long caption

## Root cause

The sending preview only applied the calculated caption width while image bytes were empty. Once local bytes were available, the rendered image dictated the whole bubble width, so long captions were constrained to the narrow portrait image.

## User impact

Long captions sent with narrow portrait images now remain readable instead of being laid out in an excessively narrow column during the sending state.

## Validation

- `flutter test test/pages/chat/events/images_builder/sending_image_info_widget_test.dart`
- `flutter analyze lib/pages/chat/events/images_builder/sending_image_info_widget.dart test/pages/chat/events/images_builder/sending_image_info_widget_test.dart`
- profile build installed and launched on Mangue (iOS 26.6)
<img width="660" height="1434" alt="Capture d’écran 2026-07-24 à 14 06 19" src="https://github.com/user-attachments/assets/0cd0d6fb-e657-4169-aa80-c1e4266b91ea" />


Fixes #3268


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected message bubble width calculations for image/video events when shown in caption or reply mode, improving consistency across device sizes.
  * Refined sending-image bubble sizing and placeholder behavior so narrow images expand properly and the BlurHash placeholder layout is more consistent while loading.
  * Updated message content width/new-line handling for caption/reply scenarios to avoid edge-case overflow.

* **Tests**
  * Added/updated widget tests to verify image caption and sending-image bubble widths render as expected without exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->