### PR TITLE
fix(ci): stabilize Android FTL performance nightlies

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -381,6 +381,8 @@ jobs:
           echo "Physical logcat files: ${LOGCAT_FILES[*]}"
 
           python3 scripts/perf/compute_median.py \
+            --expected-samples 3 \
+            --requirements scripts/perf/android_requirements.json \
             "${LOGCAT_FILES[@]}" \
             perf_median_physical.json
 

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -19,12 +19,6 @@ on:
 
 name: Integration Tests
 
-# The Android and Web nightlies use the same Matrix CI account. The matching
-# group in patrol-web-integration-test.yaml prevents cross-workflow overlap.
-concurrency:
-  group: matrix-ci-shared-account
-  cancel-in-progress: false
-
 env:
   FLUTTER_VERSION: "3.38.9"
   JAVA_VERSION: 17
@@ -39,6 +33,10 @@ jobs:
   integration_test:
     name: Integration Test
     runs-on: ubuntu-latest
+    concurrency:
+      group: matrix-ci-shared-account
+      queue: max
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read
@@ -272,6 +270,10 @@ jobs:
       }}
     needs: [perf_build, integration_test]
     runs-on: ubuntu-latest
+    concurrency:
+      group: matrix-ci-shared-account
+      queue: max
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -5,10 +5,6 @@ on:
         description: "Path to Patrol integration test Dart file. Defaults to the perf test."
         required: false
         default: "integration_test/tests/chat/perf_test.dart"
-      perf_runs:
-        description: "Number of perf test runs for median (3-5 recommended)."
-        required: false
-        default: "3"
       run_perf:
         description: "Also run the performance jobs (build + physical median). Off by default so a functional dispatch only runs the integration tests."
         required: false
@@ -21,7 +17,13 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
-name: Integration
+name: Integration Tests
+
+# The Android and Web nightlies use the same Matrix CI account. The matching
+# group in patrol-web-integration-test.yaml prevents cross-workflow overlap.
+concurrency:
+  group: matrix-ci-shared-account
+  cancel-in-progress: false
 
 env:
   FLUTTER_VERSION: "3.38.9"
@@ -146,7 +148,7 @@ jobs:
             --type instrumentation \
             --app build/app/outputs/apk/debug/app-debug.apk \
             --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
-            --device model=oriole,version=33 \
+            --device model=MediumPhone.arm,version=34 \
             --timeout 45m \
             --use-orchestrator \
             --environment-variables clearPackageData=true
@@ -257,14 +259,18 @@ jobs:
             build/app/outputs/apk/androidTest/profile/app-profile-androidTest.apk
 
   # ────────────────────────────────────────────────────────────────────────────
-  # Job 3a – Memory metrics: 3 runs on virtual device (free tier)
-  # RSS and imageCache are reliable on virtual devices. Running ×3 gives a
-  # median that filters outliers from GC pauses or background activity.
+  # Job 3 – All performance metrics: 3 sequential runs on physical hardware.
+  # Virtual-device performance is not representative. Serial execution also
+  # prevents concurrent Matrix logins with the shared CI account.
   # ────────────────────────────────────────────────────────────────────────────
-  perf_run_virtual:
-    name: Perf Memory Run ${{ matrix.run }}/3
-    if: ${{ github.event_name == 'schedule' || inputs.run_perf == 'true' }}
-    needs: perf_build
+  perf_run_physical:
+    name: Perf Physical Run ${{ matrix.run }}/3
+    if: >-
+      ${{
+        always() && needs.perf_build.result == 'success' &&
+        (github.event_name == 'schedule' || inputs.run_perf == 'true')
+      }}
+    needs: [perf_build, integration_test]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -274,6 +280,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         run: [1, 2, 3]
 
@@ -302,94 +309,10 @@ jobs:
           name: perf-apks-${{ github.run_id }}
           path: apks/
 
-      # upload-artifact@v4 strips to the least common ancestor of the uploaded
-      # paths (build/app/outputs/apk/), so the layout under apks/ is:
-      #   apks/profile/app-profile.apk
-      #   apks/androidTest/profile/app-profile-androidTest.apk
-      - name: Run perf test on virtual device
-        run: |
-          PERF_RUN_ID="perf-virtual-${{ github.run_id }}-run${{ matrix.run }}"
-          # Export before FTL so logcat download still works if the test fails.
-          echo "PERF_RUN_ID=$PERF_RUN_ID" >> "$GITHUB_ENV"
-
-          gcloud firebase test android run \
-            --type instrumentation \
-            --app apks/profile/app-profile.apk \
-            --test apks/androidTest/profile/app-profile-androidTest.apk \
-            --device model=MediumPhone.arm,version=34 \
-            --timeout 30m \
-            --use-orchestrator \
-            --environment-variables clearPackageData=true \
-            --results-bucket "$FTL_RESULTS_BUCKET" \
-            --results-dir "$PERF_RUN_ID"
-
-      # gcloud storage (not gsutil): gsutil often ignores WIF/ADC and hits 401 Anonymous.
-      - name: Download logcat from GCS
-        if: always() && env.PERF_RUN_ID != ''
-        run: |
-          GCS_PATH="gs://$FTL_RESULTS_BUCKET/$PERF_RUN_ID"
-          mkdir -p ./perf_gcs_results
-          gcloud storage cp -r "${GCS_PATH}/*" ./perf_gcs_results/ \
-            || { echo "ERROR: gcloud storage failed to download results from $GCS_PATH"; exit 1; }
-          find ./perf_gcs_results -name "logcat" -exec cat {} + > perf_logcat.txt \
-            || { echo "ERROR: no logcat file found in GCS results"; exit 1; }
-          if [ ! -s perf_logcat.txt ]; then
-            echo "ERROR: logcat is empty"; exit 1
-          fi
-
-      - name: Upload run logcat
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: perf-virtual-logcat-${{ github.run_id }}-run${{ matrix.run }}
-          retention-days: 7
-          path: perf_logcat.txt
-
-  # ────────────────────────────────────────────────────────────────────────────
-  # Job 3b – Frame timing metrics: 1 run on physical device (free tier)
-  # build_p95, jank_rate are only meaningful on real hardware. 1 run within
-  # the 30min/day free tier — no median, but the signal is reliable.
-  # ────────────────────────────────────────────────────────────────────────────
-  perf_run_physical:
-    name: Perf Frame Run (physical)
-    if: ${{ github.event_name == 'schedule' || inputs.run_perf == 'true' }}
-    needs: perf_build
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      FTL_RESULTS_BUCKET: "${{ secrets.GOOGLE_CLOUD_PROJECT_ID }}_test_results"
-
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Validate FTL bucket name
-        run: |
-          if [[ "$FTL_RESULTS_BUCKET" == _* ]]; then
-            echo "ERROR: FTL_RESULTS_BUCKET='$FTL_RESULTS_BUCKET' — GOOGLE_CLOUD_PROJECT_ID secret is missing or empty."
-            exit 1
-          fi
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
-        with:
-          project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT_ID }}
-          workload_identity_provider: ${{ secrets.GOOGLE_CLOUD_WORKLOAD_IDENTITY_PROVIDER_ID }}
-          service_account: ${{ secrets.GOOGLE_CLOUD_SERVICE_ACCOUNT }}
-
-      - name: Download APKs
-        uses: actions/download-artifact@v4
-        with:
-          name: perf-apks-${{ github.run_id }}
-          path: apks/
-
-      # See perf_run_virtual: artifact layout is LCA-stripped under apks/.
+      # upload-artifact@v4 strips the APK paths to their least common ancestor.
       - name: Run perf test on physical device
         run: |
-          PERF_RUN_ID="perf-physical-${{ github.run_id }}"
+          PERF_RUN_ID="perf-physical-${{ github.run_id }}-run${{ matrix.run }}"
           # Export before FTL so logcat download still works if the test fails.
           echo "PERF_RUN_ID=$PERF_RUN_ID" >> "$GITHUB_ENV"
 
@@ -422,17 +345,17 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: perf-physical-logcat-${{ github.run_id }}
+          name: perf-physical-logcat-${{ github.run_id }}-run${{ matrix.run }}
           retention-days: 7
           path: perf_logcat.txt
 
   # ────────────────────────────────────────────────────────────────────────────
-  # Job 4 – Compute median across the 3 virtual runs + annotate physical
+  # Job 4 – Compute a median across the 3 physical runs
   # ────────────────────────────────────────────────────────────────────────────
   perf_median:
     name: Compute Perf Median
     if: ${{ github.event_name == 'schedule' || inputs.run_perf == 'true' }}
-    needs: [perf_run_virtual, perf_run_physical]
+    needs: perf_run_physical
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -445,51 +368,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download virtual run logcats
+      - name: Download physical run logcats
         uses: actions/download-artifact@v4
         with:
-          pattern: perf-virtual-logcat-${{ github.run_id }}-run*
-          path: perf_logcats/virtual/
+          pattern: perf-physical-logcat-${{ github.run_id }}-run*
+          path: perf_logcats/physical/
           merge-multiple: false
 
-      - name: Download physical run logcat
-        uses: actions/download-artifact@v4
-        with:
-          name: perf-physical-logcat-${{ github.run_id }}
-          path: perf_logcats/physical/
-
-      - name: Compute median (memory metrics — virtual ×3)
+      - name: Compute physical median
         run: |
-          mapfile -t LOGCAT_FILES < <(find perf_logcats/virtual/ -name "perf_logcat.txt" | sort)
-          echo "Virtual logcat files: ${LOGCAT_FILES[*]}"
+          mapfile -t LOGCAT_FILES < <(find perf_logcats/physical/ -name "perf_logcat.txt" | sort)
+          echo "Physical logcat files: ${LOGCAT_FILES[*]}"
 
           python3 scripts/perf/compute_median.py \
             "${LOGCAT_FILES[@]}" \
-            perf_median_memory.json
+            perf_median_physical.json
 
-          echo "=== Memory Median Results ==="
-          cat perf_median_memory.json
-
-      - name: Extract frame metrics (physical ×1)
-        run: |
-          PHYSICAL_LOGCAT="perf_logcats/physical/perf_logcat.txt"
-          echo "Physical logcat: $PHYSICAL_LOGCAT"
-
-          python3 scripts/perf/compute_median.py \
-            "$PHYSICAL_LOGCAT" \
-            perf_frame_physical.json
-
-          echo "=== Frame Results (physical device) ==="
-          cat perf_frame_physical.json
+          echo "=== Physical Median Results ==="
+          cat perf_median_physical.json
 
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:
           name: perf-results-${{ github.run_id }}
           retention-days: 90
-          path: |
-            perf_median_memory.json
-            perf_frame_physical.json
+          path: perf_median_physical.json
 
   # ────────────────────────────────────────────────────────────────────────────
   # Job 5 – Append the successful nightly aggregate to the GitHub Pages history
@@ -557,8 +460,10 @@ jobs:
           cp -R scripts/perf/dashboard/. performance-site/
 
           python3 scripts/perf/update_history.py \
-            --memory perf-results/perf_median_memory.json \
-            --physical perf-results/perf_frame_physical.json \
+            --memory perf-results/perf_median_physical.json \
+            --physical perf-results/perf_median_physical.json \
+            --benchmark-source physical \
+            --physical-runs 3 \
             --data-directory performance-site/data \
             --date "$(date -u +%F)" \
             --generated-at "$(date -u +%FT%TZ)" \

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -1,10 +1,7 @@
 name: Patrol Web Integration Tests
 
-# Shared with integration-tests.yaml so separate workflow runs cannot log in
-# concurrently with the same Matrix CI account.
-concurrency:
-  group: matrix-ci-shared-account
-  cancel-in-progress: false
+# Every Web job provisions an isolated local Synapse instance, so these jobs do
+# not need the shared-account lock used by the Android FTL workflow.
 
 on:
   # Nightly web E2E run on free GitHub-hosted runners (no FTL cost).

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -317,6 +317,7 @@ jobs:
         run: |
           python3 scripts/perf/compute_median.py \
             --include-values \
+            --expected-samples 3 \
             patrol-web-perf.log \
             perf_web.json
           python3 - <<'PY'

--- a/.github/workflows/patrol-web-integration-test.yaml
+++ b/.github/workflows/patrol-web-integration-test.yaml
@@ -1,5 +1,11 @@
 name: Patrol Web Integration Tests
 
+# Shared with integration-tests.yaml so separate workflow runs cannot log in
+# concurrently with the same Matrix CI account.
+concurrency:
+  group: matrix-ci-shared-account
+  cancel-in-progress: false
+
 on:
   # Nightly web E2E run on free GitHub-hosted runners (no FTL cost).
   # 02:00 UTC — offset from the FTL integration workflow (00:00 UTC) so the

--- a/integration_test/base/matrix_login_retry.dart
+++ b/integration_test/base/matrix_login_retry.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:matrix/matrix.dart';
+
+typedef LoginWait = Future<void> Function(Duration delay);
+typedef LoginJitter = int Function(int maxMilliseconds);
+
+/// Runs [login] again only when the homeserver reports `M_LIMIT_EXCEEDED`.
+///
+/// The server-provided `Retry-After` header takes precedence over the Matrix
+/// `retry_after_ms` body field. When neither exists, retries use exponential
+/// backoff. A small jitter is always added so concurrent FTL workers do not
+/// retry at the exact same instant.
+Future<T> loginWithRateLimitRetry<T>(
+  Future<T> Function() login, {
+  int maxAttempts = 4,
+  Duration fallbackDelay = const Duration(seconds: 5),
+  Duration maxJitter = const Duration(seconds: 3),
+  LoginWait? wait,
+  LoginJitter? jitterMilliseconds,
+  DateTime Function()? now,
+  void Function(String message)? log,
+}) async {
+  if (maxAttempts < 1) {
+    throw ArgumentError.value(maxAttempts, 'maxAttempts', 'must be at least 1');
+  }
+  if (fallbackDelay.isNegative) {
+    throw ArgumentError.value(
+      fallbackDelay,
+      'fallbackDelay',
+      'must not be negative',
+    );
+  }
+  if (maxJitter.isNegative) {
+    throw ArgumentError.value(maxJitter, 'maxJitter', 'must not be negative');
+  }
+
+  final delay = wait ?? Future<void>.delayed;
+  final randomJitter = jitterMilliseconds ?? Random().nextInt;
+  final currentTime = now ?? DateTime.now;
+
+  for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await login();
+    } on MatrixException catch (exception) {
+      final canRetry =
+          exception.error == MatrixError.M_LIMIT_EXCEEDED &&
+          attempt < maxAttempts;
+      if (!canRetry) rethrow;
+
+      final serverDelay = _serverRetryDelay(exception, currentTime());
+      final backoffMultiplier = 1 << (attempt - 1);
+      final baseDelay = serverDelay ?? fallbackDelay * backoffMultiplier;
+      final jitterRange = maxJitter.inMilliseconds;
+      final jitter = jitterRange == 0 ? 0 : randomJitter(jitterRange + 1);
+      final retryDelay = baseDelay + Duration(milliseconds: jitter);
+
+      log?.call(
+        'Matrix login rate limited on attempt $attempt/$maxAttempts; '
+        'retrying in ${retryDelay.inMilliseconds} ms.',
+      );
+      await delay(retryDelay);
+    }
+  }
+
+  throw StateError('Unreachable login retry state');
+}
+
+Duration? _serverRetryDelay(MatrixException exception, DateTime now) {
+  String? retryAfterHeader;
+  for (final entry
+      in exception.response?.headers.entries ??
+          const <MapEntry<String, String>>[]) {
+    if (entry.key.toLowerCase() == 'retry-after') {
+      retryAfterHeader = entry.value.trim();
+      break;
+    }
+  }
+
+  final retryAfterSeconds = int.tryParse(retryAfterHeader ?? '');
+  if (retryAfterSeconds != null && retryAfterSeconds >= 0) {
+    return Duration(seconds: retryAfterSeconds);
+  }
+  if (retryAfterHeader != null) {
+    try {
+      final retryAt = HttpDate.parse(retryAfterHeader).toUtc();
+      final delay = retryAt.difference(now.toUtc());
+      return delay.isNegative ? Duration.zero : delay;
+    } on HttpException {
+      // Fall through to the Matrix body field or local backoff.
+    } on FormatException {
+      // Fall through to the Matrix body field or local backoff.
+    }
+  }
+
+  final retryAfterMs = exception.retryAfterMs;
+  if (retryAfterMs != null && retryAfterMs >= 0) {
+    return Duration(milliseconds: retryAfterMs);
+  }
+  return null;
+}

--- a/integration_test/base/perf_collector.dart
+++ b/integration_test/base/perf_collector.dart
@@ -5,6 +5,7 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/scheduler.dart';
 
 const _frameBudgetUs60Fps = 16667;
+const _frameTimingsBatchDrain = Duration(milliseconds: 200);
 
 /// Computes frame metrics for an active rendering window.
 ///
@@ -69,9 +70,9 @@ int _percentile(List<int> sorted, int percentile) {
 /// final perf = PerfCollector('scroll_room');
 /// perf.start();
 /// // ... navigate, interact ...
-/// perf.checkpoint('room_entered');
+/// await perf.checkpoint('room_entered');
 /// // ... scroll ...
-/// perf.checkpoint('after_30s_scroll');
+/// await perf.checkpoint('after_30s_scroll');
 /// perf.stop();
 /// await perf.flush();
 /// ```
@@ -86,10 +87,14 @@ class PerfCollector {
   int _seq = 0;
   final List<String> _pending = [];
   final List<FrameTiming> _frameBuffer = [];
+  final Future<void> Function(Duration) _waitForFrameTimings;
   TimingsCallback? _timingsCallback;
 
-  PerfCollector(this.scenario)
-    : _runId = DateTime.now().millisecondsSinceEpoch.toString();
+  PerfCollector(
+    this.scenario, {
+    Future<void> Function(Duration)? waitForFrameTimings,
+  }) : _waitForFrameTimings = waitForFrameTimings ?? Future<void>.delayed,
+       _runId = DateTime.now().millisecondsSinceEpoch.toString();
 
   /// Starts accumulating frame timings. Call before the first action to measure.
   void start() {
@@ -109,7 +114,16 @@ class PerfCollector {
   /// previous checkpoint.
   ///
   /// [extra] allows adding arbitrary key=value metrics (e.g. latency_ms).
-  void checkpoint(String label, {Map<String, dynamic> extra = const {}}) {
+  Future<void> checkpoint(
+    String label, {
+    Map<String, dynamic> extra = const {},
+  }) async {
+    // In profile mode Flutter batches FrameTiming delivery approximately every
+    // 100 ms. Let the final rasterized frames reach the callback before taking
+    // and clearing the snapshot, otherwise short transitions intermittently
+    // produce frame_count=0 and omit every derived frame metric.
+    await _waitForFrameTimings(_frameTimingsBatchDrain);
+
     final rss = ProcessInfo.currentRss;
     final cache = PaintingBinding.instance.imageCache;
     final frames = List<FrameTiming>.from(_frameBuffer);

--- a/integration_test/robots/login_robot.dart
+++ b/integration_test/robots/login_robot.dart
@@ -13,6 +13,7 @@ import 'package:matrix/matrix.dart';
 import 'package:patrol/patrol.dart';
 import '../base/api_login_helper.dart';
 import '../base/core_robot.dart';
+import '../base/matrix_login_retry.dart';
 import 'abstract/abstract_login_robot.dart';
 
 class LoginRobot extends CoreRobot implements AbstractLoginRobot {
@@ -343,11 +344,14 @@ class LoginRobot extends CoreRobot implements AbstractLoginRobot {
         .checkHomeserver(Uri.parse(serverUrl))
         .toHomeserverSummary();
 
-    await client.login(
-      LoginType.mLoginPassword,
-      identifier: AuthenticationUserIdentifier(user: username),
-      password: password,
-      initialDeviceDisplayName: PlatformInfos.clientName,
+    await loginWithRateLimitRetry(
+      () => client.login(
+        LoginType.mLoginPassword,
+        identifier: AuthenticationUserIdentifier(user: username),
+        password: password,
+        initialDeviceDisplayName: PlatformInfos.clientName,
+      ),
+      log: debugPrint,
     );
 
     // Force the router to re-evaluate redirects so the now-logged-in client

--- a/integration_test/tests/chat/perf_test.dart
+++ b/integration_test/tests/chat/perf_test.dart
@@ -85,19 +85,19 @@ Future<PerfCollector> _runNavCycles(PatrolIntegrationTester $) async {
 
   await HomeRobot($).gotoChatListScreen();
   await $.pumpAndSettle();
-  perf.checkpoint('chat_list_baseline');
+  await perf.checkpoint('chat_list_baseline');
 
   for (int i = 1; i <= 5; i++) {
     final t0 = DateTime.now().millisecondsSinceEpoch;
     await _openRoomFromList($, _navRoom);
-    perf.checkpoint(
+    await perf.checkpoint(
       'room_enter_cycle$i',
       extra: {'transition_ms': DateTime.now().millisecondsSinceEpoch - t0},
     );
     await ChatGroupDetailRobot($).clickOnBackIcon();
     await $.pumpAndSettle();
     await Future.delayed(const Duration(seconds: 2));
-    perf.checkpoint('chat_list_after_cycle$i');
+    await perf.checkpoint('chat_list_after_cycle$i');
   }
 
   perf.stop();
@@ -118,18 +118,18 @@ Future<void> _runScrollScenario(
   await HomeRobot($).gotoChatListScreen();
   await $.pumpAndSettle();
   await _openRoomFromList($, roomName);
-  perf.checkpoint('room_entered');
+  await perf.checkpoint('room_entered');
 
   await _scrollForDuration($, perf, roomLabel, durationSeconds: 30);
-  perf.checkpoint('scroll_end');
+  await perf.checkpoint('scroll_end');
 
   await Future.delayed(const Duration(seconds: 3));
-  perf.checkpoint('scroll_settled');
+  await perf.checkpoint('scroll_settled');
 
   await ChatGroupDetailRobot($).clickOnBackIcon();
   await $.pumpAndSettle();
   await Future.delayed(const Duration(seconds: 3));
-  perf.checkpoint('back_to_list');
+  await perf.checkpoint('back_to_list');
 
   perf.stop();
   await perf.flush();
@@ -143,14 +143,14 @@ Future<void> _runChatListScroll(PatrolIntegrationTester $) async {
 
   await HomeRobot($).gotoChatListScreen();
   await $.pumpAndSettle();
-  perf.checkpoint('list_top');
+  await perf.checkpoint('list_top');
 
   await CoreRobot($).scrollToBottom($);
-  perf.checkpoint('list_bottom');
+  await perf.checkpoint('list_bottom');
 
   await CoreRobot($).scrollToTop($);
   await Future.delayed(const Duration(seconds: 2));
-  perf.checkpoint('list_top_again');
+  await perf.checkpoint('list_top_again');
 
   perf.stop();
   await perf.flush();
@@ -187,7 +187,7 @@ Future<void> _scrollForDuration(
     await $.pump(Duration(milliseconds: pauseMs));
 
     if ((i + 1) % logEveryNSteps == 0) {
-      perf.checkpoint('${roomLabel}_scroll_step_${i + 1}of$steps');
+      await perf.checkpoint('${roomLabel}_scroll_step_${i + 1}of$steps');
     }
   }
 }

--- a/scripts/perf/android_requirements.json
+++ b/scripts/perf/android_requirements.json
@@ -49,7 +49,22 @@
         "jank_rate"
       ]
     },
-    {"scenario": "scroll_room1", "label": "scroll_settled"},
+    {
+      "scenario": "scroll_room1",
+      "label": "scroll_settled",
+      "excluded_metrics": [
+        "frame_window_ms",
+        "fps",
+        "build_p50_us",
+        "build_p95_us",
+        "build_p99_us",
+        "raster_p50_us",
+        "raster_p95_us",
+        "raster_p99_us",
+        "jank_count",
+        "jank_rate"
+      ]
+    },
     {"scenario": "scroll_room1", "label": "back_to_list"},
     {"scenario": "scroll_room2", "label": "room_entered"},
     {"scenario": "scroll_room2", "label": "room2_scroll_step_5of15"},
@@ -71,7 +86,22 @@
         "jank_rate"
       ]
     },
-    {"scenario": "scroll_room2", "label": "scroll_settled"},
+    {
+      "scenario": "scroll_room2",
+      "label": "scroll_settled",
+      "excluded_metrics": [
+        "frame_window_ms",
+        "fps",
+        "build_p50_us",
+        "build_p95_us",
+        "build_p99_us",
+        "raster_p50_us",
+        "raster_p95_us",
+        "raster_p99_us",
+        "jank_count",
+        "jank_rate"
+      ]
+    },
     {"scenario": "scroll_room2", "label": "back_to_list"},
     {"scenario": "chat_list_scroll", "label": "list_top"},
     {"scenario": "chat_list_scroll", "label": "list_bottom"},

--- a/scripts/perf/android_requirements.json
+++ b/scripts/perf/android_requirements.json
@@ -1,0 +1,80 @@
+{
+  "common_metrics": [
+    "rss_bytes",
+    "cache_bytes",
+    "cache_count",
+    "cache_live",
+    "cache_pending",
+    "frame_count",
+    "frame_window_ms",
+    "fps",
+    "build_p50_us",
+    "build_p95_us",
+    "build_p99_us",
+    "raster_p50_us",
+    "raster_p95_us",
+    "raster_p99_us",
+    "jank_count",
+    "jank_rate"
+  ],
+  "checkpoints": [
+    {"scenario": "nav_cycles", "label": "chat_list_baseline"},
+    {"scenario": "nav_cycles", "label": "room_enter_cycle1", "extra_metrics": ["transition_ms"]},
+    {"scenario": "nav_cycles", "label": "chat_list_after_cycle1"},
+    {"scenario": "nav_cycles", "label": "room_enter_cycle2", "extra_metrics": ["transition_ms"]},
+    {"scenario": "nav_cycles", "label": "chat_list_after_cycle2"},
+    {"scenario": "nav_cycles", "label": "room_enter_cycle3", "extra_metrics": ["transition_ms"]},
+    {"scenario": "nav_cycles", "label": "chat_list_after_cycle3"},
+    {"scenario": "nav_cycles", "label": "room_enter_cycle4", "extra_metrics": ["transition_ms"]},
+    {"scenario": "nav_cycles", "label": "chat_list_after_cycle4"},
+    {"scenario": "nav_cycles", "label": "room_enter_cycle5", "extra_metrics": ["transition_ms"]},
+    {"scenario": "nav_cycles", "label": "chat_list_after_cycle5"},
+    {"scenario": "scroll_room1", "label": "room_entered"},
+    {"scenario": "scroll_room1", "label": "room1_scroll_step_5of15"},
+    {"scenario": "scroll_room1", "label": "room1_scroll_step_10of15"},
+    {"scenario": "scroll_room1", "label": "room1_scroll_step_15of15"},
+    {
+      "scenario": "scroll_room1",
+      "label": "scroll_end",
+      "excluded_metrics": [
+        "frame_window_ms",
+        "fps",
+        "build_p50_us",
+        "build_p95_us",
+        "build_p99_us",
+        "raster_p50_us",
+        "raster_p95_us",
+        "raster_p99_us",
+        "jank_count",
+        "jank_rate"
+      ]
+    },
+    {"scenario": "scroll_room1", "label": "scroll_settled"},
+    {"scenario": "scroll_room1", "label": "back_to_list"},
+    {"scenario": "scroll_room2", "label": "room_entered"},
+    {"scenario": "scroll_room2", "label": "room2_scroll_step_5of15"},
+    {"scenario": "scroll_room2", "label": "room2_scroll_step_10of15"},
+    {"scenario": "scroll_room2", "label": "room2_scroll_step_15of15"},
+    {
+      "scenario": "scroll_room2",
+      "label": "scroll_end",
+      "excluded_metrics": [
+        "frame_window_ms",
+        "fps",
+        "build_p50_us",
+        "build_p95_us",
+        "build_p99_us",
+        "raster_p50_us",
+        "raster_p95_us",
+        "raster_p99_us",
+        "jank_count",
+        "jank_rate"
+      ]
+    },
+    {"scenario": "scroll_room2", "label": "scroll_settled"},
+    {"scenario": "scroll_room2", "label": "back_to_list"},
+    {"scenario": "chat_list_scroll", "label": "list_top"},
+    {"scenario": "chat_list_scroll", "label": "list_bottom"},
+    {"scenario": "chat_list_scroll", "label": "list_top_again"}
+  ]
+}

--- a/scripts/perf/compute_median.py
+++ b/scripts/perf/compute_median.py
@@ -114,6 +114,7 @@ def _build_checkpoints(
             },
         )
         cp[key] = statistics.median(values)
+        cp[f'{key}_sample_count'] = len(values)
         if include_values:
             cp[f'{key}_values'] = values
         if len(values) >= 2:

--- a/scripts/perf/compute_median.py
+++ b/scripts/perf/compute_median.py
@@ -5,7 +5,9 @@ groups values by (scenario, label, metric_key), and outputs a JSON file
 containing the median value of each metric across all runs.
 
 Usage:
-    python3 compute_median.py [--include-values] logcat1.txt logcat2.txt logcat3.txt output.json
+    python3 compute_median.py [--include-values] [--expected-samples N]
+        [--requirements FILE]
+        logcat1.txt logcat2.txt logcat3.txt output.json
 """
 import json
 import re
@@ -19,6 +21,21 @@ from typing import Iterator
 _PERF_RE = re.compile(r'PERF_METRIC \| ([^|]+) \| ([^|]+) \| (.+)')
 # Keys present on every PERF_METRIC line that carry no measurement value.
 _SKIP_KEYS: frozenset[str] = frozenset({'scenario', 'label', 'run', 'seq', 'ts'})
+
+
+def _load_requirements(path: str) -> dict[tuple[str, str], set[str]]:
+    """Load common and checkpoint-specific required metrics from JSON."""
+    data = json.loads(Path(path).read_text(encoding='utf-8'))
+    common_metrics = set(data.get('common_metrics', []))
+    requirements: dict[tuple[str, str], set[str]] = {}
+    for checkpoint in data.get('checkpoints', []):
+        key = (checkpoint['scenario'], checkpoint['label'])
+        if key in requirements:
+            raise ValueError(f"duplicate required checkpoint {key[0]}/{key[1]}")
+        requirements[key] = (
+            common_metrics | set(checkpoint.get('extra_metrics', []))
+        ) - set(checkpoint.get('excluded_metrics', []))
+    return requirements
 
 
 def _parse_kv_pairs(raw: str) -> dict:
@@ -66,7 +83,9 @@ def _entry_metrics(entry: dict) -> Iterator[tuple[str, str, str, float]]:
 
 def _aggregate_groups(
     logcat_files: list[str],
-) -> tuple[dict[tuple, list[float]], dict[tuple, int], int]:
+    *,
+    identity_by_source: bool = False,
+) -> tuple[dict[tuple, dict[tuple[int, str], float]], dict[tuple, set], int]:
     """Parse all logcat files and collect numeric values grouped by (scenario, label, key).
 
     Returns (groups, checkpoint_counts, total_parsed_lines).
@@ -76,22 +95,32 @@ def _aggregate_groups(
     so sample_count represents completed runs rather than the least common
     optional metric.
     """
-    groups: dict[tuple, list[float]] = defaultdict(list)
-    checkpoint_counts: dict[tuple, int] = defaultdict(int)
+    groups: dict[tuple, dict[tuple[int, str], float]] = defaultdict(dict)
+    checkpoint_samples: dict[tuple, set[tuple[int, str]]] = defaultdict(set)
     total_lines = 0
-    for f in logcat_files:
+    for source_index, f in enumerate(logcat_files):
         entries = parse_logcat(f)
         total_lines += len(entries)
         for entry in entries:
-            checkpoint_counts[(entry['scenario'], entry['label'])] += 1
+            checkpoint = (entry['scenario'], entry['label'])
+            sample = (
+                source_index,
+                '' if identity_by_source else entry.get('run', ''),
+            )
+            if sample in checkpoint_samples[checkpoint]:
+                raise ValueError(
+                    f"duplicate sample for {checkpoint[0]}/{checkpoint[1]} "
+                    f"from source {source_index}, run={sample[1] or '<missing>'}"
+                )
+            checkpoint_samples[checkpoint].add(sample)
             for scenario, label, k, v in _entry_metrics(entry):
-                groups[(scenario, label, k)].append(v)
-    return groups, checkpoint_counts, total_lines
+                groups[(scenario, label, k)][sample] = v
+    return groups, checkpoint_samples, total_lines
 
 
 def _build_checkpoints(
-    groups: dict[tuple, list[float]],
-    checkpoint_counts: dict[tuple, int],
+    groups: dict[tuple, dict[tuple[int, str], float]],
+    checkpoint_samples: dict[tuple, set],
     *,
     include_values: bool = False,
 ) -> list[dict]:
@@ -103,14 +132,15 @@ def _build_checkpoints(
     """
     checkpoints: dict[tuple, dict] = {}
 
-    for (scenario, label, key), values in groups.items():
+    for (scenario, label, key), samples in groups.items():
+        values = list(samples.values())
         cp_key = (scenario, label)
         cp = checkpoints.setdefault(
             cp_key,
             {
                 'scenario': scenario,
                 'label': label,
-                'sample_count': checkpoint_counts[cp_key],
+                'sample_count': len(checkpoint_samples[cp_key]),
             },
         )
         cp[key] = statistics.median(values)
@@ -141,16 +171,67 @@ def _emit_warnings(output: list[dict]) -> None:
         )
 
 
+def _validate_expected_samples(
+    groups: dict[tuple, dict[tuple[int, str], float]],
+    checkpoint_samples: dict[tuple, set],
+    expected_samples: int,
+) -> None:
+    """Reject checkpoints or metrics absent from any expected repetition."""
+    for (scenario, label), samples in sorted(checkpoint_samples.items()):
+        count = len(samples)
+        if count != expected_samples:
+            raise ValueError(
+                f"{scenario}/{label} has {count} checkpoint sample(s); "
+                f"expected {expected_samples}"
+            )
+    for (scenario, label, metric), samples in sorted(groups.items()):
+        if len(samples) != expected_samples:
+            raise ValueError(
+                f"{scenario}/{label}/{metric} has {len(samples)} sample(s); "
+                f"expected {expected_samples}"
+            )
+
+
+def _validate_requirements(
+    groups: dict[tuple, dict[tuple[int, str], float]],
+    checkpoint_samples: dict[tuple, set],
+    requirements: dict[tuple[str, str], set[str]],
+) -> None:
+    """Reject required checkpoints or metrics absent from every repetition."""
+    for (scenario, label), metrics in sorted(requirements.items()):
+        if (scenario, label) not in checkpoint_samples:
+            raise ValueError(f"required checkpoint {scenario}/{label} is missing")
+        for metric in sorted(metrics):
+            if (scenario, label, metric) not in groups:
+                raise ValueError(f"{scenario}/{label}/{metric} is missing")
+
+
 def compute_median(
     logcat_files: list[str],
     output_file: str,
     *,
     include_values: bool = False,
+    expected_samples: int | None = None,
+    requirements: dict[tuple[str, str], set[str]] | None = None,
 ) -> None:
-    groups, checkpoint_counts, total_lines = _aggregate_groups(logcat_files)
+    if expected_samples is not None and len(logcat_files) not in (1, expected_samples):
+        raise ValueError(
+            f"received {len(logcat_files)} logcat file(s); expected either one "
+            f"combined log or {expected_samples} repetition files"
+        )
+    groups, checkpoint_samples, total_lines = _aggregate_groups(
+        logcat_files,
+        identity_by_source=(
+            expected_samples is not None and len(logcat_files) == expected_samples
+        ),
+    )
+    if requirements is not None:
+        _validate_requirements(groups, checkpoint_samples, requirements)
+    if expected_samples is not None:
+        _validate_expected_samples(groups, checkpoint_samples, expected_samples)
     output = _build_checkpoints(
         groups,
-        checkpoint_counts,
+        checkpoint_samples,
         include_values=include_values,
     )
     output.sort(key=lambda x: (x['scenario'], x.get('seq', 0)))
@@ -169,12 +250,34 @@ def compute_median(
 if __name__ == '__main__':
     arguments = sys.argv[1:]
     include_values = False
+    expected_samples = None
+    requirements_file = None
     if '--include-values' in arguments:
         arguments.remove('--include-values')
         include_values = True
+    if '--expected-samples' in arguments:
+        option_index = arguments.index('--expected-samples')
+        try:
+            expected_samples = int(arguments[option_index + 1])
+        except (IndexError, ValueError):
+            print("--expected-samples requires a positive integer", file=sys.stderr)
+            sys.exit(1)
+        if expected_samples < 1:
+            print("--expected-samples requires a positive integer", file=sys.stderr)
+            sys.exit(1)
+        del arguments[option_index:option_index + 2]
+    if '--requirements' in arguments:
+        option_index = arguments.index('--requirements')
+        try:
+            requirements_file = arguments[option_index + 1]
+        except IndexError:
+            print("--requirements requires a JSON file", file=sys.stderr)
+            sys.exit(1)
+        del arguments[option_index:option_index + 2]
     if len(arguments) < 2:
         print(
-            "Usage: compute_median.py [--include-values]"
+            "Usage: compute_median.py [--include-values] [--expected-samples N]"
+            " [--requirements FILE]"
             " <logcat1> [logcat2 ...] <output.json>"
         )
         sys.exit(1)
@@ -182,4 +285,10 @@ if __name__ == '__main__':
         arguments[:-1],
         arguments[-1],
         include_values=include_values,
+        expected_samples=expected_samples,
+        requirements=(
+            _load_requirements(requirements_file)
+            if requirements_file is not None
+            else None
+        ),
     )

--- a/scripts/perf/compute_median.py
+++ b/scripts/perf/compute_median.py
@@ -9,13 +9,14 @@ Usage:
         [--requirements FILE]
         logcat1.txt logcat2.txt logcat3.txt output.json
 """
+import argparse
 import json
 import re
 import statistics
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Sized
 
 
 _PERF_RE = re.compile(r'PERF_METRIC \| ([^|]+) \| ([^|]+) \| (.+)')
@@ -23,7 +24,7 @@ _PERF_RE = re.compile(r'PERF_METRIC \| ([^|]+) \| ([^|]+) \| (.+)')
 _SKIP_KEYS: frozenset[str] = frozenset({'scenario', 'label', 'run', 'seq', 'ts'})
 
 
-def _load_requirements(path: str) -> dict[tuple[str, str], set[str]]:
+def _load_requirements(path: str | Path) -> dict[tuple[str, str], set[str]]:
     """Load common and checkpoint-specific required metrics from JSON."""
     data = json.loads(Path(path).read_text(encoding='utf-8'))
     common_metrics = set(data.get('common_metrics', []))
@@ -178,18 +179,59 @@ def _validate_expected_samples(
 ) -> None:
     """Reject checkpoints or metrics absent from any expected repetition."""
     for (scenario, label), samples in sorted(checkpoint_samples.items()):
-        count = len(samples)
-        if count != expected_samples:
-            raise ValueError(
-                f"{scenario}/{label} has {count} checkpoint sample(s); "
-                f"expected {expected_samples}"
-            )
+        _validate_sample_count(
+            f"{scenario}/{label}",
+            "checkpoint ",
+            samples,
+            expected_samples,
+        )
     for (scenario, label, metric), samples in sorted(groups.items()):
-        if len(samples) != expected_samples:
-            raise ValueError(
-                f"{scenario}/{label}/{metric} has {len(samples)} sample(s); "
-                f"expected {expected_samples}"
-            )
+        _validate_sample_count(
+            f"{scenario}/{label}/{metric}",
+            "",
+            samples,
+            expected_samples,
+        )
+
+
+def _validate_sample_count(
+    location: str,
+    sample_kind: str,
+    samples: Sized,
+    expected_samples: int,
+) -> None:
+    """Reject one checkpoint or metric with an unexpected sample count."""
+    count = len(samples)
+    if count != expected_samples:
+        raise ValueError(
+            f"{location} has {count} {sample_kind}sample(s); expected {expected_samples}"
+        )
+
+
+def _validate_required_checkpoint(
+    checkpoint: tuple[str, str],
+    checkpoint_samples: dict[tuple, set],
+) -> None:
+    """Reject one required checkpoint when it is absent."""
+    if checkpoint not in checkpoint_samples:
+        raise ValueError(
+            f"required checkpoint {checkpoint[0]}/{checkpoint[1]} is missing"
+        )
+
+
+def _validate_required_metrics(
+    checkpoint: tuple[str, str],
+    metrics: set[str],
+    groups: dict[tuple, dict[tuple[int, str], float]],
+) -> None:
+    """Reject the first absent metric for one required checkpoint."""
+    missing_metrics = sorted(
+        metric for metric in metrics if (*checkpoint, metric) not in groups
+    )
+    if missing_metrics:
+        raise ValueError(
+            f"{checkpoint[0]}/{checkpoint[1]}/{missing_metrics[0]} is missing"
+        )
 
 
 def _validate_requirements(
@@ -198,12 +240,9 @@ def _validate_requirements(
     requirements: dict[tuple[str, str], set[str]],
 ) -> None:
     """Reject required checkpoints or metrics absent from every repetition."""
-    for (scenario, label), metrics in sorted(requirements.items()):
-        if (scenario, label) not in checkpoint_samples:
-            raise ValueError(f"required checkpoint {scenario}/{label} is missing")
-        for metric in sorted(metrics):
-            if (scenario, label, metric) not in groups:
-                raise ValueError(f"{scenario}/{label}/{metric} is missing")
+    for checkpoint, metrics in sorted(requirements.items()):
+        _validate_required_checkpoint(checkpoint, checkpoint_samples)
+        _validate_required_metrics(checkpoint, metrics, groups)
 
 
 def compute_median(
@@ -247,48 +286,38 @@ def compute_median(
     )
 
 
+def _positive_integer(raw: str) -> int:
+    """Parse an argparse value that must be a positive integer."""
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a positive integer") from error
+    if value < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return value
+
+
+def _parse_arguments(arguments: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line options and input/output paths."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--include-values", action="store_true")
+    parser.add_argument("--expected-samples", type=_positive_integer)
+    parser.add_argument("--requirements", type=Path, metavar="FILE")
+    parser.add_argument("logcat_files", nargs="+")
+    parser.add_argument("output_file")
+    return parser.parse_intermixed_args(arguments)
+
+
 if __name__ == '__main__':
-    arguments = sys.argv[1:]
-    include_values = False
-    expected_samples = None
-    requirements_file = None
-    if '--include-values' in arguments:
-        arguments.remove('--include-values')
-        include_values = True
-    if '--expected-samples' in arguments:
-        option_index = arguments.index('--expected-samples')
-        try:
-            expected_samples = int(arguments[option_index + 1])
-        except (IndexError, ValueError):
-            print("--expected-samples requires a positive integer", file=sys.stderr)
-            sys.exit(1)
-        if expected_samples < 1:
-            print("--expected-samples requires a positive integer", file=sys.stderr)
-            sys.exit(1)
-        del arguments[option_index:option_index + 2]
-    if '--requirements' in arguments:
-        option_index = arguments.index('--requirements')
-        try:
-            requirements_file = arguments[option_index + 1]
-        except IndexError:
-            print("--requirements requires a JSON file", file=sys.stderr)
-            sys.exit(1)
-        del arguments[option_index:option_index + 2]
-    if len(arguments) < 2:
-        print(
-            "Usage: compute_median.py [--include-values] [--expected-samples N]"
-            " [--requirements FILE]"
-            " <logcat1> [logcat2 ...] <output.json>"
-        )
-        sys.exit(1)
+    arguments = _parse_arguments()
     compute_median(
-        arguments[:-1],
-        arguments[-1],
-        include_values=include_values,
-        expected_samples=expected_samples,
+        arguments.logcat_files,
+        arguments.output_file,
+        include_values=arguments.include_values,
+        expected_samples=arguments.expected_samples,
         requirements=(
-            _load_requirements(requirements_file)
-            if requirements_file is not None
+            _load_requirements(arguments.requirements)
+            if arguments.requirements is not None
             else None
         ),
     )

--- a/scripts/perf/dashboard/app.js
+++ b/scripts/perf/dashboard/app.js
@@ -8,6 +8,7 @@
     ROOM_ENTRY_SUMMARY,
     checkpointForSelection,
     classifySeries,
+    compatibleBenchmarkRecords,
     hasEnoughFrames,
     hasEnoughWebFrames,
     historyWindow,
@@ -249,8 +250,8 @@
       state.loadId
     )) return false;
     const selectedDates = new Set(entries.map(entry => entry.date));
-    state.historyRecords = loaded;
-    state.records = loaded.filter(record => selectedDates.has(record.date));
+    state.historyRecords = compatibleBenchmarkRecords(loaded);
+    state.records = state.historyRecords.filter(record => selectedDates.has(record.date));
     return true;
   }
 
@@ -822,16 +823,16 @@
       : "Firebase Test Lab · suivi quotidien";
     elements["source-rss"].textContent = web
       ? "médiane · 3 répétitions Chrome"
-      : "médiane · 3 appareils virtuels";
+      : "médiane · 3 runs physiques";
     elements["source-fps"].textContent = web
       ? "indice relatif · 3 répétitions Chrome"
-      : "1 téléphone physique";
+      : "médiane · 3 runs physiques";
     elements["source-jank"].textContent = web
       ? "médiane · 3 répétitions Chrome"
-      : "1 téléphone physique";
+      : "médiane · 3 runs physiques";
     elements["source-transition"].textContent = web
       ? "médiane · 3 répétitions Chrome"
-      : "1 téléphone physique";
+      : "médiane · 3 runs physiques";
     elements["title-rss"].textContent = web ? "Mémoire JavaScript" : "Mémoire utilisée";
     elements["description-rss"].textContent = web
       ? "Mémoire du moteur JavaScript exposée par Chrome ; elle n’est jamais comparée à la RAM Android."
@@ -852,7 +853,7 @@
     elements["filter-checkpoint"].hidden = web;
     elements["footer-source"].textContent = web
       ? "Chrome headless · GitHub runner · médiane de 3 répétitions"
-      : "Mémoire : médiane de 3 runs virtuels · Fluidité : 1 run physique";
+      : "Pixel 6 physique · APK profile · médiane de 3 runs séquentiels";
     elements["workflow-link"].href = web
       ? "https://github.com/linagora/twake-on-matrix/actions/workflows/patrol-web-integration-test.yaml"
       : "https://github.com/linagora/twake-on-matrix/actions/workflows/integration-tests.yaml";

--- a/scripts/perf/dashboard/index.html
+++ b/scripts/perf/dashboard/index.html
@@ -87,7 +87,7 @@
         <article class="metric-card metric-memory" data-metric="rss_bytes">
           <div class="metric-heading">
             <span class="metric-icon">RAM</span>
-            <span class="source-badge" id="source-rss">médiane · 3 appareils virtuels</span>
+            <span class="source-badge" id="source-rss">médiane · 3 runs physiques</span>
           </div>
           <strong id="value-rss">—</strong>
           <h2 id="title-rss">Mémoire utilisée</h2>
@@ -98,7 +98,7 @@
         <article class="metric-card metric-fps" data-metric="fps">
           <div class="metric-heading">
             <span class="metric-icon" id="metric-icon-fps">FPS</span>
-            <span class="source-badge physical" id="source-fps">1 téléphone physique</span>
+            <span class="source-badge physical" id="source-fps">médiane · 3 runs physiques</span>
           </div>
           <strong id="value-fps">—</strong>
           <h2 id="title-fps">Fluidité mesurée</h2>
@@ -109,7 +109,7 @@
         <article class="metric-card metric-jank" data-metric="jank_rate">
           <div class="metric-heading">
             <span class="metric-icon">!</span>
-            <span class="source-badge physical" id="source-jank">1 téléphone physique</span>
+            <span class="source-badge physical" id="source-jank">médiane · 3 runs physiques</span>
           </div>
           <strong id="value-jank">—</strong>
           <h2 id="title-jank">Frames saccadées</h2>
@@ -120,7 +120,7 @@
         <article class="metric-card metric-transition" data-metric="transition_ms">
           <div class="metric-heading">
             <span class="metric-icon">↗</span>
-            <span class="source-badge physical" id="source-transition">1 téléphone physique</span>
+            <span class="source-badge physical" id="source-transition">médiane · 3 runs physiques</span>
           </div>
           <strong id="value-transition">—</strong>
           <h2 id="title-transition">Ouverture d’une conversation</h2>
@@ -186,7 +186,7 @@
     </main>
 
     <footer>
-      <span id="footer-source">Mémoire&nbsp;: médiane de 3 runs virtuels · Fluidité&nbsp;: 1 run physique</span>
+      <span id="footer-source">Pixel 6 physique · APK profile · médiane de 3 runs séquentiels</span>
       <a id="workflow-link" href="https://github.com/linagora/twake-on-matrix/actions/workflows/integration-tests.yaml">
         Voir le workflow nightly ↗
       </a>

--- a/scripts/perf/dashboard/metrics.js
+++ b/scripts/perf/dashboard/metrics.js
@@ -186,13 +186,25 @@ globalThis.PerfMetrics = (() => {
     return record?.environment?.build_mode === "profile";
   }
 
+  function benchmarkSource(record) {
+    return record?.environment?.benchmark_source || "hybrid";
+  }
+
+  function compatibleBenchmarkRecords(records) {
+    if (!records.length) return [];
+    const source = benchmarkSource(records.at(-1));
+    return records.filter(record => benchmarkSource(record) === source);
+  }
+
   return {
     MIN_FRAME_SAMPLE,
     MIN_WEB_FRAME_SAMPLE,
     MIN_WEB_FRAME_WINDOW_MS,
     ROOM_ENTRY_SUMMARY,
+    benchmarkSource,
     checkpointForSelection,
     classifySeries,
+    compatibleBenchmarkRecords,
     hasEnoughFrames,
     hasEnoughWebFrames,
     historyWindow,

--- a/scripts/perf/tests/test_compute_median.py
+++ b/scripts/perf/tests/test_compute_median.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from scripts.perf.compute_median import compute_median
+from scripts.perf.compute_median import _load_requirements, compute_median
 
 
 class ComputeMedianTest(unittest.TestCase):
@@ -22,6 +22,35 @@ class ComputeMedianTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.temporary_directory.cleanup()
+
+    def test_load_requirements_combines_common_and_checkpoint_metrics(self) -> None:
+        manifest = self.directory / "requirements.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "common_metrics": ["fps", "frame_count"],
+                    "checkpoints": [
+                        {
+                            "scenario": "nav_cycles",
+                            "label": "room_enter_cycle1",
+                            "extra_metrics": ["transition_ms"],
+                            "excluded_metrics": ["fps"],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertEqual(
+            _load_requirements(str(manifest)),
+            {
+                ("nav_cycles", "room_enter_cycle1"): {
+                    "frame_count",
+                    "transition_ms",
+                }
+            },
+        )
 
     def test_default_output_keeps_existing_contract(self) -> None:
         output = self.directory / "median.json"
@@ -59,6 +88,103 @@ class ComputeMedianTest(unittest.TestCase):
         self.assertEqual(checkpoint["fps_values"], [58.0, 62.0])
         self.assertEqual(checkpoint["transition_ms_sample_count"], 3)
         self.assertEqual(checkpoint["transition_ms_values"], [101.0, 102.0, 103.0])
+
+    def test_expected_samples_rejects_incomplete_metric(self) -> None:
+        Path(self.logs[1]).write_text(
+            "PERF_METRIC | web_navigation | room_opened"
+            " | transition_ms=102\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"web_navigation/room_opened/fps has 2 sample\(s\); expected 3",
+        ):
+            compute_median(
+                self.logs,
+                str(self.directory / "median.json"),
+                expected_samples=3,
+            )
+
+    def test_expected_samples_rejects_duplicate_repetition(self) -> None:
+        combined_log = self.directory / "combined.log"
+        combined_log.write_text(
+            "PERF_METRIC | web_navigation | room_opened | run=r1 | fps=58\n"
+            "PERF_METRIC | web_navigation | room_opened | run=r1 | fps=59\n"
+            "PERF_METRIC | web_navigation | room_opened | run=r2 | fps=60\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"duplicate sample.*web_navigation/room_opened.*r1",
+        ):
+            compute_median(
+                [str(combined_log)],
+                str(self.directory / "median.json"),
+                expected_samples=3,
+            )
+
+    def test_expected_samples_rejects_two_android_samples_from_one_file(self) -> None:
+        Path(self.logs[0]).write_text(
+            "PERF_METRIC | nav_cycles | room_enter_cycle1 | run=r1 | fps=58\n"
+            "PERF_METRIC | nav_cycles | room_enter_cycle1 | run=r2 | fps=59\n",
+            encoding="utf-8",
+        )
+        Path(self.logs[1]).write_text(
+            "PERF_METRIC | nav_cycles | room_enter_cycle1 | run=r3 | fps=60\n",
+            encoding="utf-8",
+        )
+        Path(self.logs[2]).write_text("", encoding="utf-8")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"duplicate sample.*nav_cycles/room_enter_cycle1.*source 0",
+        ):
+            compute_median(
+                self.logs,
+                str(self.directory / "median.json"),
+                expected_samples=3,
+            )
+
+    def test_requirements_reject_metric_absent_from_every_repetition(self) -> None:
+        for index, path in enumerate(self.logs, start=1):
+            Path(path).write_text(
+                "PERF_METRIC | web_navigation | room_opened"
+                f" | transition_ms={100 + index}\n",
+                encoding="utf-8",
+            )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"web_navigation/room_opened/fps is missing",
+        ):
+            compute_median(
+                self.logs,
+                str(self.directory / "median.json"),
+                expected_samples=3,
+                requirements={
+                    ("web_navigation", "room_opened"): {
+                        "fps",
+                        "transition_ms",
+                    },
+                },
+            )
+
+    def test_requirements_reject_checkpoint_absent_from_every_repetition(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            r"required checkpoint web_navigation/scroll_completed is missing",
+        ):
+            compute_median(
+                self.logs,
+                str(self.directory / "median.json"),
+                expected_samples=3,
+                requirements={
+                    ("web_navigation", "room_opened"): {"fps"},
+                    ("web_navigation", "scroll_completed"): {"fps"},
+                },
+            )
 
     def test_missing_checkpoint_reduces_sample_count(self) -> None:
         Path(self.logs[1]).write_text("", encoding="utf-8")

--- a/scripts/perf/tests/test_compute_median.py
+++ b/scripts/perf/tests/test_compute_median.py
@@ -52,6 +52,73 @@ class ComputeMedianTest(unittest.TestCase):
             },
         )
 
+    def test_android_requirements_exclude_frames_only_from_idle_checkpoints(
+        self,
+    ) -> None:
+        requirements = _load_requirements(
+            str(Path(__file__).parents[1] / "android_requirements.json")
+        )
+        frame_metrics = {
+            "frame_window_ms",
+            "fps",
+            "build_p50_us",
+            "build_p95_us",
+            "build_p99_us",
+            "raster_p50_us",
+            "raster_p95_us",
+            "raster_p99_us",
+            "jank_count",
+            "jank_rate",
+        }
+        idle_checkpoints = {
+            ("scroll_room1", "scroll_end"),
+            ("scroll_room1", "scroll_settled"),
+            ("scroll_room2", "scroll_end"),
+            ("scroll_room2", "scroll_settled"),
+        }
+        expected_checkpoints = {
+            ("nav_cycles", "chat_list_baseline"),
+            *(('nav_cycles', f'room_enter_cycle{cycle}') for cycle in range(1, 6)),
+            *(
+                ('nav_cycles', f'chat_list_after_cycle{cycle}')
+                for cycle in range(1, 6)
+            ),
+            *(
+                (scenario, label)
+                for scenario, room in (("scroll_room1", 1), ("scroll_room2", 2))
+                for label in (
+                    "room_entered",
+                    f"room{room}_scroll_step_5of15",
+                    f"room{room}_scroll_step_10of15",
+                    f"room{room}_scroll_step_15of15",
+                    "scroll_end",
+                    "scroll_settled",
+                    "back_to_list",
+                )
+            ),
+            ("chat_list_scroll", "list_top"),
+            ("chat_list_scroll", "list_bottom"),
+            ("chat_list_scroll", "list_top_again"),
+        }
+        always_required = {
+            "rss_bytes",
+            "cache_bytes",
+            "cache_count",
+            "cache_live",
+            "cache_pending",
+            "frame_count",
+        }
+
+        self.assertEqual(set(requirements), expected_checkpoints)
+        self.assertEqual(len(requirements), 28)
+
+        for checkpoint, metrics in requirements.items():
+            self.assertTrue(always_required.issubset(metrics), checkpoint)
+            if checkpoint in idle_checkpoints:
+                self.assertTrue(frame_metrics.isdisjoint(metrics), checkpoint)
+            else:
+                self.assertTrue(frame_metrics.issubset(metrics), checkpoint)
+
     def test_default_output_keeps_existing_contract(self) -> None:
         output = self.directory / "median.json"
         compute_median(self.logs, str(output))

--- a/scripts/perf/tests/test_compute_median.py
+++ b/scripts/perf/tests/test_compute_median.py
@@ -55,7 +55,9 @@ class ComputeMedianTest(unittest.TestCase):
         checkpoint = json.loads(output.read_text(encoding="utf-8"))[0]
         self.assertEqual(checkpoint["sample_count"], 3)
         self.assertEqual(checkpoint["fps"], 60.0)
+        self.assertEqual(checkpoint["fps_sample_count"], 2)
         self.assertEqual(checkpoint["fps_values"], [58.0, 62.0])
+        self.assertEqual(checkpoint["transition_ms_sample_count"], 3)
         self.assertEqual(checkpoint["transition_ms_values"], [101.0, 102.0, 103.0])
 
     def test_missing_checkpoint_reduces_sample_count(self) -> None:

--- a/scripts/perf/tests/test_compute_median.py
+++ b/scripts/perf/tests/test_compute_median.py
@@ -1,9 +1,15 @@
+import io
 import json
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 
-from scripts.perf.compute_median import _load_requirements, compute_median
+from scripts.perf.compute_median import (
+    _load_requirements,
+    _parse_arguments,
+    compute_median,
+)
 
 
 class ComputeMedianTest(unittest.TestCase):
@@ -51,6 +57,49 @@ class ComputeMedianTest(unittest.TestCase):
                 }
             },
         )
+
+    def test_command_line_parser_accepts_options_between_paths(self) -> None:
+        requirements = self.directory / "requirements.json"
+
+        arguments = _parse_arguments(
+            [
+                self.logs[0],
+                "--include-values",
+                "--expected-samples",
+                "3",
+                "--requirements",
+                str(requirements),
+                self.logs[1],
+                "median.json",
+            ]
+        )
+
+        self.assertTrue(arguments.include_values)
+        self.assertEqual(arguments.expected_samples, 3)
+        self.assertEqual(arguments.requirements, requirements)
+        self.assertEqual(arguments.logcat_files, self.logs[:2])
+        self.assertEqual(arguments.output_file, "median.json")
+
+    def test_command_line_parser_rejects_invalid_option_values(self) -> None:
+        cases = (
+            (["--expected-samples", "0", "run.log", "out.json"], "positive integer"),
+            (
+                ["--expected-samples", "many", "run.log", "out.json"],
+                "positive integer",
+            ),
+            (
+                ["--requirements", "--include-values", "run.log", "out.json"],
+                "expected one argument",
+            ),
+        )
+
+        for arguments, expected_error in cases:
+            with self.subTest(arguments=arguments):
+                stderr = io.StringIO()
+                with redirect_stderr(stderr), self.assertRaises(SystemExit) as error:
+                    _parse_arguments(arguments)
+                self.assertEqual(error.exception.code, 2)
+                self.assertIn(expected_error, stderr.getvalue())
 
     def test_android_requirements_exclude_frames_only_from_idle_checkpoints(
         self,

--- a/scripts/perf/tests/test_dashboard_metrics.js
+++ b/scripts/perf/tests/test_dashboard_metrics.js
@@ -8,8 +8,10 @@ const {
   MIN_WEB_FRAME_SAMPLE,
   MIN_WEB_FRAME_WINDOW_MS,
   ROOM_ENTRY_SUMMARY,
+  benchmarkSource,
   checkpointForSelection,
   classifySeries,
+  compatibleBenchmarkRecords,
   hasEnoughFrames,
   hasEnoughWebFrames,
   historyWindow,
@@ -152,6 +154,25 @@ test("rejects legacy debug records from performance comparisons", () => {
   assert.equal(isProfileRecord(record([])), false);
   assert.equal(isProfileRecord({ environment: { build_mode: "debug" } }), false);
   assert.equal(isProfileRecord({ environment: { build_mode: "profile" } }), true);
+});
+
+test("keeps hybrid and physical-only Android histories separate", () => {
+  const hybrid = { date: "2026-07-27", environment: { build_mode: "profile" } };
+  const physical = {
+    date: "2026-07-28",
+    environment: { build_mode: "profile", benchmark_source: "physical" },
+  };
+  const latestPhysical = {
+    date: "2026-07-29",
+    environment: { build_mode: "profile", benchmark_source: "physical" },
+  };
+
+  assert.equal(benchmarkSource(hybrid), "hybrid");
+  assert.equal(benchmarkSource(physical), "physical");
+  assert.deepEqual(
+    compatibleBenchmarkRecords([hybrid, physical, latestPhysical]),
+    [physical, latestPhysical]
+  );
 });
 
 test("anchors a finite history window to the latest recorded night", () => {

--- a/scripts/perf/tests/test_update_history.py
+++ b/scripts/perf/tests/test_update_history.py
@@ -29,6 +29,18 @@ def checkpoint(samples=3, value=100.0):
     }
 
 
+def physical_checkpoint(samples=3, value=100.0):
+    result = checkpoint(samples=samples, value=value)
+    for key, metric in list(result.items()):
+        if (
+            key not in {"scenario", "label", "sample_count"}
+            and isinstance(metric, (int, float))
+            and not key.endswith(("_stddev", "_range"))
+        ):
+            result[f"{key}_sample_count"] = samples
+    return result
+
+
 def record(day="2026-07-22", sha="abc123"):
     metadata = RecordMetadata(
         day=day,
@@ -59,6 +71,51 @@ class BuildDailyRecordTest(unittest.TestCase):
         self.assertEqual(daily["environment"]["virtual_device"]["runs"], 3)
         self.assertEqual(daily["environment"]["physical_device"]["runs"], 1)
         self.assertEqual(daily["environment"]["build_mode"], "profile")
+
+    def test_describes_three_run_physical_only_aggregation(self):
+        metadata = RecordMetadata(
+            day="2026-07-22",
+            generated_at="2026-07-22T00:15:00Z",
+            repository="linagora/twake-on-matrix",
+            sha="abc123",
+            run_id="12345",
+            flutter_version="3.38.9",
+        )
+
+        daily = build_daily_record(
+            [physical_checkpoint()],
+            [physical_checkpoint()],
+            metadata,
+            benchmark_source="physical",
+            physical_runs=3,
+        )
+
+        self.assertNotIn("virtual_device", daily["environment"])
+        self.assertEqual(daily["environment"]["benchmark_source"], "physical")
+        self.assertEqual(daily["environment"]["physical_device"]["runs"], 3)
+        self.assertEqual(daily["memory"]["aggregation"], "median")
+        self.assertEqual(daily["physical"]["aggregation"], "median")
+
+    def test_rejects_incomplete_metric_in_physical_median(self):
+        metadata = RecordMetadata(
+            day="2026-07-22",
+            generated_at="2026-07-22T00:15:00Z",
+            repository="linagora/twake-on-matrix",
+            sha="abc123",
+            run_id="12345",
+            flutter_version="3.38.9",
+        )
+        incomplete = physical_checkpoint()
+        incomplete["rss_bytes_sample_count"] = 1
+
+        with self.assertRaisesRegex(HistoryError, "rss_bytes has 1 sample"):
+            build_daily_record(
+                [incomplete],
+                [incomplete],
+                metadata,
+                benchmark_source="physical",
+                physical_runs=3,
+            )
 
     def test_rejects_invalid_virtual_aggregation(self):
         cases = (
@@ -209,6 +266,39 @@ class UpdateHistoryTest(unittest.TestCase):
             write_summary(summary_path, data_directory, index, current)
 
             self.assertNotIn("### Largest visual regression markers", summary_path.read_text())
+
+    def test_summary_excludes_hybrid_baselines_for_physical_only_run(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            data_directory = Path(temporary_directory)
+            for day in range(1, 8):
+                update_history(
+                    data_directory,
+                    record(f"2026-07-{day:02d}", f"hybrid-{day}"),
+                )
+
+            metadata = RecordMetadata(
+                day="2026-07-08",
+                generated_at="2026-07-08T00:15:00Z",
+                repository="linagora/twake-on-matrix",
+                sha="physical",
+                run_id="54321",
+                flutter_version="3.38.9",
+            )
+            current = build_daily_record(
+                [physical_checkpoint(value=150.0)],
+                [physical_checkpoint(value=150.0)],
+                metadata,
+                benchmark_source="physical",
+                physical_runs=3,
+            )
+            index = update_history(data_directory, current)
+            summary_path = data_directory / "summary.md"
+            write_summary(summary_path, data_directory, index, current)
+
+            self.assertNotIn(
+                "### Largest visual regression markers",
+                summary_path.read_text(),
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/perf/tests/test_update_history.py
+++ b/scripts/perf/tests/test_update_history.py
@@ -69,6 +69,7 @@ class BuildDailyRecordTest(unittest.TestCase):
         self.assertEqual(daily["physical"]["checkpoints"][0]["fps"], 60.0)
         self.assertEqual(daily["physical"]["checkpoints"][0]["frame_window_ms"], 650.0)
         self.assertEqual(daily["environment"]["virtual_device"]["runs"], 3)
+        self.assertEqual(daily["environment"]["benchmark_source"], "hybrid")
         self.assertEqual(daily["environment"]["physical_device"]["runs"], 1)
         self.assertEqual(daily["environment"]["build_mode"], "profile")
 

--- a/scripts/perf/update_history.py
+++ b/scripts/perf/update_history.py
@@ -112,6 +112,35 @@ def _validate_checkpoints(value: Any, source: str, minimum_samples: int) -> list
     ]
 
 
+def _validate_metric_sample_counts(
+    checkpoints: list[dict],
+    source: str,
+    minimum_samples: int,
+) -> None:
+    derived_suffixes = ("_sample_count", "_stddev", "_range")
+    for position, checkpoint in enumerate(checkpoints):
+        location = _checkpoint_location(source, position)
+        metric_keys = [
+            key
+            for key in checkpoint
+            if key not in {"scenario", "label", "sample_count"}
+            and not key.endswith(derived_suffixes)
+        ]
+        for key in metric_keys:
+            sample_count = checkpoint.get(f"{key}_sample_count")
+            if not _is_finite_number(sample_count):
+                raise HistoryError(f"{location}.{key}_sample_count is required")
+            assert isinstance(sample_count, (int, float)) and not isinstance(
+                sample_count,
+                bool,
+            )
+            if sample_count < minimum_samples:
+                raise HistoryError(
+                    f"{location}.{key} has {sample_count} sample(s); "
+                    f"at least {minimum_samples} required"
+                )
+
+
 def _validate_day(day: str) -> None:
     try:
         date.fromisoformat(day)
@@ -150,11 +179,44 @@ def build_daily_record(
     memory: Any,
     physical: Any,
     metadata: RecordMetadata,
+    *,
+    benchmark_source: str = "hybrid",
+    physical_runs: int = 1,
 ) -> dict:
     _validate_metadata(metadata)
+    if benchmark_source not in {"hybrid", "physical"}:
+        raise HistoryError(f"Unsupported benchmark source: {benchmark_source}")
+    if physical_runs < 1:
+        raise HistoryError("physical_runs must be at least 1")
     memory_checkpoints = _validate_checkpoints(memory, "memory", minimum_samples=3)
-    physical_checkpoints = _validate_checkpoints(physical, "physical", minimum_samples=1)
+    physical_minimum_samples = 3 if benchmark_source == "physical" else 1
+    physical_checkpoints = _validate_checkpoints(
+        physical,
+        "physical",
+        minimum_samples=physical_minimum_samples,
+    )
+    if benchmark_source == "physical":
+        _validate_metric_sample_counts(memory_checkpoints, "memory", physical_runs)
+        _validate_metric_sample_counts(physical_checkpoints, "physical", physical_runs)
     repository_url = f"https://github.com/{metadata.repository}"
+
+    environment = {
+        "flutter_version": metadata.flutter_version,
+        "build_mode": "profile",
+        "physical_device": {
+            "model": "oriole",
+            "android": 33,
+            "runs": physical_runs,
+        },
+    }
+    if benchmark_source == "hybrid":
+        environment["virtual_device"] = {
+            "model": "MediumPhone.arm",
+            "android": 34,
+            "runs": 3,
+        }
+    else:
+        environment["benchmark_source"] = "physical"
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -168,14 +230,12 @@ def build_daily_record(
             "id": str(metadata.run_id),
             "url": f"{repository_url}/actions/runs/{metadata.run_id}",
         },
-        "environment": {
-            "flutter_version": metadata.flutter_version,
-            "build_mode": "profile",
-            "virtual_device": {"model": "MediumPhone.arm", "android": 34, "runs": 3},
-            "physical_device": {"model": "oriole", "android": 33, "runs": 1},
-        },
+        "environment": environment,
         "memory": {"aggregation": "median", "checkpoints": memory_checkpoints},
-        "physical": {"aggregation": "single_run", "checkpoints": physical_checkpoints},
+        "physical": {
+            "aggregation": "median" if physical_runs >= 3 else "single_run",
+            "checkpoints": physical_checkpoints,
+        },
     }
 
 
@@ -330,10 +390,16 @@ def _regressions(data_directory: Path, index: dict, current: dict) -> list[dict]
     prior_entries = [item for item in index["entries"] if item["date"] < current["date"]]
     prior_records = [_load_json(data_directory / item["file"]) for item in prior_entries]
     build_mode = current.get("environment", {}).get("build_mode")
+    benchmark_source = current.get("environment", {}).get(
+        "benchmark_source",
+        "hybrid",
+    )
     compatible_records = [
         record
         for record in prior_records
         if record.get("environment", {}).get("build_mode") == build_mode
+        and record.get("environment", {}).get("benchmark_source", "hybrid")
+        == benchmark_source
     ][-7:]
     if len(compatible_records) < 7:
         return []
@@ -382,6 +448,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--sha", required=True)
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--flutter-version", required=True)
+    parser.add_argument(
+        "--benchmark-source",
+        choices=("hybrid", "physical"),
+        default="hybrid",
+    )
+    parser.add_argument("--physical-runs", type=int, default=1)
     parser.add_argument("--summary-file", type=Path)
     return parser.parse_args()
 
@@ -400,6 +472,8 @@ def main() -> None:
         _load_json(args.memory),
         _load_json(args.physical),
         metadata,
+        benchmark_source=args.benchmark_source,
+        physical_runs=args.physical_runs,
     )
     index = update_history(args.data_directory, record)
     if args.summary_file:

--- a/scripts/perf/update_history.py
+++ b/scripts/perf/update_history.py
@@ -203,6 +203,7 @@ def build_daily_record(
     environment = {
         "flutter_version": metadata.flutter_version,
         "build_mode": "profile",
+        "benchmark_source": benchmark_source,
         "physical_device": {
             "model": "oriole",
             "android": 33,
@@ -215,9 +216,6 @@ def build_daily_record(
             "android": 34,
             "runs": 3,
         }
-    else:
-        environment["benchmark_source"] = "physical"
-
     return {
         "schema_version": SCHEMA_VERSION,
         "date": metadata.day,

--- a/test/integration_test/base/perf_collector_test.dart
+++ b/test/integration_test/base/perf_collector_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -24,6 +25,33 @@ FrameTiming frameTiming({
 }
 
 void main() {
+  testWidgets('waits for batched frame timings before checkpointing', (
+    tester,
+  ) async {
+    final waits = <Duration>[];
+    final timingBatchReported = Completer<void>();
+    final collector = PerfCollector(
+      'test',
+      waitForFrameTimings: (duration) {
+        waits.add(duration);
+        return timingBatchReported.future;
+      },
+    );
+
+    var checkpointCompleted = false;
+    final checkpoint = collector.checkpoint('after_transition').then((_) {
+      checkpointCompleted = true;
+    });
+    await tester.pump();
+
+    expect(waits, [const Duration(milliseconds: 200)]);
+    expect(checkpointCompleted, isFalse);
+
+    timingBatchReported.complete();
+    await checkpoint;
+    expect(checkpointCompleted, isTrue);
+  });
+
   test('computes effective FPS from the observed vsync window', () {
     final frames = List.generate(
       31,

--- a/test/integration_test/matrix_login_retry_test.dart
+++ b/test/integration_test/matrix_login_retry_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:matrix/matrix.dart';
+
+import '../../integration_test/base/matrix_login_retry.dart';
+
+void main() {
+  test('retries a rate-limited login using retry_after_ms', () async {
+    var attempts = 0;
+    final waits = <Duration>[];
+
+    final result = await loginWithRateLimitRetry(
+      () async {
+        attempts++;
+        if (attempts == 1) {
+          throw MatrixException.fromJson({
+            'errcode': 'M_LIMIT_EXCEEDED',
+            'error': 'Too Many Requests',
+            'retry_after_ms': 1500,
+          });
+        }
+        return 'logged-in';
+      },
+      wait: (delay) async => waits.add(delay),
+      jitterMilliseconds: (_) => 0,
+    );
+
+    expect(result, 'logged-in');
+    expect(attempts, 2);
+    expect(waits, [const Duration(milliseconds: 1500)]);
+  });
+
+  test('prefers Retry-After over retry_after_ms', () async {
+    var attempts = 0;
+    final waits = <Duration>[];
+
+    final result = await loginWithRateLimitRetry(
+      () async {
+        attempts++;
+        if (attempts == 1) {
+          throw MatrixException(
+            http.Response(
+              '{'
+              '"errcode":"M_LIMIT_EXCEEDED",'
+              '"error":"Too Many Requests",'
+              '"retry_after_ms":1500'
+              '}',
+              429,
+              headers: {'Retry-After': '7'},
+            ),
+          );
+        }
+        return 'logged-in';
+      },
+      wait: (delay) async => waits.add(delay),
+      jitterMilliseconds: (_) => 0,
+    );
+
+    expect(result, 'logged-in');
+    expect(attempts, 2);
+    expect(waits, [const Duration(seconds: 7)]);
+  });
+
+  test('supports Retry-After in HTTP-date format', () async {
+    var attempts = 0;
+    final waits = <Duration>[];
+
+    await loginWithRateLimitRetry(
+      () async {
+        attempts++;
+        if (attempts == 1) {
+          throw MatrixException(
+            http.Response(
+              '{"errcode":"M_LIMIT_EXCEEDED","error":"Too Many Requests"}',
+              429,
+              headers: {'Retry-After': 'Wed, 29 Jul 2026 10:00:07 GMT'},
+            ),
+          );
+        }
+      },
+      now: () => DateTime.utc(2026, 7, 29, 10),
+      wait: (delay) async => waits.add(delay),
+      jitterMilliseconds: (_) => 0,
+    );
+
+    expect(waits, [const Duration(seconds: 7)]);
+  });
+
+  test(
+    'falls back to retry_after_ms for an invalid Retry-After header',
+    () async {
+      var attempts = 0;
+      final waits = <Duration>[];
+
+      await loginWithRateLimitRetry(
+        () async {
+          attempts++;
+          if (attempts == 1) {
+            throw MatrixException(
+              http.Response(
+                '{'
+                '"errcode":"M_LIMIT_EXCEEDED",'
+                '"error":"Too Many Requests",'
+                '"retry_after_ms":2200'
+                '}',
+                429,
+                headers: {'Retry-After': 'not-a-date'},
+              ),
+            );
+          }
+        },
+        wait: (delay) async => waits.add(delay),
+        jitterMilliseconds: (_) => 0,
+      );
+
+      expect(waits, [const Duration(milliseconds: 2200)]);
+    },
+  );
+
+  test('does not retry Matrix errors other than M_LIMIT_EXCEEDED', () async {
+    var attempts = 0;
+    final waits = <Duration>[];
+    final exception = MatrixException.fromJson({
+      'errcode': 'M_FORBIDDEN',
+      'error': 'Forbidden',
+    });
+
+    await expectLater(
+      loginWithRateLimitRetry(() async {
+        attempts++;
+        throw exception;
+      }, wait: (delay) async => waits.add(delay)),
+      throwsA(same(exception)),
+    );
+
+    expect(attempts, 1);
+    expect(waits, isEmpty);
+  });
+
+  test('stops after the configured maximum number of attempts', () async {
+    var attempts = 0;
+    final waits = <Duration>[];
+
+    await expectLater(
+      loginWithRateLimitRetry<void>(
+        () async {
+          attempts++;
+          throw MatrixException.fromJson({
+            'errcode': 'M_LIMIT_EXCEEDED',
+            'error': 'Too Many Requests',
+            'retry_after_ms': 1000,
+          });
+        },
+        maxAttempts: 3,
+        wait: (delay) async => waits.add(delay),
+        jitterMilliseconds: (_) => 0,
+      ),
+      throwsA(
+        isA<MatrixException>().having(
+          (exception) => exception.error,
+          'error',
+          MatrixError.M_LIMIT_EXCEEDED,
+        ),
+      ),
+    );
+
+    expect(attempts, 3);
+    expect(waits, [const Duration(seconds: 1), const Duration(seconds: 1)]);
+  });
+
+  test(
+    'uses exponential fallback and jitter when no server delay exists',
+    () async {
+      var attempts = 0;
+      final waits = <Duration>[];
+
+      final result = await loginWithRateLimitRetry(
+        () async {
+          attempts++;
+          if (attempts < 3) {
+            throw MatrixException.fromJson({
+              'errcode': 'M_LIMIT_EXCEEDED',
+              'error': 'Too Many Requests',
+            });
+          }
+          return 'logged-in';
+        },
+        maxAttempts: 3,
+        fallbackDelay: const Duration(seconds: 5),
+        wait: (delay) async => waits.add(delay),
+        jitterMilliseconds: (_) => 250,
+      );
+
+      expect(result, 'logged-in');
+      expect(waits, [
+        const Duration(milliseconds: 5250),
+        const Duration(milliseconds: 10250),
+      ]);
+    },
+  );
+}


### PR DESCRIPTION
## Ticket

**Related issue:** CI reliability follow-up; no linked issue.

## Root cause

Android nightlies could trigger concurrent password logins with the shared Matrix CI account and receive `M_LIMIT_EXCEEDED`. After login serialization and bounded retry were added, real FTL artifacts exposed a second race: Flutter delivers `FrameTiming` asynchronously in batches, so short checkpoints could read and reset the accumulator before the final batch arrived. This produced 30 incomplete metric series.

## Solution

- retry only `M_LIMIT_EXCEEDED`, honoring HTTP `Retry-After` before `retry_after_ms`, with bounded attempts and jitter
- scope shared-account serialization to the Android jobs that use that account; Web jobs keep their isolated local Synapse instances
- run three physical Android performance repetitions sequentially
- drain batched frame timings before checkpoint reset
- require three distinct samples and an explicit 28-checkpoint Android metric inventory
- record benchmark provenance and prevent physical/hybrid baseline mixing
- replace brittle performance CLI parsing with validated `argparse` options and simplify validation paths for code health

## Impact description

Android nightly performance data becomes publishable only when all three physical repetitions provide every required metric. Missing or duplicated samples fail closed. Existing hybrid history remains readable but is not compared with the new physical-only series.

## Test recommendations

- inspect the functional virtual-device E2E and all three sequential physical jobs
- confirm 28 checkpoints per physical logcat and three samples per required metric
- confirm `M_LIMIT_EXCEEDED` is retried but unrelated login/configuration errors fail immediately
- confirm Web E2E continues using one isolated local Synapse per job

Validated on FTL: https://github.com/linagora/twake-on-matrix/actions/runs/30446566008

- virtual-device E2E passed
- three sequential physical runs passed
- 84 `PERF_METRIC` records aggregated into 28 checkpoints
- zero incomplete metric sample counts
- no `M_LIMIT_EXCEEDED` / `Too Many Requests`

Local checks: Flutter analysis and targeted Dart tests, 31 Python tests, 17 Node dashboard tests, Python compilation and diff checks.

## Pre-merge

- obtain green PR quality gates after the review-comment fixes
- no migration or deployment required
- performance publication was deliberately disabled during FTL validation

## Resolved

No UI behavior changes; screenshots/videos are not applicable.

- Web: automated E2E passed
- Android: physical FTL validation passed
- iOS: not affected