### PR TITLE
TW-3333: Refresh devices list after verification

### DIFF
--- a/lib/pages/device_settings/device_settings.dart
+++ b/lib/pages/device_settings/device_settings.dart
@@ -286,10 +286,16 @@ Future<void> verifyDeviceAction(
   Device device,
 ) async {
   final client = Matrix.of(context).client;
-  final req = await client
-      .userDeviceKeys[client.userID!]!
-      .deviceKeys[device.deviceId]!
-      .startVerification();
+  // Block the list while the request is set up so Verify can't be re-tapped.
+  final result = await TwakeDialog.showFutureLoadingDialogFullScreen(
+    future: () => client
+        .userDeviceKeys[client.userID!]!
+        .deviceKeys[device.deviceId]!
+        .startVerification(),
+  );
+  final req = result.result;
+  if (req == null) return;
+  // Refresh only on a terminal state; a plain dialog close (cancel) is not one.
   req.onUpdate = () {
     if ({
       KeyVerificationState.error,

--- a/lib/pages/device_settings/device_settings_state.dart
+++ b/lib/pages/device_settings/device_settings_state.dart
@@ -20,6 +20,10 @@ sealed class DevicesSettingsState with _$DevicesSettingsState {
     required List<Device> devices,
     @Default(VerificationBannerVisibility.shown)
     VerificationBannerVisibility bannerVisibility,
+
+    /// Bumped when device-key trust changes without the [Device] list
+    /// changing, so Riverpod notifies listeners (e.g. after SAS verify).
+    @Default(0) int keysRevision,
   }) = DevicesSettingsLoaded;
 
   /// The "remove all other devices" action is in flight.
@@ -27,6 +31,7 @@ sealed class DevicesSettingsState with _$DevicesSettingsState {
     required List<Device> devices,
     @Default(VerificationBannerVisibility.shown)
     VerificationBannerVisibility bannerVisibility,
+    @Default(0) int keysRevision,
   }) = DevicesSettingsDeletingDevices;
 
   /// The "remove all other devices" action failed.
@@ -35,5 +40,6 @@ sealed class DevicesSettingsState with _$DevicesSettingsState {
     required String message,
     @Default(VerificationBannerVisibility.shown)
     VerificationBannerVisibility bannerVisibility,
+    @Default(0) int keysRevision,
   }) = DevicesSettingsDeleteDevicesError;
 }

--- a/lib/pages/device_settings/device_settings_view_model.dart
+++ b/lib/pages/device_settings/device_settings_view_model.dart
@@ -34,33 +34,45 @@ class DevicesSettingsViewModel extends _$DevicesSettingsViewModel {
     _ => VerificationBannerVisibility.shown,
   };
 
+  int get _keysRevision => switch (state) {
+    DevicesSettingsLoaded(:final keysRevision) => keysRevision,
+    DevicesSettingsDeletingDevices(:final keysRevision) => keysRevision,
+    DevicesSettingsDeleteDevicesError(:final keysRevision) => keysRevision,
+    _ => 0,
+  };
+
   /// Transitions to a new "devices loaded" variant, carrying over the
-  /// current [_devices]/[_bannerVisibility] unless overridden. No-op if
-  /// devices haven't loaded yet.
+  /// current [_devices]/[_bannerVisibility]/[_keysRevision] unless
+  /// overridden. No-op if devices haven't loaded yet.
   void _transition({
     List<Device>? devices,
     VerificationBannerVisibility? bannerVisibility,
+    int? keysRevision,
     String? deleteError,
     bool deleting = false,
   }) {
     final resolvedDevices = devices ?? _devices;
     if (resolvedDevices == null) return;
     final resolvedBannerVisibility = bannerVisibility ?? _bannerVisibility;
+    final resolvedKeysRevision = keysRevision ?? _keysRevision;
     if (deleting) {
       state = DevicesSettingsState.deletingDevices(
         devices: resolvedDevices,
         bannerVisibility: resolvedBannerVisibility,
+        keysRevision: resolvedKeysRevision,
       );
     } else if (deleteError != null) {
       state = DevicesSettingsState.deleteDevicesError(
         devices: resolvedDevices,
         message: deleteError,
         bannerVisibility: resolvedBannerVisibility,
+        keysRevision: resolvedKeysRevision,
       );
     } else {
       state = DevicesSettingsState.loaded(
         devices: resolvedDevices,
         bannerVisibility: resolvedBannerVisibility,
+        keysRevision: resolvedKeysRevision,
       );
     }
   }
@@ -80,10 +92,12 @@ class DevicesSettingsViewModel extends _$DevicesSettingsViewModel {
     }
     if (devices.isEmpty) return false;
     final deviceKeys = client.userDeviceKeys[client.userID]?.deviceKeys;
-    // encryptToDevice reflects whether this device will actually receive
-    // room keys and be able to decrypt messages (per ShareKeysWith policy),
-    // unlike directVerified/verified which the SDK force-trusts for the
-    // own device regardless of any user action.
+    // Devices settings banner: any session in the `/devices` list that will
+    // not receive room keys (`encryptToDevice == false`), including this
+    // session when it is out of sync.
+    //
+    // Intentionally different from the chat banner, which warns about
+    // *other* unverified sessions via [DeviceKeys.verified].
     return devices.any(
       (device) => deviceKeys?[device.deviceId]?.encryptToDevice == false,
     );
@@ -138,8 +152,9 @@ class DevicesSettingsViewModel extends _$DevicesSettingsViewModel {
       _transition(deleteError: error);
 
   void refreshDeviceKeys() {
-    final devices = _devices;
-    if (devices == null) return;
-    _transition(devices: List<Device>.from(devices));
+    if (_devices == null) return;
+    // Device list identity is unchanged after SAS; bump keysRevision so
+    // Freezed equality fails and list items re-read DeviceKeys.verified.
+    _transition(keysRevision: _keysRevision + 1);
   }
 }


### PR DESCRIPTION
## Ticket
**Related issue**

- #3333


## Resolved
**Attach screenshots or videos demonstrating the changes**
- Web:
- Android:
- IOS:


https://github.com/user-attachments/assets/c051d448-8ea3-4a5a-a3a6-57cab5d6a8b7



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Device verification now displays a full-screen loading dialog while the request is being prepared, preventing duplicate taps.
  - Verification can be canceled safely without triggering an incomplete request.

- **Bug Fixes**
  - Device settings now refresh reliably after device-key trust changes, ensuring updated verification status is displayed even when the device list remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->