### PR TITLE
TW-3303: File caption wrongly shown for files sent without a caption

### DIFF
--- a/lib/pages/chat/send_file_dialog/send_file_dialog.dart
+++ b/lib/pages/chat/send_file_dialog/send_file_dialog.dart
@@ -78,7 +78,15 @@ class SendFileDialogController extends State<SendFileDialog> {
       widget.room,
     );
     textEditingController.text = widget.pendingText ?? '';
-    requestFocusCaptions();
+    // Deferred to after the first frame: the caption FocusNode isn't
+    // attached to the FocusScope tree yet inside initState, so requesting
+    // focus here can silently no-op and leave focus on the chat's main
+    // composer underneath. On cold app start (chat composer autofocuses
+    // too) that race lets keystrokes/Enter reach both input bars, sending
+    // the caption a second time as a standalone text message.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) requestFocusCaptions();
+    });
     loadThumbnailsForMedia(filesNotifier.value);
   }
 

--- a/lib/pages/chat/send_file_dialog/send_file_dialog_view.dart
+++ b/lib/pages/chat/send_file_dialog/send_file_dialog_view.dart
@@ -4,7 +4,6 @@ import 'package:twake_chat/pages/chat/send_file_dialog/media_page_view_widget.da
 import 'package:twake_chat/pages/chat/send_file_dialog/send_file_dialog.dart';
 import 'package:twake_chat/pages/chat/send_file_dialog/send_file_dialog_style.dart';
 import 'package:twake_chat/presentation/enum/chat/send_media_with_caption_status_enum.dart';
-import 'package:twake_chat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
 
 import 'package:twake_chat/generated/l10n/app_localizations.dart';
@@ -111,7 +110,11 @@ class SendFileDialogView extends StatelessWidget {
                   ),
                   keyboardType: TextInputType.multiline,
                   typeAheadFocusNode: controller.captionsFocusNode,
-                  autofocus: !PlatformInfos.isMobile,
+                  // Focus is claimed explicitly via requestFocusCaptions()
+                  // (post-first-frame, see SendFileDialogController.initState)
+                  // instead of autofocus here, to avoid racing with the
+                  // chat composer's own autofocus underneath this dialog.
+                  autofocus: false,
                   onSubmitted: (_) => controller.send(),
                 ),
               ),

--- a/lib/utils/matrix_sdk_extensions/event_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/event_extension.dart
@@ -432,8 +432,19 @@ extension LocalizedBody on Event {
 
   /// Returns true if the event's body text differs from its filename.
   /// Used to determine if a caption should be displayed for media files.
+  ///
+  /// Per the Matrix media-captions extension to `m.file`/`m.image`/
+  /// `m.video`, `filename` is only set by clients that support captions,
+  /// and only when there IS a caption; `body` then holds the caption while
+  /// `filename` holds the original file name. When `filename` is absent,
+  /// `body` IS the filename (e.g. Element does not support file captions
+  /// and always sends the file name in `body` with no `filename` field),
+  /// so it must not be treated as a caption.
   bool isBodyDiffersFromFilename() {
-    return content["body"] != content["filename"];
+    final rawFilename = content.tryGet<String>('filename');
+    if (rawFilename == null) return false;
+
+    return body != rawFilename;
   }
 
   /// Returns true if this event is a reply to another event.

--- a/test/pages/chat/events/event_extension_test.dart
+++ b/test/pages/chat/events/event_extension_test.dart
@@ -787,8 +787,9 @@ void main() {
       expect(event.isCaptionModeOrReply(), false);
     });
 
-    test('GIVEN image event with no filename field (body differs from null)\n'
-        'THEN return true\n', () {
+    test('GIVEN image event with no filename field and body equal to the '
+        'implicit filename (e.g. sent from Element without a caption)\n'
+        'THEN return false\n', () {
       final event = createEvent(
         content: {
           'body': 'image.jpg',
@@ -797,7 +798,52 @@ void main() {
         },
       );
 
+      expect(event.isCaptionModeOrReply(), false);
+    });
+
+    test('GIVEN file event WITH a filename field and a different body '
+        '(real caption, matches spec: filename separate from body)\n'
+        'THEN return true\n', () {
+      final event = createEvent(
+        content: {
+          'body': 'Please review this before Friday',
+          'filename': 'report.pdf',
+          'msgtype': 'm.file',
+          'url': 'mxc://example.org/file123',
+        },
+      );
+
       expect(event.isCaptionModeOrReply(), true);
+    });
+
+    test('GIVEN file event sent from Element without a caption '
+        '(filename stored only in body)\n'
+        'THEN return false\n', () {
+      final event = createEvent(
+        content: {
+          'body': 'HuyNQ Remote Weekly Report 2026.xlsx',
+          'msgtype': 'm.file',
+          'url': 'mxc://stg.lin-saas.com/ayJakhwDGwMdCQqXipNwbBMq',
+        },
+      );
+
+      expect(event.isCaptionModeOrReply(), false);
+    });
+
+    test('GIVEN CSV file event sent from Element (issue #3303 payload, no '
+        'filename field)\n'
+        'THEN return false\n', () {
+      final event = createEvent(
+        content: {
+          'body': 'LARES-07-2026.csv',
+          'info': {'mimetype': 'text/csv', 'size': 100},
+          'm.mentions': {},
+          'msgtype': 'm.file',
+          'url': 'mxc://stg.lin-saas.com/YAtVeEBeCCwifqbzrNxzPknZ',
+        },
+      );
+
+      expect(event.isCaptionModeOrReply(), false);
     });
   });
 

--- a/test/pages/chat/events/message/message_content_builder_mixin_test.dart
+++ b/test/pages/chat/events/message/message_content_builder_mixin_test.dart
@@ -108,7 +108,8 @@ Future<void> main() async {
   );
   final imageEvent = Event(
     content: {
-      'body': 'filename.jpg',
+      'body': 'My vacation photo',
+      'filename': 'filename.jpg',
       'info': {'h': 398, 'mimetype': 'image/jpeg', 'size': 31037, 'w': 394},
       'msgtype': 'm.image',
       'url': 'mxc://example.org/JWEIFJgwEIhweiWJE',
@@ -122,6 +123,7 @@ Future<void> main() async {
   final videoEvent = Event(
     content: {
       'body': 'Gangnam Style',
+      'filename': 'gangnam_style.mp4',
       'info': {
         'duration': 2140786,
         'h': 320,


### PR DESCRIPTION
## Issue:
- #3303



https://github.com/user-attachments/assets/c420f6cc-4ac0-43ac-bcf1-33cc34f5e510


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved focus handling in the file-sending dialog to prevent conflicts with the chat composer.
- Corrected caption detection for media and file messages when filenames are available.
- Improved handling of files that do not include an explicit filename.

## Tests

- Expanded coverage for caption detection across image, video, CSV, and regular file messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->