### PR TITLE
fix(web): restore asset caching with our own service worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ARG YQ_VERSION=4.44.3
 # Single apt layer: install all deps, install Rust, install yq, then clean up
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      curl pkg-config libssl-dev openssh-client && \
+      curl pkg-config libssl-dev openssh-client python3 && \
     rm -rf /var/lib/apt/lists/* && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
     curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \

--- a/scripts/build-web.sh
+++ b/scripts/build-web.sh
@@ -8,3 +8,6 @@ flutter pub run build_runner build --delete-conflicting-outputs
 flutter build web --release --verbose --source-maps --base-href="$TWAKECHAT_BASE_HREF"
 cp config.sample.json ./build/web/config.json
 ./scripts/run-sentry.sh
+# Last: sentry_dart_plugin rewrites main.dart.js to inject Debug IDs, and the
+# manifest must hash what is actually served.
+./scripts/generate-sw-manifest.py

--- a/scripts/generate-sw-manifest.py
+++ b/scripts/generate-sw-manifest.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Injects the precache manifest into build/web/push_sw.js.
+
+Run from the repository root, as the LAST step that touches build/web: anything
+mutating the output afterwards (sentry_dart_plugin injects Debug IDs into
+main.dart.js) would leave the manifest describing bytes that are never served.
+
+Flutter does not content-hash its output filenames, so comparing content is the
+only way to know a resource changed between two deploys.
+
+config.json is excluded because it is injected at deploy time from Helm values:
+precached, it would pin the app to a stale homeserver or VAPID key whenever the
+config changes without an image rebuild. Source maps are excluded because
+main.dart.js.map alone is ~10 MB.
+"""
+
+import hashlib
+import json
+import pathlib
+import re
+import sys
+
+BUILD_DIR = pathlib.Path("build/web")
+WORKER = BUILD_DIR / "push_sw.js"
+
+EXCLUDED_NAMES = {"config.json", "push_sw.js", "flutter_service_worker.js"}
+EXCLUDED_SUFFIXES = (".map", ".gz")
+
+CORE_CANDIDATES = [
+    "main.dart.js",
+    "index.html",
+    "flutter_bootstrap.js",
+    "assets/AssetManifest.bin.json",
+    "assets/FontManifest.json",
+]
+
+ASSET_REFERENCE = re.compile(r"""\b(?:src|href)=["']([^"']+)["']""")
+
+
+def is_excluded(relative):
+    if relative in EXCLUDED_NAMES or relative.endswith(EXCLUDED_SUFFIXES):
+        return True
+    return any(part.startswith(".") for part in relative.split("/"))
+
+
+def collect_resources():
+    resources = {}
+    for path in sorted(BUILD_DIR.rglob("*")):
+        relative = path.relative_to(BUILD_DIR).as_posix()
+        if path.is_file() and not is_excluded(relative):
+            resources[relative] = hashlib.md5(path.read_bytes()).hexdigest()
+    return resources
+
+
+def referenced_by_index(index_html):
+    for reference in ASSET_REFERENCE.findall(index_html):
+        if reference.startswith(("http://", "https://", "//", "/", "#", "data:")):
+            continue
+        yield reference.split("?", 1)[0].split("#", 1)[0]
+
+
+def build_core(resources):
+    """CORE also holds what index.html pulls in: those load during the initial
+    HTML parse, before a first-visit worker exists, so leaving them out delays
+    the full benefit by one load."""
+    core = list(CORE_CANDIDATES)
+    core.extend(referenced_by_index((BUILD_DIR / "index.html").read_text()))
+    return [name for name in dict.fromkeys(core) if name in resources]
+
+
+def placeholder_for(token):
+    empty = "{}" if token.endswith("RESOURCES") else "[]"
+    return f"/*{{{{{token}}}}}*/ {empty}"
+
+
+def inject(source, values_by_token):
+    for token, value in values_by_token.items():
+        placeholder = placeholder_for(token)
+        if placeholder not in source:
+            sys.exit(f"error: placeholder for {token} not found in {WORKER}")
+        source = source.replace(placeholder, json.dumps(value, sort_keys=True), 1)
+    return source
+
+
+def main():
+    if not WORKER.is_file():
+        sys.exit(f"error: {WORKER} not found, run 'flutter build web' first")
+
+    resources = collect_resources()
+    if "index.html" not in resources:
+        sys.exit("error: index.html missing from the build output")
+    resources["/"] = resources["index.html"]
+
+    core = build_core(resources)
+    WORKER.write_text(
+        inject(
+            WORKER.read_text(),
+            {"TWAKE_PRECACHE_RESOURCES": resources, "TWAKE_PRECACHE_CORE": core},
+        )
+    )
+    print(f"precache manifest: {len(resources)} resources, {len(core)} in CORE")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/index.html
+++ b/web/index.html
@@ -88,43 +88,22 @@
 
         initialTchatApp();
 
-        if ('serviceWorker' in navigator) {
-          navigator
-            .serviceWorker
-            .getRegistrations()
-            .then(async function(registrations) {
-              try {
-                // Purge stale Flutter/legacy service workers (cache-busting workaround),
-                // but KEEP our Web Push SW so background notifications survive reloads.
-                await Promise.all(registrations.map(function(registration) {
-                  var url = (registration.active || registration.installing || registration.waiting || {}).scriptURL || '';
-                  if (url.indexOf('push_sw.js') !== -1) return Promise.resolve();
-                  return registration.unregister();
-                }));
-              } catch (error) {
-                console.log('[Twake Chat] Error unregistering service worker: ', error);
-              }
-              _flutter.loader.load({
-                onEntrypointLoaded: async function(engineInitializer) {
-                  const appRunner = await engineInitializer.initializeEngine({useColorEmoji: true});
-                  await setTimeout( async function () {
-                    await appRunner.runApp();
-                    // Register after runApp so this load's unregister sweep can't catch it.
-                    navigator.serviceWorker.register('push_sw.js').catch(function (error) {
-                      console.log('[Twake Chat] Error registering push service worker: ', error);
-                    });
-                  }, 2000);
-                }
-              });
+        _flutter.loader.load({
+          onEntrypointLoaded: async function (engineInitializer) {
+            const appRunner = await engineInitializer.initializeEngine({
+              useColorEmoji: true,
             });
-        } else {
-          _flutter.loader.load({
-            onEntrypointLoaded: async function (engineInitializer) {
-              const appRunner = await engineInitializer.initializeEngine({useColorEmoji: true});
-              await setTimeout( async function () {
-                await appRunner.runApp();
-              }, 2000);
-            },
+            await setTimeout( async function () {
+              await appRunner.runApp();
+            }, 2000);
+          },
+        });
+
+        // Registered after the entrypoint and never awaited: startup must not
+        // depend on the service worker settling.
+        if ('serviceWorker' in navigator) {
+          navigator.serviceWorker.register('push_sw.js').catch(function (error) {
+            console.log('[Twake Chat] Error registering service worker: ', error);
           });
         }
       });

--- a/web/push_sw.js
+++ b/web/push_sw.js
@@ -1,27 +1,162 @@
-/* Twake Chat — Web Push service worker (RFC 8030).
+/* Twake Chat — service worker: Web Push (RFC 8030) + precache.
+ *
  * Pusher is event_id_only (same privacy contract as mobile): the push carries
  * NO message content — only event_id/room_id. The SW shows a generic
- * notification; the app fetches the content when the user clicks it. No message
- * content ever transits the push service. Sygnal's events_only flag suppresses
- * content-less count-clear pushes, so every push maps to a real event
- * (satisfies userVisibleOnly).
- * ponytail: no JS test harness in this Flutter repo; covered by the manual
- * chrome://discards freeze repro in the plan's acceptance criteria.
+ * notification; the app fetches the content when the user clicks it. Sygnal's
+ * events_only flag suppresses content-less count-clear pushes, so every push
+ * maps to a real event (satisfies userVisibleOnly).
+ *
+ * A scope can only be controlled by a single service worker, so push and
+ * precache share this file. Do not add a second registration under /web/: it
+ * would silently replace this one.
+ *
+ * ponytail: no JS test harness in this Flutter repo.
  */
 
-// skipWaiting is required: without it a new SW version installs but stays in
-// `waiting` behind the old active worker while any tab is open, so users get
-// stuck on a stale worker until they manually unregister it (DevTools) — the
-// exact problem testers hit. skipWaiting promotes the new version to active on
-// the next load, replacing the old one with no user action.
-// No clients.claim(): a push SW only needs `push`/`notificationclick` on its
-// active worker, never to control app windows. (Verified: claim fires a
-// `controllerchange` but does NOT reload this app — flutter.js registers no SW
-// and has no controllerchange handler. Omitting claim is simply correct, not a
-// reload fix.)
-self.addEventListener('install', function () {
+'use strict';
+
+// Injected at build time by scripts/generate-sw-manifest.py. Empty on purpose:
+// an unbuilt worker falls through to the network rather than breaking.
+const RESOURCES = /*{{TWAKE_PRECACHE_RESOURCES}}*/ {};
+const CORE = /*{{TWAKE_PRECACHE_CORE}}*/ [];
+
+const CACHE_NAME = 'twake-chat-cache';
+const TEMP = 'twake-chat-cache-temp';
+const MANIFEST = 'twake-chat-manifest';
+
+// Keys in RESOURCES are scope-relative: the app is deployed under /web/, not at
+// the origin root.
+function resourceKey(url) {
+  const scope = self.registration.scope;
+  if (!url.startsWith(scope)) return null;
+  const key = url.substring(scope.length);
+  return key === '' ? '/' : key;
+}
+
+// skipWaiting is required: without it a new version stays in `waiting` behind
+// the old worker while any tab is open.
+//
+// CORE is fetched with the default cache mode, NOT {cache:'reload'}: the app is
+// requesting main.dart.js at the same time, and forcing a bypass would download
+// those 3.5 MB twice on a first visit. This is only safe because nginx serves
+// every asset with `Cache-Control: no-cache`, so the HTTP cache always
+// revalidates and can never hand back stale bytes. Keep the two in step.
+self.addEventListener('install', function (event) {
   self.skipWaiting();
+  event.waitUntil(
+    caches.open(TEMP).then(function (cache) {
+      return cache.addAll(CORE);
+    })
+  );
 });
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(
+    (async function () {
+      try {
+        var contentCache = await caches.open(CACHE_NAME);
+        const tempCache = await caches.open(TEMP);
+        const manifestCache = await caches.open(MANIFEST);
+        const manifest = await manifestCache.match('manifest');
+
+        if (!manifest) {
+          await caches.delete(CACHE_NAME);
+          contentCache = await caches.open(CACHE_NAME);
+          for (const request of await tempCache.keys()) {
+            const response = await tempCache.match(request);
+            await contentCache.put(request, response);
+          }
+          await caches.delete(TEMP);
+          await manifestCache.put(
+            'manifest',
+            new Response(JSON.stringify(RESOURCES))
+          );
+          await self.clients.claim();
+          return;
+        }
+
+        const oldManifest = await manifest.json();
+        for (const request of await contentCache.keys()) {
+          const key = resourceKey(request.url);
+          if (key === null || !RESOURCES[key] ||
+              RESOURCES[key] !== oldManifest[key]) {
+            await contentCache.delete(request);
+          }
+        }
+        for (const request of await tempCache.keys()) {
+          const response = await tempCache.match(request);
+          await contentCache.put(request, response);
+        }
+        await caches.delete(TEMP);
+        await manifestCache.put(
+          'manifest',
+          new Response(JSON.stringify(RESOURCES))
+        );
+        await self.clients.claim();
+      } catch (error) {
+        // A half-written cache is worse than none.
+        console.log('[Twake Chat] service worker activation failed: ', error);
+        await caches.delete(CACHE_NAME);
+        await caches.delete(TEMP);
+        await caches.delete(MANIFEST);
+      }
+    })()
+  );
+});
+
+self.addEventListener('fetch', function (event) {
+  if (event.request.method !== 'GET') return;
+
+  // config.json is deliberately absent from RESOURCES: it is injected at deploy
+  // time, so it must always come from the network.
+  const key = resourceKey(event.request.url);
+  if (key === null || !RESOURCES[key]) return;
+
+  // Serving index.html from cache would hide a deploy.
+  if (key === '/') return onlineFirst(event);
+
+  event.respondWith(
+    caches.open(CACHE_NAME).then(function (cache) {
+      return cache.match(event.request).then(function (response) {
+        return (
+          response ||
+          fetch(event.request).then(function (fetched) {
+            if (fetched && fetched.ok) cache.put(event.request, fetched.clone());
+            return fetched;
+          })
+        );
+      });
+    })
+  );
+});
+
+function onlineFirst(event) {
+  return event.respondWith(
+    fetch(event.request)
+      .then(function (response) {
+        return caches.open(CACHE_NAME).then(function (cache) {
+          cache.put(event.request, response.clone());
+          return response;
+        });
+      })
+      .catch(function (error) {
+        // CORE precaches the shell under index.html, so a root navigation misses
+        // until an online load has stored '/' as well. Fall back to the shell,
+        // or a first offline start would fail with the page already cached.
+        return caches.open(CACHE_NAME).then(function (cache) {
+          return cache
+            .match(event.request)
+            .then(function (response) {
+              return response || cache.match('index.html');
+            })
+            .then(function (response) {
+              if (response != null) return response;
+              throw error;
+            });
+        });
+      })
+  );
+}
 
 self.addEventListener('push', function (event) {
   var data = {};
@@ -59,8 +194,7 @@ self.addEventListener('pushsubscriptionchange', function (event) {
   // Endpoint rotated (expiry/reset). Re-subscribe so pushes keep arriving;
   // the Matrix pusher is re-synced by setupWebPush on the next app open
   // (it drops the stale pusher). applicationServerKey accepts the base64url
-  // VAPID string directly. ponytail: read the key from config.json so the SW
-  // stays config-driven without a build step.
+  // VAPID string directly.
   event.waitUntil(
     fetch('config.json')
       .then(function (r) { return r.json(); })


### PR DESCRIPTION
## Summary

- Move precaching into `web/push_sw.js`, alongside the existing Web Push handlers, driven by a path/MD5 manifest generated at build time by `scripts/generate-sw-manifest.py`.
- Stop unregistering service workers on every load in `web/index.html`, and register this one instead, awaited before the entrypoint so a first install does not download `main.dart.js` twice.
- Exclude `config.json` from the precache manifest, along with source maps, pre-compressed `.gz` twins and dotfiles.

## Why the cache was off

Flutter does not content-hash its build output. `main.dart.js`, `canvaskit/`, fonts and assets all keep fixed URLs across releases, so an HTTP cache cannot serve them: a long `max-age` would go stale forever, and the only safe header is `Cache-Control: no-cache`, which is what `server/nginx.conf` sends for everything.

The mechanism that makes fixed URLs workable is a content manifest diffed between deploys. Flutter shipped one as `flutter_service_worker.js`. PR #2268 removed it (`48497fcdc`, "Delegate cache to browser") and added the global `no-cache` in the same change. The `no-cache` was not a mistake, it was the forced consequence of dropping the manifest: with no invalidation mechanism left, revalidating everything is the only correct option.

That is what issue #2266 was about. Before #2268 the Dockerfile mounted no nginx config at all, so responses carried `ETag` and `Last-Modified` but no `Cache-Control`, and browsers applied heuristic freshness of roughly 10% of the age since `Last-Modified`. On a build a few weeks old that froze `index.html` and `flutter_service_worker.js` for days, and both gate the service worker update chain, so the app stayed on the old release until a manual cache clear.

## Why not simply restore Flutter's service worker

It was replaced by a self-unregistering stub in the 3.39 cycle (`flutter/flutter#176834`), and `generateServiceWorker` no longer accepts a resource map at all. Restoring it would work on the pinned 3.38.9 and silently stop working at the next Flutter bump, with the stub actively unregistering itself. Owning the worker also resolves the scope conflict that motivated the sweep in the first place: a scope can only be controlled by one worker, so push and precache have to share a file.

## Behaviour

Measured against a local nginx running `server/nginx.conf` unchanged.

| | requests |
|---|---|
| warm reload before | 56, all conditional, none served without a round trip |
| warm reload after | 5 |

The remaining five are structural: `index.html` (fetched online first, which is what makes a deploy visible), `version.json?cachebuster` (never cacheable), `config.json` twice, and the browser revalidating the worker script.

On a deploy, a tab left open issues no request and keeps running the old version. The next load installs the new worker and downloads the changed resources, and the one after serves them, which is the normal one reload lag of a service worker. `config.json` is current from the first load since it is never precached.

An unbuilt `push_sw.js` carries an empty manifest, so a missing build step falls back to today's behaviour rather than breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added offline support for key web app resources through service-worker caching.
  - Improved loading reliability with cached resources available when the network is unavailable.
  - Added automatic detection and cleanup of outdated cached files during updates.
  - Ensured the app shell and required resources are refreshed accurately after each build.

- **Bug Fixes**
  - Improved startup reliability by allowing the app to load without waiting for service-worker registration.
  - Prevented unsuccessful network responses from replacing the offline app shell.
  - Added safer recovery that clears invalid caches if an update fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->