### PR TITLE
Enable prefer_constructors_over_static_methods lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,6 +13,7 @@ linter:
     - avoid_unused_constructor_parameters
     - matching_super_parameters
     - prefer_asserts_in_initializer_lists
+    - prefer_constructors_over_static_methods
 
 analyzer:
   errors:

--- a/lib/domain/model/extensions/xfile/xfile_extension.dart
+++ b/lib/domain/model/extensions/xfile/xfile_extension.dart
@@ -6,7 +6,7 @@ import 'package:matrix/matrix.dart';
 
 extension XFileExtension on XFile {
   Future<MatrixFile> toMatrixFileOnWeb() async {
-    final mime = MimeTypeUitls.instance.getTwakeMimeType(name);
+    final mime = MimeTypeUitls().getTwakeMimeType(name);
     final msgType = mime.msgTypeFromMime;
     final bytes = await readAsBytes();
     final size = msgType == MessageTypes.Image ? await bytes.imageSize : null;

--- a/lib/domain/model/extensions/xfile/xfile_extension.dart
+++ b/lib/domain/model/extensions/xfile/xfile_extension.dart
@@ -6,7 +6,7 @@ import 'package:matrix/matrix.dart';
 
 extension XFileExtension on XFile {
   Future<MatrixFile> toMatrixFileOnWeb() async {
-    final mime = MimeTypeUitls().getTwakeMimeType(name);
+    final mime = MimeTypeUitls.getTwakeMimeType(name);
     final msgType = mime.msgTypeFromMime;
     final bytes = await readAsBytes();
     final size = msgType == MessageTypes.Image ? await bytes.imageSize : null;

--- a/lib/presentation/mixins/pick_avatar_mixin.dart
+++ b/lib/presentation/mixins/pick_avatar_mixin.dart
@@ -30,7 +30,7 @@ mixin PickAvatarMixin {
     final matrixFile = MatrixFile.fromMimeType(
       bytes: bytes,
       name: file.name,
-      mimeType: MimeTypeUitls.instance.getTwakeMimeType(file.name),
+      mimeType: MimeTypeUitls().getTwakeMimeType(file.name),
     );
 
     if (matrixFile.size > AppConfig.defaultMaxUploadAvtarSizeInBytes) {

--- a/lib/presentation/mixins/pick_avatar_mixin.dart
+++ b/lib/presentation/mixins/pick_avatar_mixin.dart
@@ -30,7 +30,7 @@ mixin PickAvatarMixin {
     final matrixFile = MatrixFile.fromMimeType(
       bytes: bytes,
       name: file.name,
-      mimeType: MimeTypeUitls().getTwakeMimeType(file.name),
+      mimeType: MimeTypeUitls.getTwakeMimeType(file.name),
     );
 
     if (matrixFile.size > AppConfig.defaultMaxUploadAvtarSizeInBytes) {

--- a/lib/presentation/mixins/send_files_mixin.dart
+++ b/lib/presentation/mixins/send_files_mixin.dart
@@ -96,7 +96,7 @@ mixin SendFilesMixin {
   /// a bare [FileInfo]) is what lets `sendFileEventMobile` run HEIC→JPG
   /// conversion and thumbnail generation, which are gated on the concrete type.
   FileInfo _xFileToFileInfo(native_picker.XFile file) {
-    final mimeType = MimeTypeUitls.instance.getTwakeMimeType(file.name);
+    final mimeType = MimeTypeUitls().getTwakeMimeType(file.name);
     return switch (mimeType.msgTypeFromMime) {
       MessageTypes.Image => ImageFileInfo(
         file.name,

--- a/lib/presentation/mixins/send_files_mixin.dart
+++ b/lib/presentation/mixins/send_files_mixin.dart
@@ -96,7 +96,7 @@ mixin SendFilesMixin {
   /// a bare [FileInfo]) is what lets `sendFileEventMobile` run HEIC→JPG
   /// conversion and thumbnail generation, which are gated on the concrete type.
   FileInfo _xFileToFileInfo(native_picker.XFile file) {
-    final mimeType = MimeTypeUitls().getTwakeMimeType(file.name);
+    final mimeType = MimeTypeUitls.getTwakeMimeType(file.name);
     return switch (mimeType.msgTypeFromMime) {
       MessageTypes.Image => ImageFileInfo(
         file.name,

--- a/lib/utils/mime_type_uitls.dart
+++ b/lib/utils/mime_type_uitls.dart
@@ -5,7 +5,7 @@ import 'package:mime/mime.dart';
 class MimeTypeUitls {
   MimeTypeUitls._();
 
-  static MimeTypeUitls get instance => MimeTypeUitls._();
+  factory MimeTypeUitls() => MimeTypeUitls._();
 
   String getTwakeMimeType(String path) {
     final mimeType = lookupMimeType(path);

--- a/lib/utils/mime_type_uitls.dart
+++ b/lib/utils/mime_type_uitls.dart
@@ -5,9 +5,7 @@ import 'package:mime/mime.dart';
 class MimeTypeUitls {
   MimeTypeUitls._();
 
-  factory MimeTypeUitls() => MimeTypeUitls._();
-
-  String getTwakeMimeType(String path) {
+  static String getTwakeMimeType(String path) {
     final mimeType = lookupMimeType(path);
     if (mimeType == null) {
       return 'application/octet-stream';

--- a/lib/widgets/mixins/drag_drog_file_mixin.dart
+++ b/lib/widgets/mixins/drag_drog_file_mixin.dart
@@ -42,9 +42,7 @@ mixin DragDrogFileMixin {
         MatrixFile(
           bytes: bytesList.result![i],
           name: details.files[i].name,
-          mimeType: MimeTypeUitls.instance.getTwakeMimeType(
-            details.files[i].name,
-          ),
+          mimeType: MimeTypeUitls().getTwakeMimeType(details.files[i].name),
         ).detectFileType,
       );
     }

--- a/lib/widgets/mixins/drag_drog_file_mixin.dart
+++ b/lib/widgets/mixins/drag_drog_file_mixin.dart
@@ -42,7 +42,7 @@ mixin DragDrogFileMixin {
         MatrixFile(
           bytes: bytesList.result![i],
           name: details.files[i].name,
-          mimeType: MimeTypeUitls().getTwakeMimeType(details.files[i].name),
+          mimeType: MimeTypeUitls.getTwakeMimeType(details.files[i].name),
         ).detectFileType,
       );
     }


### PR DESCRIPTION
## Summary

- enable `prefer_constructors_over_static_methods`, the next rule from Discussion #3311
- replace `MimeTypeUitls.instance` with a factory constructor
- migrate the four internal call sites without changing MIME resolution behavior

## Validation

- repository pre-commit hook (`flutter analyze` and `dart format`)
- `./scripts/code_analyze.sh` with Flutter 3.38.9

Stacked on #3320.
Follows #3313.
Related to #3311.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * MIME type detection continues to work consistently when uploading, dragging, or selecting files on the web.
  * Public room interfaces can now be created more efficiently without changing their behavior.

* **Maintenance**
  * Updated code quality checks to encourage more consistent constructor and assertion patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->