### PR TITLE
fix(ci): version performance dashboard assets

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -556,6 +556,10 @@ jobs:
           fi
           cp -R scripts/perf/dashboard/. performance-site/
 
+          python3 scripts/perf/version_dashboard_assets.py \
+            --index performance-site/index.html \
+            --version "$GITHUB_SHA"
+
           python3 scripts/perf/update_history.py \
             --memory perf-results/perf_median_memory.json \
             --physical perf-results/perf_frame_physical.json \

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -401,6 +401,10 @@ jobs:
           fi
           cp -R scripts/perf/dashboard/. performance-site/
 
+          python3 scripts/perf/version_dashboard_assets.py \
+            --index performance-site/index.html \
+            --version "$GITHUB_SHA"
+
           python3 scripts/perf/update_web_history.py \
             --web perf-results/perf_web.json \
             --log perf-results/patrol-web-perf.log \

--- a/scripts/perf/tests/test_version_dashboard_assets.py
+++ b/scripts/perf/tests/test_version_dashboard_assets.py
@@ -1,0 +1,31 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.perf.version_dashboard_assets import version_dashboard_assets
+
+
+class VersionDashboardAssetsTest(unittest.TestCase):
+    def test_versions_every_local_dashboard_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            index_path = Path(directory) / "index.html"
+            index_path.write_text(
+                """<link rel=\"stylesheet\" href=\"styles.css\" />
+<script src=\"vendor/chart.umd.min.js\"></script>
+<script src=\"metrics.js\"></script>
+<script src=\"app.js\"></script>
+""",
+                encoding="utf-8",
+            )
+
+            version_dashboard_assets(index_path, "abc123")
+
+            html = index_path.read_text(encoding="utf-8")
+            self.assertIn('href="styles.css?v=abc123"', html)
+            self.assertIn('src="vendor/chart.umd.min.js?v=abc123"', html)
+            self.assertIn('src="metrics.js?v=abc123"', html)
+            self.assertIn('src="app.js?v=abc123"', html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/perf/version_dashboard_assets.py
+++ b/scripts/perf/version_dashboard_assets.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Add a deployment version to dashboard assets to avoid stale browser caches."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ASSETS = (
+    "styles.css",
+    "vendor/chart.umd.min.js",
+    "metrics.js",
+    "app.js",
+)
+
+
+def version_dashboard_assets(index_path: Path, version: str) -> None:
+    """Append the same cache-busting version to every local dashboard asset."""
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", version):
+        raise ValueError("Asset version contains unsupported characters")
+
+    html = index_path.read_text(encoding="utf-8")
+    for asset in ASSETS:
+        pattern = rf'((?:href|src)="{re.escape(asset)})(?:\?v=[^"]*)?(\")'
+        html, replacements = re.subn(
+            pattern,
+            rf"\g<1>?v={version}\g<2>",
+            html,
+        )
+        if replacements != 1:
+            raise ValueError(
+                f"Expected exactly one dashboard reference to {asset}, "
+                f"found {replacements}"
+            )
+    index_path.write_text(html, encoding="utf-8")
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--index", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = _arguments()
+    version_dashboard_assets(arguments.index, arguments.version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Ticket
**Related issue**

Follow-up to #3288.

## Root cause
**If this is a bug, please provide a brief description of the root cause of the issue**

GitHub Pages caches `app.js` for up to 10 minutes. Immediately after the Android/Web dashboard replaced the Android-only version, an existing browser tab could load the new page with the stale Android-only script. That script requests `performance/data/index.json`, which is currently absent, instead of falling back to `performance/data/web/index.json`; the UI therefore remains on "Chargement…" even though the Web history was published successfully.

## Solution
**Outline the implemented solution, detailing the changes made and how they address the issue**

- add a small publisher helper that appends the deployment commit SHA to every local dashboard asset URL
- invoke it from both Android and Web performance publishers
- validate that CSS, Chart.js, metrics, and application JavaScript always receive the same cache-busting version
- add a regression test for the generated asset URLs

Each dashboard publication now loads a mutually compatible set of HTML, CSS, and JavaScript instead of reusing stale browser assets from a previous dashboard version.

## Impact description
**If this is not a bug, please explain how the changes affect the project**

Only the generated GitHub Pages HTML is modified. Performance measurements and persisted history formats are unchanged.

## Test recommendations
**Recommendations for how to test this, or anything else you are worried about?**

- publish the dashboard from `main`
- verify that `index.html` references assets with `?v=<commit-sha>`
- load the dashboard in a browser that previously opened the Android-only version and confirm the Web cards render

Validated locally:

- `python3 -m unittest discover -s scripts/perf/tests -v` — 20 passed
- `node --test scripts/perf/tests/test_dashboard_metrics.js` — 16 passed
- `actionlint .github/workflows/integration-tests.yaml .github/workflows/patrol-web-integration-test.yaml`
- publication simulation confirmed all four versioned asset URLs

## Pre-merge
**Does anything else need to be done before merging?**

No. After merge, rerun the Web performance publication once on `main` to deploy the versioned HTML.

## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web: the live bug was reproduced as stale Android-only JavaScript requesting the missing `performance/data/index.json`; the current uncached application loads `performance/data/web/index.json` successfully.
- Android: not applicable
- IOS: not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Performance dashboards now version their CSS and JavaScript assets automatically, helping browsers load the latest dashboard updates.

* **Bug Fixes**
  * Improved dashboard publishing reliability by preventing stale cached assets from being served.

* **Tests**
  * Added coverage to verify that all local dashboard assets receive the correct version identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->