### PR TITLE
Enable prefer_asserts_in_initializer_lists lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -12,6 +12,7 @@ linter:
     - avoid_field_initializers_in_const_classes
     - avoid_unused_constructor_parameters
     - matching_super_parameters
+    - prefer_asserts_in_initializer_lists
 
 analyzer:
   errors:

--- a/lib/widgets/public_room_bottom_sheet.dart
+++ b/lib/widgets/public_room_bottom_sheet.dart
@@ -18,15 +18,13 @@ class PublicRoomBottomSheet extends StatelessWidget {
   final PublicRoomsChunk? chunk;
   final VoidCallback? onRoomJoined;
 
-  PublicRoomBottomSheet({
+  const PublicRoomBottomSheet({
     this.roomAlias,
     required this.outerContext,
     this.chunk,
     this.onRoomJoined,
     super.key,
-  }) {
-    assert(roomAlias != null || chunk != null);
-  }
+  }) : assert(roomAlias != null || chunk != null);
 
   void _joinRoom(BuildContext context) async {
     final client = Matrix.of(context).client;


### PR DESCRIPTION
## Summary

- enable `prefer_asserts_in_initializer_lists`, the next rule from Discussion #3311
- move the `PublicRoomBottomSheet` assertion into its initializer list
- make the constructor `const` after removing its body

## Validation

- repository pre-commit hook (`flutter analyze` and `dart format`)
- `./scripts/code_analyze.sh` with Flutter 3.38.9

Follows #3313.
Related to #3311.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal code quality and consistency by enabling stricter linting.
  - Preserved existing validation behavior while making the public room interface more efficient to construct.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->