### PR TITLE
fix(test): target Support Twake Workplace room

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -146,7 +146,7 @@ jobs:
             --type instrumentation \
             --app build/app/outputs/apk/debug/app-debug.apk \
             --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
-            --device model=Pixel2.arm,version=33 \
+            --device model=MediumPhone.arm,version=34 \
             --timeout 45m \
             --use-orchestrator \
             --environment-variables clearPackageData=true

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -146,7 +146,7 @@ jobs:
             --type instrumentation \
             --app build/app/outputs/apk/debug/app-debug.apk \
             --test build/app/outputs/apk/androidTest/debug/app-debug-androidTest.apk \
-            --device model=MediumPhone.arm,version=34 \
+            --device model=Pixel2.arm,version=33 \
             --timeout 45m \
             --use-orchestrator \
             --environment-variables clearPackageData=true

--- a/integration_test/base/api_login_helper_io.dart
+++ b/integration_test/base/api_login_helper_io.dart
@@ -42,9 +42,55 @@ Future<String> fetchAuthToken({
 /// Sends a Matrix message as the configured receiver account via the
 /// Client-Server API. Used by tests that need the receiving side to emit a
 /// message while the primary account is logged in from the UI.
-Future<void> sendMessageAsReceiver({required String message}) async {
+///
+/// [roomId] overrides the CICD `GroupID` dart-define so a test-created
+/// fixture room receives the event instead of a stale staging room.
+Future<void> sendMessageAsReceiver({required String message, String? roomId}) =>
+    sendMessagesAsReceiver(messages: [message], roomId: roomId);
+
+/// Sends several events with one receiver login.
+Future<void> sendMessagesAsReceiver({
+  required List<String> messages,
+  String? roomId,
+}) async {
   const endpoints = _SsoEndpoints.fromEnvironment();
   const groupID = String.fromEnvironment('GroupID');
+  const receiver = String.fromEnvironment('Receiver');
+  const passOfReceiver = String.fromEnvironment('ReceiverPass');
+  final targetRoom = roomId ?? groupID;
+  if (targetRoom.isEmpty) {
+    throw StateError('Missing roomId and GroupID dart-define');
+  }
+
+  final loginToken = await fetchAuthToken(
+    username: receiver,
+    password: passOfReceiver,
+  );
+
+  final client = HttpClient()..autoUncompress = true;
+  try {
+    final session = await _loginWithMLoginToken(
+      client: client,
+      endpoints: endpoints,
+      loginToken: loginToken,
+    );
+    for (final message in messages) {
+      await _putMatrixMessage(
+        client: client,
+        session: session,
+        groupID: targetRoom,
+        message: message,
+      );
+    }
+  } finally {
+    client.close(force: true);
+  }
+}
+
+/// Makes the configured receiver join [roomId] after the primary account
+/// invited it. Used by mobile group scenarios that create their own room.
+Future<void> ensureReceiverJoined({required String roomId}) async {
+  const endpoints = _SsoEndpoints.fromEnvironment();
   const receiver = String.fromEnvironment('Receiver');
   const passOfReceiver = String.fromEnvironment('ReceiverPass');
 
@@ -60,12 +106,25 @@ Future<void> sendMessageAsReceiver({required String message}) async {
       endpoints: endpoints,
       loginToken: loginToken,
     );
-    await _putMatrixMessage(
-      client: client,
-      session: session,
-      groupID: groupID,
-      message: message,
+    final encodedRoomId = Uri.encodeComponent(roomId);
+    final joinUri = Uri.https(
+      endpoints.matrixURL,
+      '/_matrix/client/v3/rooms/$encodedRoomId/join',
     );
+    final request = await client.postUrl(joinUri);
+    request.headers
+      ..set(HttpHeaders.contentTypeHeader, 'application/json')
+      ..set(HttpHeaders.authorizationHeader, 'Bearer ${session.accessToken}')
+      ..set(HttpHeaders.userAgentHeader, _userAgent);
+    request.write('{}');
+    final response = await request.close();
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final body = await utf8.decoder.bind(response).join();
+      throw Exception(
+        'Receiver join failed [status=${response.statusCode}] '
+        'body=${body.substring(0, body.length.clamp(0, 300))}',
+      );
+    }
   } finally {
     client.close(force: true);
   }

--- a/integration_test/base/api_login_helper_io.dart
+++ b/integration_test/base/api_login_helper_io.dart
@@ -48,32 +48,22 @@ Future<String> fetchAuthToken({
 Future<void> sendMessageAsReceiver({required String message, String? roomId}) =>
     sendMessagesAsReceiver(messages: [message], roomId: roomId);
 
-/// Sends several events with one receiver login.
+/// Sends several events with one receiver login. Join + send share a cached
+/// access token so a single Patrol process does not hit SSO twice.
 Future<void> sendMessagesAsReceiver({
   required List<String> messages,
   String? roomId,
 }) async {
   const endpoints = _SsoEndpoints.fromEnvironment();
   const groupID = String.fromEnvironment('GroupID');
-  const receiver = String.fromEnvironment('Receiver');
-  const passOfReceiver = String.fromEnvironment('ReceiverPass');
   final targetRoom = roomId ?? groupID;
   if (targetRoom.isEmpty) {
     throw StateError('Missing roomId and GroupID dart-define');
   }
 
-  final loginToken = await fetchAuthToken(
-    username: receiver,
-    password: passOfReceiver,
-  );
-
   final client = HttpClient()..autoUncompress = true;
   try {
-    final session = await _loginWithMLoginToken(
-      client: client,
-      endpoints: endpoints,
-      loginToken: loginToken,
-    );
+    final session = await _receiverSession(client, endpoints);
     for (final message in messages) {
       await _putMatrixMessage(
         client: client,
@@ -91,21 +81,9 @@ Future<void> sendMessagesAsReceiver({
 /// invited it. Used by mobile group scenarios that create their own room.
 Future<void> ensureReceiverJoined({required String roomId}) async {
   const endpoints = _SsoEndpoints.fromEnvironment();
-  const receiver = String.fromEnvironment('Receiver');
-  const passOfReceiver = String.fromEnvironment('ReceiverPass');
-
-  final loginToken = await fetchAuthToken(
-    username: receiver,
-    password: passOfReceiver,
-  );
-
   final client = HttpClient()..autoUncompress = true;
   try {
-    final session = await _loginWithMLoginToken(
-      client: client,
-      endpoints: endpoints,
-      loginToken: loginToken,
-    );
+    final session = await _receiverSession(client, endpoints);
     final encodedRoomId = Uri.encodeComponent(roomId);
     final joinUri = Uri.https(
       endpoints.matrixURL,
@@ -128,6 +106,72 @@ Future<void> ensureReceiverJoined({required String roomId}) async {
   } finally {
     client.close(force: true);
   }
+}
+
+_MatrixSession? _cachedReceiverSession;
+
+Future<_MatrixSession> _receiverSession(
+  HttpClient client,
+  _SsoEndpoints endpoints,
+) async {
+  final cached = _cachedReceiverSession;
+  if (cached != null) return cached;
+
+  const receiver = String.fromEnvironment('Receiver');
+  const passOfReceiver = String.fromEnvironment('ReceiverPass');
+  final session = endpoints.ssoURL.isEmpty
+      ? await _loginWithPassword(
+          client: client,
+          endpoints: endpoints,
+          credentials: const _Credentials(
+            username: receiver,
+            password: passOfReceiver,
+          ),
+        )
+      : await _loginWithMLoginToken(
+          client: client,
+          endpoints: endpoints,
+          loginToken: await fetchAuthToken(
+            username: receiver,
+            password: passOfReceiver,
+          ),
+        );
+  return _cachedReceiverSession = session;
+}
+
+Future<_MatrixSession> _loginWithPassword({
+  required HttpClient client,
+  required _SsoEndpoints endpoints,
+  required _Credentials credentials,
+}) async {
+  final loginUri = Uri.https(endpoints.matrixURL, '/_matrix/client/v3/login');
+  final request = await client.postUrl(loginUri);
+  request.headers
+    ..set(HttpHeaders.contentTypeHeader, 'application/json')
+    ..set(HttpHeaders.userAgentHeader, _userAgent)
+    ..set('Origin', 'https://${endpoints.chatURL}');
+  request.write(
+    jsonEncode({
+      'identifier': {'type': 'm.id.user', 'user': credentials.username},
+      'initial_device_display_name': _deviceDisplayName,
+      'password': credentials.password,
+      'type': 'm.login.password',
+    }),
+  );
+  final response = await request.close();
+  final body = await response.transform(utf8.decoder).join();
+  if (response.statusCode < 200 || response.statusCode >= 300) {
+    throw Exception(
+      'Receiver m.login.password failed [status=${response.statusCode}] '
+      'body=${body.substring(0, body.length.clamp(0, 300))}',
+    );
+  }
+  final accessToken =
+      (jsonDecode(body) as Map<String, dynamic>)['access_token'] as String?;
+  if (accessToken == null) {
+    throw Exception('Receiver login response missing access_token: $body');
+  }
+  return _MatrixSession(endpoints: endpoints, accessToken: accessToken);
 }
 
 // ---------------------------------------------------------------------------

--- a/integration_test/base/api_login_helper_io.dart
+++ b/integration_test/base/api_login_helper_io.dart
@@ -84,10 +84,10 @@ Future<void> ensureReceiverJoined({required String roomId}) async {
   final client = HttpClient()..autoUncompress = true;
   try {
     final session = await _receiverSession(client, endpoints);
-    final encodedRoomId = Uri.encodeComponent(roomId);
-    final joinUri = Uri.https(
-      endpoints.matrixURL,
-      '/_matrix/client/v3/rooms/$encodedRoomId/join',
+    final joinUri = Uri(
+      scheme: 'https',
+      host: endpoints.matrixURL,
+      pathSegments: ['_matrix', 'client', 'v3', 'rooms', roomId, 'join'],
     );
     final request = await client.postUrl(joinUri);
     request.headers
@@ -478,20 +478,25 @@ Future<void> _putMatrixMessage({
   final endpoints = session.endpoints;
   // Matrix `PUT /send/{eventType}/{txnId}` uses a per-request transaction ID
   // for idempotency. Format: `<chatURL>: <device> <sep> <epoch_ms>`.
-  final txnId = Uri.encodeComponent(
-    '${endpoints.chatURL}: $_deviceDisplayName $_txnIdSeparator'
-    '${DateTime.now().millisecondsSinceEpoch}',
-  );
-  // `groupID` is expected to be a full Matrix room ID (`!localpart:server`)
-  // so tests work against any homeserver, not only `linagora.com`. Encode
-  // it the same way as `txnId` — `!` and `:` are technically RFC 3986-safe
-  // in path segments but the Matrix C-S spec calls for percent-encoding,
-  // and some reverse proxies (and federation endpoints) do not tolerate
-  // the raw form.
-  final encodedRoomId = Uri.encodeComponent(groupID);
-  final sendUri = Uri.https(
-    endpoints.matrixURL,
-    '/_matrix/client/v3/rooms/$encodedRoomId/send/m.room.message/$txnId',
+  final txnId =
+      '${endpoints.chatURL}: $_deviceDisplayName $_txnIdSeparator'
+      '${DateTime.now().millisecondsSinceEpoch}';
+  // `groupID` is a full Matrix room ID (`!localpart:server`). Build the
+  // path from segments so `!` and `:` are encoded once, matching the
+  // Client-Server spec without double-encoding.
+  final sendUri = Uri(
+    scheme: 'https',
+    host: endpoints.matrixURL,
+    pathSegments: [
+      '_matrix',
+      'client',
+      'v3',
+      'rooms',
+      groupID,
+      'send',
+      'm.room.message',
+      txnId,
+    ],
   );
   final request = await client.putUrl(sendUri);
   request.headers

--- a/integration_test/base/api_login_helper_web.dart
+++ b/integration_test/base/api_login_helper_web.dart
@@ -54,17 +54,21 @@ Future<String> fetchAuthToken({
 }
 
 /// Sends a message as the `Receiver` account by first obtaining its access
-/// token via `m.login.password`, then `PUT`-ing the event to the configured
-/// `GroupID`.
-Future<void> sendMessageAsReceiver({required String message}) async {
+/// token via `m.login.password`, then `PUT`-ing the event to [roomId] or
+/// the configured `GroupID`.
+Future<void> sendMessageAsReceiver({
+  required String message,
+  String? roomId,
+}) async {
   const matrixURL = String.fromEnvironment('MATRIX_URL');
   const receiver = String.fromEnvironment('Receiver');
   const passOfReceiver = String.fromEnvironment('ReceiverPass');
   const groupID = String.fromEnvironment('GroupID');
+  final targetRoom = roomId ?? groupID;
   if (matrixURL.isEmpty ||
       receiver.isEmpty ||
       passOfReceiver.isEmpty ||
-      groupID.isEmpty) {
+      targetRoom.isEmpty) {
     throw StateError(
       'Missing required dart-defines: MATRIX_URL/Receiver/ReceiverPass/GroupID',
     );
@@ -75,7 +79,7 @@ Future<void> sendMessageAsReceiver({required String message}) async {
     password: passOfReceiver,
   );
 
-  final encodedRoomId = Uri.encodeComponent(groupID);
+  final encodedRoomId = Uri.encodeComponent(targetRoom);
   final sendUri = Uri.parse(
     '$matrixURL/_matrix/client/v3/rooms/$encodedRoomId/send/m.room.message/'
     'patrol-web-${DateTime.now().millisecondsSinceEpoch}',
@@ -93,4 +97,21 @@ Future<void> sendMessageAsReceiver({required String message}) async {
       'sendMessage failed [${response.statusCode}]: ${response.body}',
     );
   }
+}
+
+Future<void> sendMessagesAsReceiver({
+  required List<String> messages,
+  String? roomId,
+}) async {
+  for (final message in messages) {
+    await sendMessageAsReceiver(message: message, roomId: roomId);
+  }
+}
+
+/// Mobile group fixtures create rooms on the device client. Web tests use
+/// the pre-provisioned Synapse [GroupID] and never invite the receiver.
+Future<void> ensureReceiverJoined({required String roomId}) async {
+  throw UnsupportedError(
+    'ensureReceiverJoined is only used by mobile group fixtures',
+  );
 }

--- a/integration_test/base/mobile_group_fixture.dart
+++ b/integration_test/base/mobile_group_fixture.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:twake_chat/pages/chat_list/chat_list.dart';
+import 'package:twake_chat/widgets/matrix.dart' as twake;
+
+import 'api_login_helper.dart';
+import 'base_test_scenario.dart';
+
+const mobileGroupFixtureTitle = 'FTL Mobile Test Group';
+const mobileReceiverMessageDisplayMenu = 'FTL receiver fixture display menu';
+const mobileReceiverMessageReply = 'FTL receiver fixture reply';
+const mobileReceiverMessageDelete = 'FTL receiver fixture delete';
+const mobileReceiverMessageCopy = 'FTL receiver fixture copy';
+
+const _receiverFixtureMessages = [
+  mobileReceiverMessageDisplayMenu,
+  mobileReceiverMessageReply,
+  mobileReceiverMessageDelete,
+  mobileReceiverMessageCopy,
+];
+
+class MobileGroupFixture {
+  const MobileGroupFixture({
+    required this.roomId,
+    required this.title,
+    required this.memberMatrixId,
+  });
+
+  final String roomId;
+  final String title;
+  final String memberMatrixId;
+}
+
+Future<MobileGroupFixture>? _fixture;
+
+/// Creates (or repairs) the mobile-only group fixture and makes sure the
+/// configured receiver is a joined member. The fixture is cached for the
+/// instrumentation process so the seven group tests do not create seven rooms.
+Future<MobileGroupFixture> prepareMobileGroupFixture(
+  BaseTestScenario scenario,
+) {
+  if (kIsWeb) {
+    throw UnsupportedError('The web suite provisions its own Matrix fixture.');
+  }
+  return _fixture ??= _prepareMobileGroupFixture(scenario);
+}
+
+Future<MobileGroupFixture> _prepareMobileGroupFixture(
+  BaseTestScenario scenario,
+) async {
+  const receiver = String.fromEnvironment('Receiver');
+  if (receiver.isEmpty) {
+    throw StateError('Missing required --dart-define=Receiver');
+  }
+
+  await scenario
+      .$(ChatList)
+      .waitUntilVisible(timeout: const Duration(seconds: 60));
+  final context = scenario.$.tester.element(find.byType(Scaffold).first);
+  final client = twake.Matrix.of(context).client;
+  await client.roomsLoading;
+  final receiverMatrixId = _qualifiedMatrixId(receiver, client.userID);
+
+  Room? room;
+  for (final candidate in client.rooms) {
+    if (candidate.name == mobileGroupFixtureTitle) {
+      room = candidate;
+      break;
+    }
+  }
+
+  if (room == null) {
+    final roomId = await client.createRoom(
+      name: mobileGroupFixtureTitle,
+      invite: [receiverMatrixId],
+      isDirect: false,
+      // Keep the creator at owner level and the invited receiver at the
+      // regular member level; the menu assertions exercise that distinction.
+      preset: CreateRoomPreset.privateChat,
+    );
+    room = await _waitForRoom(client, roomId, scenario);
+  }
+
+  final receiverMember = await room.requestUser(
+    receiverMatrixId,
+    requestProfile: false,
+  );
+  if (receiverMember == null || receiverMember.membership == Membership.leave) {
+    try {
+      await room.invite(receiverMatrixId);
+    } on MatrixException catch (exception) {
+      if (!exception.toString().contains('already in the room')) rethrow;
+    }
+    await ensureReceiverJoined(roomId: room.id);
+  } else if (receiverMember.membership != Membership.join) {
+    await ensureReceiverJoined(roomId: room.id);
+  }
+
+  final joined = await room.requestParticipants([Membership.join]);
+  if (!joined.any((participant) => participant.id == receiverMatrixId)) {
+    throw StateError(
+      'Receiver $receiverMatrixId did not join room ${room.id}.',
+    );
+  }
+
+  return MobileGroupFixture(
+    roomId: room.id,
+    title: mobileGroupFixtureTitle,
+    memberMatrixId: receiverMatrixId,
+  );
+}
+
+/// Ensures all receiver-owned messages needed by the group scenarios exist,
+/// using at most one receiver login. Each scenario then selects its own stable
+/// message, so later Patrol processes do not need to authenticate again.
+Future<void> prepareMobileReceiverMessages(
+  BaseTestScenario scenario,
+  MobileGroupFixture fixture,
+) async {
+  if (kIsWeb) return;
+
+  final context = scenario.$.tester.element(find.byType(Scaffold).first);
+  final client = twake.Matrix.of(context).client;
+  final room = client.getRoomById(fixture.roomId);
+  if (room == null) {
+    throw StateError('Fixture room ${fixture.roomId} is not loaded.');
+  }
+
+  final timeline = await room.getTimeline(limit: 100);
+  try {
+    final existing = timeline.events
+        .where((event) => event.senderId == fixture.memberMatrixId)
+        .map((event) => event.content['body'])
+        .whereType<String>()
+        .toSet();
+    final missing = _receiverFixtureMessages
+        .where((message) => !existing.contains(message))
+        .toList();
+    if (missing.isNotEmpty) {
+      await sendMessagesAsReceiver(messages: missing, roomId: fixture.roomId);
+    }
+  } finally {
+    timeline.cancelSubscriptions();
+  }
+}
+
+String _qualifiedMatrixId(String receiver, String? currentUserId) {
+  if (receiver.startsWith('@') && receiver.contains(':')) return receiver;
+
+  final separator = currentUserId?.indexOf(':') ?? -1;
+  if (separator < 0 || separator == currentUserId!.length - 1) {
+    throw StateError(
+      'Cannot qualify Receiver "$receiver" without a valid current Matrix ID.',
+    );
+  }
+  return '@${receiver.replaceFirst(RegExp(r'^@'), '')}:'
+      '${currentUserId.substring(separator + 1)}';
+}
+
+Future<Room> _waitForRoom(
+  Client client,
+  String roomId,
+  BaseTestScenario scenario,
+) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while (DateTime.now().isBefore(deadline)) {
+    final room = client.getRoomById(roomId);
+    if (room != null) return room;
+    await scenario.$.pump(const Duration(milliseconds: 500));
+  }
+  throw StateError('Created fixture room $roomId did not reach the client.');
+}

--- a/integration_test/base/mobile_group_fixture.dart
+++ b/integration_test/base/mobile_group_fixture.dart
@@ -93,6 +93,7 @@ Future<MobileGroupFixture> _prepareMobileGroupFixture(
     } on MatrixException catch (exception) {
       if (!exception.toString().contains('already in the room')) rethrow;
     }
+    await scenario.$.pump(const Duration(seconds: 2));
     await ensureReceiverJoined(roomId: room.id);
   } else if (receiverMember.membership != Membership.join) {
     await ensureReceiverJoined(roomId: room.id);

--- a/integration_test/robots/chat_group_detail_robot.dart
+++ b/integration_test/robots/chat_group_detail_robot.dart
@@ -153,7 +153,9 @@ class ChatGroupDetailRobot extends CoreRobot
   }
 
   Future<PullDownMenuRobot> openPullDownMenu(String message) async {
-    await $(MessageContent).containing(find.text(message)).longPress();
+    await $(
+      MessageContent,
+    ).containing(find.textContaining(message)).longPress();
     await $.waitUntilVisible($(PullDownMenu));
     await $.pump();
     return PullDownMenuRobot($);

--- a/integration_test/robots/chat_list_robot.dart
+++ b/integration_test/robots/chat_list_robot.dart
@@ -75,6 +75,7 @@ class ChatListRobot extends HomeRobot implements AbstractChatListRobot {
   @override
   Future<void> openChatByTitle(String title) async {
     final chat = getChatGroupByTitle(title);
+    await scrollUntilVisible($, chat.root);
     await $.waitUntilVisible(chat.root, timeout: const Duration(seconds: 60));
     await chat.root.tap();
     await $.pumpAndSettle();

--- a/integration_test/robots/chat_list_robot.dart
+++ b/integration_test/robots/chat_list_robot.dart
@@ -74,8 +74,9 @@ class ChatListRobot extends HomeRobot implements AbstractChatListRobot {
 
   @override
   Future<void> openChatByTitle(String title) async {
-    await $.waitUntilVisible($(TwakeListItem));
-    await getChatGroupByTitle(title).root.tap();
+    final chat = getChatGroupByTitle(title);
+    await $.waitUntilVisible(chat.root, timeout: const Duration(seconds: 60));
+    await chat.root.tap();
     await $.pumpAndSettle();
   }
 

--- a/integration_test/robots/message_menu_robot.dart
+++ b/integration_test/robots/message_menu_robot.dart
@@ -1,9 +1,9 @@
 import 'package:twake_chat/generated/l10n/app_localizations.dart';
 import 'package:twake_chat/pages/chat/events/message_content.dart';
 import 'package:twake_chat/pages/forward/forward_view.dart';
+import 'package:twake_chat/utils/dialog/twake_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:patrol/patrol.dart';
 import 'package:pull_down_button/pull_down_button.dart';
 
 import '../base/core_robot.dart';
@@ -25,7 +25,9 @@ class MessageMenuRobot extends CoreRobot implements AbstractMessageMenuRobot {
   PullDownMenuRobot get _menu => PullDownMenuRobot($);
 
   Future<void> _openMenu(String message) async {
-    await $(MessageContent).containing(find.text(message)).longPress();
+    await $(
+      MessageContent,
+    ).containing(find.textContaining(message)).longPress();
     await $.waitUntilVisible($(PullDownMenu));
     await $.pump();
   }
@@ -53,8 +55,10 @@ class MessageMenuRobot extends CoreRobot implements AbstractMessageMenuRobot {
   Future<void> openDelete(String message) async {
     await _openMenu(message);
     await _menu.getDeleteItem().tap();
-    // The deletion confirmation surfaces as a native dialog on mobile.
-    await $.native.tap(Selector(text: _l10n.delete));
+    final dialog = $(find.byKey(TwakeDialog.showConfirmAlertDialogKey));
+    final delete = dialog.$(find.text(_l10n.delete));
+    await $.waitUntilVisible(delete);
+    await delete.tap();
     await $.pump(const Duration(milliseconds: 300));
   }
 

--- a/integration_test/scenarios/chat_group_scenario.dart
+++ b/integration_test/scenarios/chat_group_scenario.dart
@@ -2,6 +2,7 @@ import 'package:twake_chat/pages/chat/chat_app_bar_title.dart';
 import 'package:twake_chat/pages/chat/chat_input_row_send_btn.dart';
 import 'package:twake_chat/pages/chat/event_info_dialog.dart';
 import 'package:twake_chat/widgets/avatar/avatar.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,7 +11,13 @@ import '../base/base_test_scenario.dart';
 import '../robots/chat_group_detail_robot.dart';
 import 'chat_scenario.dart';
 
-const _group = 'Support Twake Workplace';
+const _webGroup = String.fromEnvironment(
+  'SearchByTitle',
+  defaultValue: 'My Default Group',
+);
+const _mobileGroup = 'Support Twake Workplace';
+
+String get _group => kIsWeb ? _webGroup : _mobileGroup;
 
 int _uid() => DateTime.now().microsecondsSinceEpoch;
 

--- a/integration_test/scenarios/chat_group_scenario.dart
+++ b/integration_test/scenarios/chat_group_scenario.dart
@@ -17,13 +17,25 @@ const _webGroup = String.fromEnvironment(
 );
 const _mobileGroup = 'Support Twake Workplace';
 
-String get _group => kIsWeb ? _webGroup : _mobileGroup;
-
 int _uid() => DateTime.now().microsecondsSinceEpoch;
 
-/// Opens [_group], posts one message through the UI (sender) and one through
-/// the API as the receiver, waits for both, and returns `(senderMsg,
-/// receiverMsg)`.
+Future<void> _openGroup(BaseTestScenario scenario) async {
+  final robots = scenario.robots;
+  if (!kIsWeb) {
+    await robots.chatListRobot().openChatByTitle(_mobileGroup);
+    return;
+  }
+
+  await robots.chatListRobot().openSearchScreen();
+  final opened = await robots.searchViewRobot().searchAndOpenRoom(_webGroup);
+  if (!opened) {
+    throw Exception('Test failed: Room "$_webGroup" was not found.');
+  }
+}
+
+/// Opens the platform fixture room, posts one message through the UI (sender)
+/// and one through the API as the receiver, waits for both, and returns
+/// `(senderMsg, receiverMsg)`.
 ///
 /// Drives the UI exclusively through the abstract robots; the receiver message
 /// is injected via the cross-platform `sendMessageAsReceiver` API helper so the
@@ -32,11 +44,7 @@ Future<(String, String)> _prepareTwoMessages(BaseTestScenario scenario) async {
   final robots = scenario.robots;
   final $ = scenario.$;
 
-  await robots.chatListRobot().openSearchScreen();
-  final opened = await robots.searchViewRobot().searchAndOpenRoom(_group);
-  if (!opened) {
-    throw Exception('Test failed: Room "$_group" was not found.');
-  }
+  await _openGroup(scenario);
   await $.pump(const Duration(seconds: 1));
 
   final id = _uid();

--- a/integration_test/scenarios/chat_group_scenario.dart
+++ b/integration_test/scenarios/chat_group_scenario.dart
@@ -10,10 +10,7 @@ import '../base/base_test_scenario.dart';
 import '../robots/chat_group_detail_robot.dart';
 import 'chat_scenario.dart';
 
-const _group = String.fromEnvironment(
-  'SearchByTitle',
-  defaultValue: 'My Default Group',
-);
+const _group = 'Support Twake Workplace';
 
 int _uid() => DateTime.now().microsecondsSinceEpoch;
 

--- a/integration_test/scenarios/chat_group_scenario.dart
+++ b/integration_test/scenarios/chat_group_scenario.dart
@@ -1,4 +1,5 @@
 import 'package:twake_chat/pages/chat/chat_app_bar_title.dart';
+import 'package:twake_chat/pages/chat/chat_event_list.dart';
 import 'package:twake_chat/pages/chat/chat_input_row_send_btn.dart';
 import 'package:twake_chat/pages/chat/event_info_dialog.dart';
 import 'package:twake_chat/widgets/avatar/avatar.dart';
@@ -8,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../base/api_login_helper.dart';
 import '../base/base_test_scenario.dart';
+import '../base/mobile_group_fixture.dart';
 import '../robots/chat_group_detail_robot.dart';
 import 'chat_scenario.dart';
 
@@ -15,15 +17,20 @@ const _webGroup = String.fromEnvironment(
   'SearchByTitle',
   defaultValue: 'My Default Group',
 );
-const _mobileGroup = 'Support Twake Workplace';
-
 int _uid() => DateTime.now().microsecondsSinceEpoch;
 
-Future<void> _openGroup(BaseTestScenario scenario) async {
+Future<String?> _openGroup(BaseTestScenario scenario) async {
   final robots = scenario.robots;
   if (!kIsWeb) {
-    await robots.chatListRobot().openChatByTitle(_mobileGroup);
-    return;
+    final fixture = await prepareMobileGroupFixture(scenario);
+    await robots.chatListRobot().openSearchScreen();
+    final opened = await robots.searchViewRobot().searchAndOpenRoom(
+      fixture.title,
+    );
+    if (!opened) {
+      throw Exception('Test failed: Room "${fixture.title}" was not found.');
+    }
+    return fixture.roomId;
   }
 
   await robots.chatListRobot().openSearchScreen();
@@ -31,6 +38,7 @@ Future<void> _openGroup(BaseTestScenario scenario) async {
   if (!opened) {
     throw Exception('Test failed: Room "$_webGroup" was not found.');
   }
+  return null;
 }
 
 /// Opens the platform fixture room, posts one message through the UI (sender)
@@ -40,40 +48,74 @@ Future<void> _openGroup(BaseTestScenario scenario) async {
 /// Drives the UI exclusively through the abstract robots; the receiver message
 /// is injected via the cross-platform `sendMessageAsReceiver` API helper so the
 /// scenario has a message it does not own to act on.
-Future<(String, String)> _prepareTwoMessages(BaseTestScenario scenario) async {
+Future<(String, String)> _prepareMessages(
+  BaseTestScenario scenario, {
+  String? receiverFixtureMessage,
+}) async {
   final robots = scenario.robots;
   final $ = scenario.$;
 
-  await _openGroup(scenario);
+  final roomId = await _openGroup(scenario);
   await $.pump(const Duration(seconds: 1));
 
   final id = _uid();
   final senderMsg = 'sender sent at $id';
-  final receiverMsg = 'receiver sent at $id';
+  final receiverMsg = receiverFixtureMessage ?? '';
 
   await robots.chatGroupDetailRobot().sendMessage(senderMsg);
   await _waitShown(scenario, senderMsg);
 
-  await sendMessageAsReceiver(message: receiverMsg);
-  await _waitShown(scenario, receiverMsg);
+  if (receiverFixtureMessage != null) {
+    if (!kIsWeb) {
+      final fixture = await prepareMobileGroupFixture(scenario);
+      await prepareMobileReceiverMessages(scenario, fixture);
+    } else {
+      await sendMessageAsReceiver(message: receiverMsg, roomId: roomId);
+    }
+    await _waitShown(scenario, receiverMsg, searchTimeline: !kIsWeb);
+  }
 
   return (senderMsg, receiverMsg);
 }
 
-Future<void> _waitShown(BaseTestScenario scenario, String message) async {
+Future<void> _waitShown(
+  BaseTestScenario scenario,
+  String message, {
+  bool searchTimeline = false,
+}) async {
   final chatGroupDetailRobot = scenario.robots.chatGroupDetailRobot();
   final finder = await chatGroupDetailRobot.getText(message);
+
+  // Start at the live edge for newly sent messages. Receiver fixture events
+  // can be older than the currently materialized viewport, so search backward
+  // and then forward through the timeline instead of waiting for a lazily-built
+  // widget that will never appear without scrolling.
+  await chatGroupDetailRobot.scrollToLiveBottom();
+  if (searchTimeline && !finder.visible) {
+    final timeline = find.descendant(
+      of: find.byType(ChatEventList),
+      matching: find.byType(Scrollable),
+    );
+    for (var i = 0; i < 30 && !finder.visible; i++) {
+      if (timeline.evaluate().isEmpty) {
+        await scenario.$.pump(const Duration(milliseconds: 200));
+        continue;
+      }
+      await scenario.$.tester.drag(timeline.first, const Offset(0, 300));
+      await scenario.$.pump(const Duration(milliseconds: 200));
+    }
+  }
   await scenario.$.waitUntilExists(
     finder,
     timeout: const Duration(seconds: 60),
   );
-  // On web the timeline can build a newly sent message just outside the
-  // hit-testable viewport. Move to the live edge after the event exists so the
-  // visibility assertion cannot stall on an off-screen MessageContent.
-  await chatGroupDetailRobot.scrollToLiveBottom();
+  if (!finder.visible) {
+    await scenario.$.tester.ensureVisible(finder.finder.first);
+    await scenario.$.pumpAndSettle();
+  }
   await scenario.$.waitUntilVisible(
     finder,
-    timeout: const Duration(seconds: 60),
+    timeout: const Duration(seconds: 30),
   );
 }
 
@@ -88,23 +130,38 @@ Future<void> _waitAbsent(BaseTestScenario scenario, String message) async {
   }
 }
 
+Future<void> _waitExists(BaseTestScenario scenario, String message) async {
+  final finder = await scenario.robots.chatGroupDetailRobot().getText(message);
+  await scenario.$.waitUntilExists(
+    finder,
+    timeout: const Duration(seconds: 60),
+  );
+}
+
 /// Reply to a sender-owned and a receiver-owned message in a group chat.
 class ChatGroupReplyScenario extends BaseTestScenario {
   ChatGroupReplyScenario(super.$, super.robots);
 
   @override
   Future<void> runTestLogic() async {
-    final (senderMsg, receiverMsg) = await _prepareTwoMessages(this);
+    final (senderMsg, receiverMsg) = await _prepareMessages(
+      this,
+      receiverFixtureMessage: kIsWeb
+          ? 'receiver sent at ${_uid()}'
+          : mobileReceiverMessageReply,
+    );
 
     final replySender = 'reply sender at ${_uid()}';
+    await _waitShown(this, senderMsg);
     await robots.messageMenuRobot().openReply(senderMsg);
     await robots.chatGroupDetailRobot().sendMessage(replySender);
-    await _waitShown(this, replySender);
+    await _waitExists(this, replySender);
 
     final replyReceiver = 'reply receiver at ${_uid()}';
+    await _waitShown(this, receiverMsg, searchTimeline: !kIsWeb);
     await robots.messageMenuRobot().openReply(receiverMsg);
     await robots.chatGroupDetailRobot().sendMessage(replyReceiver);
-    await _waitShown(this, replyReceiver);
+    await _waitExists(this, replyReceiver);
   }
 }
 
@@ -115,7 +172,7 @@ class ChatGroupEditScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
-    final (senderMsg, _) = await _prepareTwoMessages(this);
+    final (senderMsg, _) = await _prepareMessages(this);
 
     // Distinct text (not a superstring of [senderMsg]) so the "original is
     // gone" check can't match the edited bubble under `textContaining`.
@@ -135,7 +192,7 @@ class ChatGroupSelectScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
-    final (senderMsg, _) = await _prepareTwoMessages(this);
+    final (senderMsg, _) = await _prepareMessages(this);
 
     await robots.messageMenuRobot().openSelect(senderMsg);
 
@@ -151,11 +208,18 @@ class ChatGroupDeleteScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
-    final (senderMsg, receiverMsg) = await _prepareTwoMessages(this);
+    final (senderMsg, receiverMsg) = await _prepareMessages(
+      this,
+      receiverFixtureMessage: kIsWeb
+          ? 'receiver sent at ${_uid()}'
+          : mobileReceiverMessageDelete,
+    );
 
+    await _waitShown(this, senderMsg);
     await robots.messageMenuRobot().openDelete(senderMsg);
     await _waitAbsent(this, senderMsg);
 
+    await _waitShown(this, receiverMsg, searchTimeline: !kIsWeb);
     await robots.messageMenuRobot().openDelete(receiverMsg);
     await _waitAbsent(this, receiverMsg);
   }
@@ -170,14 +234,19 @@ class ChatGroupDisplayMenuScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
-    final (senderMsg, receiverMsg) = await _prepareTwoMessages(this);
+    final (senderMsg, receiverMsg) = await _prepareMessages(
+      this,
+      receiverFixtureMessage: mobileReceiverMessageDisplayMenu,
+    );
 
+    await _waitShown(this, senderMsg);
     await ChatGroupDetailRobot($).openPullDownMenu(senderMsg);
     await ChatScenario(
       $,
     ).verifyTheDisplayOfPullDownMenu(senderMsg, level: UserLevel.owner);
     await ChatGroupDetailRobot($).closePullDownMenu();
 
+    await _waitShown(this, receiverMsg, searchTimeline: true);
     await ChatGroupDetailRobot($).openPullDownMenu(receiverMsg);
     await ChatScenario(
       $,
@@ -193,9 +262,13 @@ class ChatGroupCopyScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
-    final (senderMsg, receiverMsg) = await _prepareTwoMessages(this);
+    final (senderMsg, receiverMsg) = await _prepareMessages(
+      this,
+      receiverFixtureMessage: mobileReceiverMessageCopy,
+    );
 
     // copy sender
+    await _waitShown(this, senderMsg);
     await ChatScenario($).copyMessage(senderMsg);
     const addedText = 'Copy';
     await ChatGroupDetailRobot($).inputMessage(addedText);
@@ -204,6 +277,7 @@ class ChatGroupCopyScenario extends BaseTestScenario {
     await ChatScenario($).verifyMessageIsShown('$addedText$senderMsg', true);
 
     // copy receiver
+    await _waitShown(this, receiverMsg, searchTimeline: true);
     await ChatScenario($).copyMessage(receiverMsg);
     await ChatGroupDetailRobot($).inputMessage(addedText);
     await ChatScenario($).pasteFromClipBoard();
@@ -221,14 +295,22 @@ class ChatGroupMessageInfoScenario extends BaseTestScenario {
 
   @override
   Future<void> runTestLogic() async {
-    final (senderMsg, _) = await _prepareTwoMessages(this);
+    final (senderMsg, _) = await _prepareMessages(this);
 
     await robots.messageMenuRobot().openMessageInfo(senderMsg);
 
     final dialog = $(EventInfoDialog);
     await $.waitUntilVisible(dialog, timeout: const Duration(seconds: 10));
     expect(dialog.$(Avatar), findsWidgets);
-    expect(dialog.$(SelectableText), findsWidgets);
+
+    // The source JSON sits below the initially built ListView viewport on
+    // compact FTL devices, so scroll until the lazily-built widget exists.
+    final source = dialog.$(SelectableText);
+    for (var i = 0; i < 5 && !source.exists; i++) {
+      await $.tester.drag(dialog.$(ListView), const Offset(0, -300));
+      await $.pumpAndSettle();
+    }
+    expect(source, findsWidgets);
 
     // Close the dialog via its app-bar close button.
     await dialog.$(AppBar).$(IconButton).tap();


### PR DESCRIPTION
## Summary

- target `Support Twake Workplace` in mobile chat-group integration scenarios
- open the mobile support DM directly from the synchronized chat list because it is created by `CreateSupportChatInteractor` after sync and is not a search fixture
- preserve the isolated web fixture supplied through `SearchByTitle`
- wait for the exact mobile chat row before opening it

## Failure evidence

FTL run 33480059219 executed all seven chat-group tests, and every test failed while searching for the missing room `Thu Huyen HOANG`.

Targeted mobile FTL run 33486650378 remained red because the first revision tried to find the support DM through the search screen. Mobile and web use different fixtures: web searches its isolated Synapse room, while mobile receives its support DM through application startup code.

## Validation

- web `integration_test/tests/chat/chat_group_test.dart`: passed on run 33488219683 before the mobile-only navigation adjustment
- `dart analyze integration_test/scenarios/chat_group_scenario.dart integration_test/robots/chat_list_robot.dart`
- `dart format --output=none --set-exit-if-changed integration_test/scenarios/chat_group_scenario.dart integration_test/robots/chat_list_robot.dart`
- `git diff --check`

A new targeted mobile FTL run is still required to validate the corrected navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved automated chat scenario coverage across web and mobile platforms.
  - Chat rooms are now opened more reliably through platform-appropriate navigation.
  - Added clearer handling when a requested room cannot be found.
  - Improved synchronization when selecting chats, reducing timing-related test failures.
  - Updated mobile integration testing to use a Pixel 2 device running Android 33 for more consistent validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->