### PR TITLE
fix(test): align contact visibility expectation

### DIFF
--- a/integration_test/scenarios/settings_contacts_visibility_scenario.dart
+++ b/integration_test/scenarios/settings_contacts_visibility_scenario.dart
@@ -5,9 +5,11 @@ import '../robots/home_robot.dart';
 import '../robots/setting/settings_contacts_visibility_robot.dart';
 import '../robots/setting/settings_privacy_and_security_robot.dart';
 
-/// Mobile-only: select the "everyone" contacts-visibility option and verify the
-/// email/phone fields are hidden. Drives the concrete settings robots directly,
-/// so this is registered with `mobileOnly: true`.
+/// Mobile-only: select the "everyone" contacts-visibility option and verify
+/// the email/phone visibility toggles are offered. Since TW-2778 the toggles
+/// stay available for the "everyone" option — they are hidden only for
+/// "nobody" (private). Drives the concrete settings robots directly, so this
+/// is registered with `mobileOnly: true`.
 class SettingsContactsVisibilityEveryoneScenario extends BaseTestScenario {
   SettingsContactsVisibilityEveryoneScenario(super.$, super.robots);
 
@@ -31,9 +33,10 @@ class SettingsContactsVisibilityEveryoneScenario extends BaseTestScenario {
     // Wait for UI to settle after selection
     await $.pumpAndSettle();
 
-    // Verify email and phone fields are NOT visible when everyone is selected
-    expect(contactsVisibilityRobot.emailFieldOption(), findsNothing);
-    expect(contactsVisibilityRobot.phoneNumberFieldOption(), findsNothing);
+    // TW-2778: the visible-field toggles remain available for "everyone" —
+    // the user still chooses which details are visible to other users.
+    await contactsVisibilityRobot.emailFieldOption().waitUntilVisible();
+    await contactsVisibilityRobot.phoneNumberFieldOption().waitUntilVisible();
   }
 }
 


### PR DESCRIPTION
## Summary

- align the E2E expectation with TW-2778
- verify that email and phone visibility options are shown for the Everyone setting

## Validation

- targeted Dart analyze: no issues
- diff check: clean
- the equivalent contact-visibility change passed the mobile shard_3 run in https://github.com/linagora/twake-on-matrix/actions/runs/33399437458

Split from #3310 so that PR remains scoped to CI sharding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mobile contact-visibility coverage to confirm email and phone visibility controls remain available when visibility is set to “Everyone.”
  * Clarified that these controls are hidden only when visibility is set to “Nobody.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->