### PR TITLE
fix(test): handle unavailable recovery key

### DIFF
--- a/integration_test/robots/setting/settings_recovery_key_robot.dart
+++ b/integration_test/robots/setting/settings_recovery_key_robot.dart
@@ -17,12 +17,33 @@ class SettingsRecoveryKeyRobot extends HomeRobot {
     return $(SettingsKeys.recoveryKeyItem.key);
   }
 
+  PatrolFinder recoveryKeyUnavailable() {
+    return $(SettingsKeys.recoveryKeyUnavailable.key);
+  }
+
   PatrolFinder recoveryKeyCopyButton() {
     return $(SettingsKeys.recoveryKeyCopyButton.key);
   }
 
   Future<void> waitForRecoveryKeyVisible() async {
     await $.waitUntilVisible(recoveryKeyItem());
+  }
+
+  /// Waits for the recovery key item and returns whether it appeared.
+  ///
+  /// The section is rendered only when the ToM server returns recovery words.
+  /// A completed fetch without recovery words exposes an explicit unavailable
+  /// state; unrelated visibility timeouts are rethrown.
+  Future<bool> waitForRecoveryKeyVisibleOrNull({
+    Duration timeout = const Duration(seconds: 45),
+  }) async {
+    try {
+      await $.waitUntilVisible(recoveryKeyItem(), timeout: timeout);
+      return true;
+    } on WaitUntilVisibleTimeoutException {
+      if (recoveryKeyUnavailable().exists) return false;
+      rethrow;
+    }
   }
 
   /// Taps the copy button, then confirms the warning dialog by tapping "Copy".

--- a/integration_test/scenarios/settings_recovery_key_scenario.dart
+++ b/integration_test/scenarios/settings_recovery_key_scenario.dart
@@ -23,8 +23,18 @@ class SettingsRecoveryKeyScenario extends BaseTestScenario {
 
     final recoveryKeyRobot = SettingsRecoveryKeyRobot($);
 
-    // Verify recovery key item is visible
-    await recoveryKeyRobot.waitForRecoveryKeyVisible();
+    // Verify the recovery key item is visible. Skip only when the completed
+    // recovery-words fetch explicitly reports that no key is available.
+    final recoveryKeyVisible = await recoveryKeyRobot
+        .waitForRecoveryKeyVisibleOrNull();
+    if (!recoveryKeyVisible) {
+      // ignore: avoid_print
+      print(
+        'Recovery key unavailable for this ToM account. '
+        'Skipping copy assertions.',
+      );
+      return;
+    }
 
     // Tap the copy button and confirm the warning dialog
     await recoveryKeyRobot.tapCopyAndConfirm();

--- a/lib/pages/settings_dashboard/settings_security/settings_security_view.dart
+++ b/lib/pages/settings_dashboard/settings_security/settings_security_view.dart
@@ -130,6 +130,11 @@ class SettingsSecurityView extends StatelessWidget {
                 future: controller.recoveryKeyFuture,
                 builder: (context, snapshot) {
                   if (!snapshot.hasData) {
+                    if (snapshot.connectionState == ConnectionState.done) {
+                      return SizedBox.shrink(
+                        key: SettingsKeys.recoveryKeyUnavailable.key,
+                      );
+                    }
                     return const SizedBox.shrink();
                   }
                   return Column(

--- a/lib/presentation/widget_keys/settings_keys.dart
+++ b/lib/presentation/widget_keys/settings_keys.dart
@@ -9,6 +9,10 @@ enum SettingsKeys {
     Key('settings.recoveryKeyItem'),
     ValueKey('settings.recoveryKeyItem'),
   ),
+  recoveryKeyUnavailable(
+    Key('settings.recoveryKeyUnavailable'),
+    ValueKey('settings.recoveryKeyUnavailable'),
+  ),
   recoveryKeyCopyButton(
     Key('settings.recoveryKeyCopyButton'),
     ValueKey('settings.recoveryKeyCopyButton'),


### PR DESCRIPTION
## Summary

- expose an explicit keyed state when no recovery key is available
- let the mobile E2E scenario skip only that expected state
- keep unexpected visibility timeouts failing the test

## Validation

- targeted Dart analyze: no issues
- diff check: clean
- the equivalent recovery-key change passed the mobile shard_3 run in https://github.com/linagora/twake-on-matrix/actions/runs/33399437458

Split from #3310 so that PR remains scoped to CI sharding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when a recovery key is unavailable in Security Settings.
  * Recovery key actions and related checks are now skipped when no key is available, avoiding misleading failures.
  * Added clearer detection of the recovery key’s unavailable state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->