### PR TITLE
test(integration): retry message long-press until the action menu opens

### DIFF
--- a/integration_test/robots/chat_group_detail_robot.dart
+++ b/integration_test/robots/chat_group_detail_robot.dart
@@ -153,10 +153,18 @@ class ChatGroupDetailRobot extends CoreRobot
   }
 
   Future<PullDownMenuRobot> openPullDownMenu(String message) async {
-    await $(
+    // Long-press is ignored while the event is still sending, so retry until
+    // the menu opens instead of pressing once right after the bubble appears.
+    final messageFinder = $(
       MessageContent,
-    ).containing(find.textContaining(message)).longPress();
-    await $.waitUntilVisible($(PullDownMenu));
+    ).containing(find.textContaining(message));
+    final menu = $(PullDownMenu);
+    final deadline = DateTime.now().add(const Duration(seconds: 60));
+    while (!menu.exists && DateTime.now().isBefore(deadline)) {
+      await messageFinder.longPress();
+      await $.pump(const Duration(milliseconds: 700));
+    }
+    await $.waitUntilVisible(menu, timeout: const Duration(seconds: 15));
     await $.pump();
     return PullDownMenuRobot($);
   }

--- a/integration_test/robots/message_menu_robot.dart
+++ b/integration_test/robots/message_menu_robot.dart
@@ -25,10 +25,20 @@ class MessageMenuRobot extends CoreRobot implements AbstractMessageMenuRobot {
   PullDownMenuRobot get _menu => PullDownMenuRobot($);
 
   Future<void> _openMenu(String message) async {
-    await $(
+    // The app ignores long-presses while the event is still `isSending`
+    // (`MultiPlatformSelectionMode.onLongPress` is null until the server
+    // acks). Waiting only for the bubble to be *visible* races that ack, so
+    // press until the menu actually opens.
+    final messageFinder = $(
       MessageContent,
-    ).containing(find.textContaining(message)).longPress();
-    await $.waitUntilVisible($(PullDownMenu));
+    ).containing(find.textContaining(message));
+    final menu = $(PullDownMenu);
+    final deadline = DateTime.now().add(const Duration(seconds: 60));
+    while (!menu.exists && DateTime.now().isBefore(deadline)) {
+      await messageFinder.longPress();
+      await $.pump(const Duration(milliseconds: 700));
+    }
+    await $.waitUntilVisible(menu, timeout: const Duration(seconds: 15));
     await $.pump();
   }
 


### PR DESCRIPTION
## Problème

Les robots mobiles long-pressaient la bulle dès qu'elle était *visible*. Or l'app met `onLongPress: null` tant que l'event est `isSending` (`message_content_with_timestamp_builder.dart:223-230`). Sur un réseau réel, l'ack serveur arrive après l'affichage → le long-press ne fait rien et `waitUntilVisible(PullDownMenu)` finit en timeout 30s.

Observé en exécutant les tests `forward_message` de bout en bout sur émulateur : login, création du fixture, ouverture de room, envoi OK, puis échec systématique à l'étape « longPress → PullDownMenu ».

## Fix

`MessageMenuRobot._openMenu` et `ChatGroupDetailRobot.openPullDownMenu` pressent maintenant en boucle (jusqu'à 60s) tant que `PullDownMenu` n'est pas présent, puis attendent son affichage. Aucun changement de comportement une fois le message acké.

## Validation

Run émulateur x86_64 : `Total: 2 / Failed: 0` sur `forward_message_test.dart` (les deux tests passent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when opening message action menus through long-press gestures.
  - Added retry handling and bounded wait times to reduce test failures when menus take longer to appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->