### PR TITLE
chore: bump version to v2.23.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## [2.23.5] - 2026-08-31
+### Added
+- #3257: TW-3218: [Part I] Add device verification warning banner in chat screen
+- #3234: Add contacts pull to refresh
+
+### Changed
+- #3306: TW-2906: Rename package from FluffyChat to Twake Chat
+- #3285: TW-3218: [Part II] Update verify device flow
+- #3307: TW-3303: Improve caption handling for media files without filename
+- #3194: TW-3065: Warn user when not able to retry sending
+- #3184: TW-3137: Rewire input bar sticker picker search to TextSearch (Part 7)
+- #3180: TW-3135: Rewire chat details search call sites to TextSearch (Part 6)
+- TW-3220: Update bubble fonts
+
+### Fixed
+- #3290: Fix long captions on narrow sending images
+- #3236: TW-3223: Fix wrong bottom bar avatar after switching account from notification
+- #3235: Load local contacts from homeserver well-known
+
+### Tests
+- #3301: Stabilize Android FTL performance nightlies
+- #3295: Version performance dashboard assets
+- #3289: Build profile instrumentation APK
+- #3288: Track nightly Patrol Web performance
+- #3283: Publish nightly FTL performance history
+
 ## [2.23.4] - 2026-07-24
 ### Changed
 - #2787: TW-2786: Obtain FQDN from UserInfo for profile page edit button

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -11,7 +11,7 @@
 #
 
 # Uncomment the line if you want fastlane to automatically update itself
-update_fastlane
+#update_fastlane
 default_platform(:android)
 
 platform :android do

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -11,7 +11,7 @@
 #
 
 # Uncomment the line if you want fastlane to automatically update itself
-update_fastlane
+#update_fastlane
 
 default_platform(:ios)
 setup_ci if ENV['CI']

--- a/macos/fastlane/Fastfile
+++ b/macos/fastlane/Fastfile
@@ -11,7 +11,7 @@
 #
 
 # Uncomment the line if you want fastlane to automatically update itself
-update_fastlane
+#update_fastlane
 
 setup_ci
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: twake_chat
 description: A convenient Matrix-based tool for personal and corporate communication.
 publish_to: none
-version: 2.23.4+2330
+version: 2.23.5+2330
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
Version bump + stop fastlane from updating itself mid-run (which break the ci)
# [2.23.5] - 2026-08-31

# Added
•#3257: TW-3218: [Part I] Add device verification warning banner in chat screen
•#3234: Add contacts pull to refresh
# Changed
•#3306: TW-2906: Rename package from FluffyChat to Twake Chat
•#3285: TW-3218: [Part II] Update verify device flow
•#3307: TW-3303: Improve caption handling for media files without filename
•#3194: TW-3065: Warn user when not able to retry sending
•#3184: TW-3137: Rewire input bar sticker picker search to TextSearch (Part 7)
•#3180: TW-3135: Rewire chat details search call sites to TextSearch (Part 6)
•#3220: Update bubble fonts
# Fixed
•#3290: Fix long captions on narrow sending images
•#3236: TW-3223: Fix wrong bottom bar avatar after switching account from notification
•#3235: Load local contacts from homeserver well-known
# Tests
•#3301: Stabilize Android FTL performance nightlies
•#3295: Version performance dashboard assets
•#3289: Build profile instrumentation APK
•#3288: Track nightly Patrol Web performance
•#3283: Publish nightly FTL performance history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a device verification warning banner in chats.
  - Added pull-to-refresh for contacts.

- **Improvements**
  - Updated the device verification flow.
  - Improved caption handling and retry-send warnings.
  - Refreshed branding, bubble typography, sticker search, and chat details.

- **Bug Fixes**
  - Fixed long captions on narrow images.
  - Corrected the bottom-bar avatar after switching accounts.
  - Improved loading of local contacts from server configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->