### PR TITLE
Enable first three progressive linter rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,6 +11,7 @@ linter:
     - always_declare_return_types
     - avoid_field_initializers_in_const_classes
     - avoid_unused_constructor_parameters
+    - matching_super_parameters
 
 analyzer:
   errors:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,7 @@ linter:
     - prefer_final_in_for_each
     - require_trailing_commas
     - always_declare_return_types
+    - avoid_field_initializers_in_const_classes
 
 analyzer:
   errors:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,7 @@ linter:
     - require_trailing_commas
     - always_declare_return_types
     - avoid_field_initializers_in_const_classes
+    - avoid_unused_constructor_parameters
 
 analyzer:
   errors:

--- a/integration_test/base/web_perf_collector_stub.dart
+++ b/integration_test/base/web_perf_collector_stub.dart
@@ -1,6 +1,6 @@
 /// Non-web safeguard for the browser-only performance collector.
 class WebPerfCollector {
-  WebPerfCollector(String scenario);
+  WebPerfCollector(String _);
 
   void start() => throw UnsupportedError('WebPerfCollector requires a browser');
 

--- a/lib/pages/chat_details/chat_details_page_view/files/chat_details_files_row/chat_details_row_downloading_wrapper.dart
+++ b/lib/pages/chat_details/chat_details_page_view/files/chat_details_files_row/chat_details_row_downloading_wrapper.dart
@@ -18,7 +18,7 @@ class ChatDetailsFileRowDownloadingWrapper extends StatelessWidget {
     required this.downloadFileStateNotifier,
   });
 
-  final style = const MessageFileTileStyle();
+  static const style = MessageFileTileStyle();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/presentation/extensions/value_notifier_custom.dart
+++ b/lib/presentation/extensions/value_notifier_custom.dart
@@ -3,6 +3,8 @@ import 'package:flutter/foundation.dart';
 class ValueNotifierCustom<T> extends ValueNotifier<T> {
   bool _isDisposed = false;
 
+  // ValueNotifier's corresponding parameter is private to Flutter.
+  // ignore: matching_super_parameters
   ValueNotifierCustom(super.value);
 
   bool get isDisposed => _isDisposed;

--- a/test/mixin/contacts_view_controller_mixin_test.dart
+++ b/test/mixin/contacts_view_controller_mixin_test.dart
@@ -3,7 +3,6 @@ import 'package:debounce_throttle/debounce_throttle.dart';
 import 'package:twake_chat/app_state/success.dart';
 import 'package:twake_chat/domain/app_state/contact/get_contacts_state.dart';
 import 'package:twake_chat/domain/app_state/contact/get_phonebook_contact_state.dart';
-import 'package:twake_chat/domain/model/contact/contact_status.dart';
 import 'package:twake_chat/presentation/extensions/value_notifier_custom.dart';
 import 'package:twake_chat/presentation/mixins/contacts_view_controller_mixin.dart';
 import 'package:twake_chat/presentation/model/contact/get_presentation_contacts_success.dart';
@@ -24,7 +23,6 @@ class ConcretePresentationSearch extends PresentationSearch {
     required String super.displayName,
     required super.emails,
     required super.phoneNumbers,
-    required ContactStatus status,
   });
 
   @override
@@ -69,7 +67,6 @@ void main() {
           thirdPartyIdType: ThirdPartyIdType.msisdn,
         ),
       },
-      status: ContactStatus.active,
     ),
   ];
 


### PR DESCRIPTION
## Ticket

Related discussion: https://github.com/linagora/twake-on-matrix/discussions/3311

## Root cause

Not a bug. This is the first implementation step of the progressive linter rollout proposed in Discussion #3311.

## Solution

Enable and resolve the first three rules from the First wave, in the proposed order:

1. `avoid_field_initializers_in_const_classes`
2. `avoid_unused_constructor_parameters`
3. `matching_super_parameters`

Each rule and its corresponding fixes are isolated in a dedicated commit so the diagnostic impact stays reviewable.

## Impact description

- Adds three low-impact linter rules to `analysis_options.yaml`.
- Resolves 1, 2, and 1 diagnostics respectively.
- Keeps runtime behavior unchanged.

## Test recommendations

- `fvm dart analyze --format machine`
- `fvm flutter test test/mixin/contacts_view_controller_mixin_test.dart`
- Verify the three commits follow the rule order from Discussion #3311.

Local results:

- Analyzer passes with 0 diagnostics for all three new rules.
- Targeted test passes: 18 tests.
- `git diff --check` passes.

## Pre-merge

Nothing else required.

## Resolved

No UI changes.

- Web: N/A
- Android: N/A
- IOS: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal constructor and field declarations without changing visible behavior.
  * Improved consistency across shared components.

* **Tests**
  * Streamlined contact search test fixtures while preserving existing coverage.

* **Chores**
  * Added static analysis checks for unused constructor parameters, consistent parameter forwarding, and const class field patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->